### PR TITLE
feat(ucmc-web): public content routes + self-serve data export & delete

### DIFF
--- a/apps/web/src/components/layouts/app-layout.tsx
+++ b/apps/web/src/components/layouts/app-layout.tsx
@@ -294,6 +294,18 @@ function AppFooter() {
         <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
           <nav aria-label="Legal" className="flex flex-wrap gap-x-4 gap-y-1">
             <Link
+              to="/about"
+              className="underline underline-offset-2 hover:text-foreground"
+            >
+              About
+            </Link>
+            <Link
+              to="/membership"
+              className="underline underline-offset-2 hover:text-foreground"
+            >
+              Membership
+            </Link>
+            <Link
               to="/disclaimer"
               className="underline underline-offset-2 hover:text-foreground"
             >
@@ -316,6 +328,18 @@ function AppFooter() {
               className="underline underline-offset-2 hover:text-foreground"
             >
               Waiver
+            </Link>
+            <Link
+              to="/privacy"
+              className="underline underline-offset-2 hover:text-foreground"
+            >
+              Privacy
+            </Link>
+            <Link
+              to="/terms"
+              className="underline underline-offset-2 hover:text-foreground"
+            >
+              Terms
             </Link>
             <Link
               to="/open-source"

--- a/apps/web/src/config/legal.ts
+++ b/apps/web/src/config/legal.ts
@@ -233,3 +233,271 @@ export const ANTI_HAZING_BODY: readonly LegalSection[] = [
     ],
   },
 ];
+
+/**
+ * Public privacy notice. The promises here must match what the website
+ * actually does — when adding a new column, processor, or retention
+ * window, update this text first and treat the implementation as the
+ * follow-on. Industry-standard plain-language notice; UC is silent on
+ * RSO PII storage so this is not a UC compliance artifact, just a
+ * good-faith disclosure.
+ */
+export const PRIVACY_BODY: readonly LegalSection[] = [
+  {
+    heading: "What we collect",
+    paragraphs: [
+      "When you register, we collect your email, full legal name, preferred name, phone number, UC affiliation, optional bio, optional avatar, and one or more emergency contacts (name, phone, relationship). We also record the date you acknowledged UCMC's anti-hazing and non-discrimination policies, plus the version of those policies you ticked.",
+      "When an officer attests your paper waiver for the current academic cycle, we record that attestation: the cycle, the waiver version, the officer who attested, and the timestamp. We do not record the contents of the waiver itself.",
+      "We capture the timestamp of your most recent visit to /announcements so the bell-icon unread count works.",
+    ],
+  },
+  {
+    heading: "What we explicitly do not collect",
+    bullets: [
+      "UC student/staff IDs (M-numbers). The Treasurer maintains the canonical roster — including IDs — on UC's official CampusLINK platform per Bylaw 1.3.",
+      "Medical information, insurance information, and signed waivers. These exist only on the paper waiver, which lives off-platform with the Treasurer.",
+      "Payment information. UCMC dues are collected off-platform.",
+      "Browser fingerprinting, third-party analytics, ad-tech identifiers, or any tracking beyond essential session cookies.",
+    ],
+  },
+  {
+    heading: "Why each thing is collected",
+    bullets: [
+      "Email — to send you a magic-link sign-in and identify your account.",
+      "Names + UC affiliation + bio — to populate the member directory other approved members see.",
+      "Phone + emergency contact — to reach you (or someone on your behalf) about a club activity.",
+      "Avatar — purely cosmetic; you choose whether to upload one.",
+      "Waiver attestation metadata — to gate participation in club activities on a current paper waiver.",
+      "Policies-acknowledgment timestamp + version — to track that you've read the anti-hazing and non-discrimination policies, and to re-prompt if those policies are updated in a future version.",
+    ],
+  },
+  {
+    heading: "Who we share it with (processors)",
+    paragraphs: [
+      "The site runs on Cloudflare Workers; member data lives in Cloudflare's managed services in the United States. We do not sell, rent, or share member data with third parties beyond the technical processors listed below.",
+    ],
+    bullets: [
+      "Cloudflare — hosting, edge TLS, D1 (database), R2 (avatars), KV (short-lived auth state), Turnstile (anti-bot challenge on the magic-link form), rate limiting, observability logs (~7 day retention).",
+      "Resend — outbound email delivery (the magic-link emails). Recipient address and email body are sent to Resend; Resend does not retain message content beyond the sending window.",
+    ],
+  },
+  {
+    heading: "Retention",
+    bullets: [
+      "Active member data is retained as long as your account is active.",
+      "Pending registrations not approved within 30 days may be purged.",
+      "Deactivated accounts may be purged after 12 months of inactivity.",
+      "Waiver attestation records (metadata only — not the paper waiver) may be retained for up to 7 years post-cycle for liability documentation.",
+      "You can delete your account immediately at any time via the controls on /account; this also removes your avatar from R2 and signs you out everywhere.",
+    ],
+  },
+  {
+    heading: "Your rights",
+    paragraphs: [
+      "You can download a JSON copy of everything we have on you from your /account page. You can hard-delete your account from the same page; the deletion is immediate and irreversible. To correct or update individual fields, edit them on /account or /account/details.",
+    ],
+  },
+  {
+    heading: "Cookies",
+    paragraphs: ["We set only essential cookies needed to operate the site:"],
+    bullets: [
+      "Session cookie (HTTP-only, SameSite=Strict, 30-day TTL with sliding refresh) — keeps you signed in.",
+      "Proof cookie (HTTP-only, short-lived) — set after a magic-link click for first-time registrants who don't have an account row yet.",
+      "WebAuthn ceremony cookie (HTTP-only, 5-minute TTL) — links a passkey-registration begin/finish pair.",
+      "Theme + view-mode cookies — your light/dark/role-emulation UI preferences.",
+    ],
+  },
+  {
+    heading: "Contact",
+    paragraphs: [
+      "Questions, requests for correction, or privacy complaints can be emailed to the website maintainer (see the colophon for the current email).",
+    ],
+    references: [{ label: "Open source / colophon", href: "/open-source" }],
+  },
+];
+
+/**
+ * Public terms of use for the website itself. Distinct from the waiver
+ * (which covers club activities) — these terms cover the use of the
+ * member portal at ucmc.spencerwill.com. Plain-language and
+ * intentionally short.
+ */
+export const TERMS_BODY: readonly LegalSection[] = [
+  {
+    heading: "What this is",
+    paragraphs: [
+      "This site is the member portal for the University of Cincinnati Mountaineering Club (UCMC), a Registered Student Organization at the University of Cincinnati. It is operated by UCMC officers on a personal Cloudflare account, independent of UC IT. By using the site you agree to the terms below.",
+    ],
+  },
+  {
+    heading: "Account responsibility",
+    bullets: [
+      "Don't share your sign-in link, session, or passkey with anyone else.",
+      "If you suspect unauthorized access, sign out (which clears all your sessions) and contact a club officer.",
+      "Keep your name, phone, and emergency contact accurate while your account is active. The information we hold may be used to reach you (or someone on your behalf) about a club activity.",
+    ],
+  },
+  {
+    heading: "Acceptable use",
+    paragraphs: [
+      "Don't use the site to harass, threaten, or impersonate anyone. Don't attempt to bypass auth, scrape the member directory, or interfere with site operations. Don't post content that violates UCMC's anti-hazing or non-discrimination policies (linked in the footer).",
+    ],
+  },
+  {
+    heading: "No UC endorsement",
+    paragraphs: [
+      "UCMC is registered at the University of Cincinnati but operates independently of UC IT. Registration is not endorsement — see the registration disclaimer in the footer for the verbatim notice required by UC Rule 40-03-01.",
+    ],
+  },
+  {
+    heading: "Liability",
+    paragraphs: [
+      "These terms cover use of the website. They do not replace the UCMC Waiver of Liability, which separately governs participation in club activities. Use of the site is provided as-is; the maintainer makes no warranty as to availability, fitness for a particular purpose, or accuracy of any information presented.",
+    ],
+  },
+  {
+    heading: "Account termination",
+    paragraphs: [
+      "You can delete your account at any time from /account; deletion is immediate and irreversible. UCMC officers may deactivate accounts that violate these terms or club policies; deactivated accounts can be reactivated by an officer.",
+    ],
+  },
+  {
+    heading: "Governing law",
+    paragraphs: [
+      "These terms are governed by the laws of the State of Ohio, without regard to conflict-of-law principles. Any dispute arising from use of the site will be brought in a court of competent jurisdiction in Hamilton County, Ohio.",
+    ],
+  },
+];
+
+/**
+ * Public "about UCMC" copy. Frames the club, the open-membership
+ * Article III §3.2 invariant, and the additive-not-canonical
+ * relationship to CampusLINK.
+ */
+export const ABOUT_BODY: readonly LegalSection[] = [
+  {
+    heading: "Who we are",
+    paragraphs: [
+      "The University of Cincinnati Mountaineering Club (UCMC) is a student-run Registered Student Organization. We climb, hike, backpack, ice climb, kayak, and otherwise spend time outside together. New members of any experience level are welcome — including total beginners.",
+    ],
+  },
+  {
+    heading: "How we run",
+    paragraphs: [
+      "UCMC is governed by an elected officer board (President, Vice President, Treasurer, Secretary, Equipment Officer, Outings Officer) and a faculty advisor. Day-to-day operations — meetings, trips, gear lending, dues collection — happen at the club, not on this website.",
+      "The canonical UCMC roster is maintained by the Treasurer on UC's official CampusLINK platform per Bylaw 1.3. This site is an additive operational tool: it surfaces announcements, lets officers track paper-waiver attestations, and gives members a place to update their contact information. It is never a replacement for the official roster.",
+    ],
+  },
+  {
+    heading: "Joining",
+    paragraphs: [
+      "Membership is open to any UC student in good standing per Article III §3.2 of our constitution. See the membership page for the full eligibility, dues, and registration flow.",
+    ],
+    references: [{ label: "Membership", href: "/membership" }],
+  },
+];
+
+/**
+ * Public membership/eligibility/dues/how-to-join page. The verification-
+ * not-gatekeeping framing of the registration approval queue lives here
+ * — it's the constitutional invariant from Art III §3.2 that the
+ * approval flow is checking eligibility, not making discretionary
+ * admission decisions.
+ */
+export const MEMBERSHIP_BODY: readonly LegalSection[] = [
+  {
+    heading: "Eligibility",
+    paragraphs: [
+      'Per Article III §3.2 of the UCMC Constitution, voting membership is open to "any full/part-time undergraduate or graduate student, enrolled in any of the colleges, schools or divisions of the University at the time of applying for membership." Non-voting membership is open more broadly to UC alumni, faculty, staff, family members, and guests.',
+      "The approval queue exists to verify eligibility (UC enrollment, anti-bot, deduplication) — not to gatekeep on viewpoint, identity, or ideology. UCMC does not discriminate on any basis listed in our non-discrimination policy or in Ohio Senate Bill 1 (2025).",
+    ],
+    references: [{ label: "Non-discrimination", href: "/nondiscrimination" }],
+  },
+  {
+    heading: "Dues",
+    paragraphs: [
+      "Per Bylaw §7.1, members pay an annual equipment fee of $60 to access club gear and participate in club trips. Dues are collected off-platform; this site does not process payments. Talk to the Treasurer at a club meeting for current payment options.",
+    ],
+  },
+  {
+    heading: "How to join",
+    paragraphs: [
+      "Sign up via the website. After you register, an officer will verify your eligibility and approve your account, usually within a week. Once approved, you'll be asked to print, sign, and bring UCMC's paper waiver to a club meeting; the Treasurer or President will mark you attested in the member portal so you can participate in club activities.",
+      "The waiver is a paper form. We do not collect or store signed waivers, medical information, or insurance information digitally — those live with the Treasurer off-platform per Bylaw 1.3.",
+    ],
+    references: [
+      { label: "Sign up", href: "/sign-in?register=true" },
+      { label: "Waiver of liability (reference copy)", href: "/waiver" },
+    ],
+  },
+  {
+    heading: "Anti-hazing and non-discrimination",
+    paragraphs: [
+      "Membership in UCMC is conditioned on agreement with our anti-hazing and non-discrimination policies, which are constitutional commitments under Article XII. Both are linked in the footer of every page.",
+    ],
+  },
+];
+
+/**
+ * Public legal-page index — surfaces all five legal/policy routes
+ * (disclaimer, non-discrimination, anti-hazing, waiver, privacy,
+ * terms) plus the colophon, in one place. Not strictly required, but
+ * useful as a "what's the official line on X" landing pad.
+ */
+export const LEGAL_INDEX_LINKS: readonly {
+  href: string;
+  label: string;
+  description: string;
+}[] = [
+  {
+    href: "/disclaimer",
+    label: "Registration disclaimer",
+    description:
+      "Verbatim notice required by UC Rule 40-03-01 — what UCMC's registration with UC does and does not mean.",
+  },
+  {
+    href: "/nondiscrimination",
+    label: "Non-discrimination",
+    description:
+      "Protected categories under federal law, Ohio SB 1 (2025), and UC's CAMPUS Act Policy.",
+  },
+  {
+    href: "/anti-hazing",
+    label: "Anti-hazing",
+    description:
+      "UCMC's commitment under Constitution Art XII and Ohio's Collin's Law (ORC §2903.311), with reporting links.",
+  },
+  {
+    href: "/waiver",
+    label: "Waiver of liability",
+    description:
+      "Reference copy of the paper waiver members sign before participating in club activities.",
+  },
+  {
+    href: "/privacy",
+    label: "Privacy",
+    description:
+      "What data this site collects, who it's shared with, how long it's kept, and how to delete it.",
+  },
+  {
+    href: "/terms",
+    label: "Terms of use",
+    description: "Acceptable use of the website itself.",
+  },
+  {
+    href: "/membership",
+    label: "Membership",
+    description:
+      "Who can join, how dues work, and how the registration approval queue checks eligibility.",
+  },
+  {
+    href: "/about",
+    label: "About UCMC",
+    description: "Who we are, how we operate, and how this site fits in.",
+  },
+  {
+    href: "/open-source",
+    label: "Open source",
+    description: "How this site is built, maintained, and licensed.",
+  },
+];

--- a/apps/web/src/features/auth/api/use-delete-my-account.ts
+++ b/apps/web/src/features/auth/api/use-delete-my-account.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { deleteMyAccountFn } from "#/features/auth/server/server-fns";
+
+/**
+ * Hard-deletes the caller's account. Server cascades through every
+ * row that references the user and clears the session cookie; on
+ * success we wipe the entire query cache because effectively no
+ * cached query is still valid for this client.
+ */
+export function useDeleteMyAccount() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => deleteMyAccountFn(),
+    onSuccess: () => {
+      queryClient.clear();
+    },
+  });
+}

--- a/apps/web/src/features/auth/server/__tests__/delete-my-account.test.ts
+++ b/apps/web/src/features/auth/server/__tests__/delete-my-account.test.ts
@@ -1,0 +1,255 @@
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type * as AvatarsServer from "#/server/r2/avatars.server";
+import { getDb, schema } from "#/server/db";
+
+// ── mocks ──────────────────────────────────────────────────────────────
+
+const cookieJar = new Map<string, string>();
+vi.mock("@tanstack/react-start/server", () => ({
+  getCookie: (name: string) => cookieJar.get(name),
+  setCookie: (name: string, value: string) => {
+    cookieJar.set(name, value);
+  },
+  deleteCookie: (name: string) => {
+    cookieJar.delete(name);
+  },
+  getRequestHeader: () => undefined,
+}));
+
+vi.mock("#/server/rate-limit.server", () => ({
+  checkAuthRateLimitByIp: async () => true,
+  checkAuthRateLimitByEmail: async () => true,
+}));
+
+// Track deleteAvatar calls so we can assert R2 cleanup runs.
+const deleteAvatarSpy = vi.fn();
+vi.mock("#/server/r2/avatars.server", async () => {
+  const actual = await vi.importActual<typeof AvatarsServer>(
+    "#/server/r2/avatars.server",
+  );
+  return {
+    ...actual,
+    deleteAvatar: async (key: string) => {
+      deleteAvatarSpy(key);
+    },
+  };
+});
+
+const { deleteMyAccountAction } =
+  await import("#/features/auth/server/magic-link-actions.server");
+const { openSession } = await import("#/server/auth/session.server");
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+async function seedUser(
+  email: string,
+  opts?: { avatarKey?: string | null },
+): Promise<string> {
+  const id = `user_${crypto.randomUUID()}`;
+  const db = getDb();
+  await db.insert(schema.users).values({
+    id,
+    publicId: crypto.randomUUID().replace(/-/g, "").slice(0, 12),
+    email,
+    status: "approved",
+    approvedAt: new Date(),
+  });
+  await db.insert(schema.profiles).values({
+    userId: id,
+    fullName: "Test User",
+    preferredName: "Test",
+    phone: "+15135551212",
+    ucAffiliation: "student",
+    avatarKey: opts?.avatarKey ?? null,
+    updatedAt: new Date(),
+  });
+  return id;
+}
+
+async function assignRole(userId: string, roleId: string): Promise<void> {
+  await getDb()
+    .insert(schema.userRoles)
+    .values({ userId, roleId })
+    .onConflictDoNothing();
+}
+
+async function signInAs(userId: string): Promise<void> {
+  cookieJar.clear();
+  await openSession(userId);
+}
+
+beforeEach(async () => {
+  cookieJar.clear();
+  deleteAvatarSpy.mockReset();
+  const db = getDb();
+  await db.delete(schema.waiverAttestations);
+  await db.delete(schema.userRoles);
+  await db.delete(schema.passkeyCredentials);
+  await db.delete(schema.emergencyContacts);
+  await db.delete(schema.sessions);
+  await db.delete(schema.profiles);
+  await db.delete(schema.users);
+});
+
+afterEach(() => {
+  cookieJar.clear();
+});
+
+// ── tests ──────────────────────────────────────────────────────────────
+
+describe("deleteMyAccountAction", () => {
+  it("rejects unauthenticated callers", async () => {
+    await expect(deleteMyAccountAction()).rejects.toThrow("Not signed in");
+  });
+
+  it("removes the user row and cascades through all child tables", async () => {
+    const userId = await seedUser("doomed@example.com");
+    await assignRole(userId, "role_member");
+    // Seed an emergency contact, a session, a passkey, and an
+    // attestation — every cascading child the deletion must clean up.
+    const db = getDb();
+    await db.insert(schema.emergencyContacts).values({
+      id: `ec_${crypto.randomUUID()}`,
+      userId,
+      name: "Bob",
+      phone: "+15135559999",
+      relationship: "parent",
+    });
+    await db.insert(schema.passkeyCredentials).values({
+      id: `pk_${crypto.randomUUID()}`,
+      userId,
+      credentialId: `cred_${crypto.randomUUID()}`,
+      publicKey: "fake",
+      counter: 0,
+      transports: null,
+      nickname: null,
+    });
+    await db.insert(schema.waiverAttestations).values({
+      id: `wa_${crypto.randomUUID()}`,
+      userId,
+      cycle: "2025-26",
+      version: "v1",
+      attestedAt: new Date(),
+      attestedBy: userId,
+    });
+    await signInAs(userId);
+
+    await deleteMyAccountAction();
+
+    expect(
+      await db.query.users.findFirst({ where: eq(schema.users.id, userId) }),
+    ).toBeUndefined();
+    expect(
+      await db.query.profiles.findFirst({
+        where: eq(schema.profiles.userId, userId),
+      }),
+    ).toBeUndefined();
+    const contacts = await db
+      .select()
+      .from(schema.emergencyContacts)
+      .where(eq(schema.emergencyContacts.userId, userId));
+    expect(contacts).toHaveLength(0);
+    const passkeys = await db
+      .select()
+      .from(schema.passkeyCredentials)
+      .where(eq(schema.passkeyCredentials.userId, userId));
+    expect(passkeys).toHaveLength(0);
+    const sessions = await db
+      .select()
+      .from(schema.sessions)
+      .where(eq(schema.sessions.userId, userId));
+    expect(sessions).toHaveLength(0);
+    const userRoles = await db
+      .select()
+      .from(schema.userRoles)
+      .where(eq(schema.userRoles.userId, userId));
+    expect(userRoles).toHaveLength(0);
+    const attestations = await db
+      .select()
+      .from(schema.waiverAttestations)
+      .where(eq(schema.waiverAttestations.userId, userId));
+    expect(attestations).toHaveLength(0);
+  });
+
+  it("deletes the avatar from R2 when the user has one", async () => {
+    const userId = await seedUser("withavatar@example.com", {
+      avatarKey: "avatars/withavatar/abc123.webp",
+    });
+    await signInAs(userId);
+
+    await deleteMyAccountAction();
+
+    expect(deleteAvatarSpy).toHaveBeenCalledTimes(1);
+    expect(deleteAvatarSpy).toHaveBeenCalledWith(
+      "avatars/withavatar/abc123.webp",
+    );
+  });
+
+  it("does NOT call deleteAvatar when the user has no avatar", async () => {
+    const userId = await seedUser("noavatar@example.com");
+    await signInAs(userId);
+
+    await deleteMyAccountAction();
+
+    expect(deleteAvatarSpy).not.toHaveBeenCalled();
+  });
+
+  it("refuses to delete the only remaining system_admin", async () => {
+    const adminId = await seedUser("lonely-admin@example.com");
+    await assignRole(adminId, "role_system_admin");
+    await signInAs(adminId);
+
+    await expect(deleteMyAccountAction()).rejects.toThrow(
+      "only remaining system_admin",
+    );
+
+    // The user must still exist after the refused delete.
+    const db = getDb();
+    expect(
+      await db.query.users.findFirst({
+        where: eq(schema.users.id, adminId),
+      }),
+    ).toBeDefined();
+  });
+
+  it("permits deleting a system_admin when another exists", async () => {
+    const otherAdminId = await seedUser("other-admin@example.com");
+    await assignRole(otherAdminId, "role_system_admin");
+    const selfId = await seedUser("self-admin@example.com");
+    await assignRole(selfId, "role_system_admin");
+    await signInAs(selfId);
+
+    await deleteMyAccountAction();
+
+    const db = getDb();
+    expect(
+      await db.query.users.findFirst({ where: eq(schema.users.id, selfId) }),
+    ).toBeUndefined();
+    // The other admin survives.
+    expect(
+      await db.query.users.findFirst({
+        where: eq(schema.users.id, otherAdminId),
+      }),
+    ).toBeDefined();
+  });
+
+  it("preserves announcements authored by the deleted user (set null on author)", async () => {
+    const userId = await seedUser("author@example.com");
+    const db = getDb();
+    await db.insert(schema.announcements).values({
+      id: `ann_${crypto.randomUUID()}`,
+      title: "before",
+      body: "hello",
+      createdBy: userId,
+    });
+    await signInAs(userId);
+
+    await deleteMyAccountAction();
+
+    const remaining = await db.select().from(schema.announcements);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.createdBy).toBeNull();
+  });
+});

--- a/apps/web/src/features/auth/server/__tests__/export-my-data.test.ts
+++ b/apps/web/src/features/auth/server/__tests__/export-my-data.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getDb, schema } from "#/server/db";
+
+// ── mocks ──────────────────────────────────────────────────────────────
+
+const cookieJar = new Map<string, string>();
+vi.mock("@tanstack/react-start/server", () => ({
+  getCookie: (name: string) => cookieJar.get(name),
+  setCookie: (name: string, value: string) => {
+    cookieJar.set(name, value);
+  },
+  deleteCookie: (name: string) => {
+    cookieJar.delete(name);
+  },
+  getRequestHeader: () => undefined,
+}));
+
+vi.mock("#/server/rate-limit.server", () => ({
+  checkAuthRateLimitByIp: async () => true,
+  checkAuthRateLimitByEmail: async () => true,
+}));
+
+const { exportMyDataAction } =
+  await import("#/features/auth/server/magic-link-actions.server");
+const { openSession } = await import("#/server/auth/session.server");
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+async function seedUser(email: string): Promise<string> {
+  const id = `user_${crypto.randomUUID()}`;
+  const db = getDb();
+  await db.insert(schema.users).values({
+    id,
+    publicId: crypto.randomUUID().replace(/-/g, "").slice(0, 12),
+    email,
+    status: "approved",
+    approvedAt: new Date(),
+  });
+  await db.insert(schema.profiles).values({
+    userId: id,
+    fullName: "Test User",
+    preferredName: "Test",
+    phone: "+15135551212",
+    ucAffiliation: "student",
+    updatedAt: new Date(),
+  });
+  return id;
+}
+
+async function signInAs(userId: string): Promise<void> {
+  cookieJar.clear();
+  await openSession(userId);
+}
+
+beforeEach(async () => {
+  cookieJar.clear();
+  const db = getDb();
+  await db.delete(schema.waiverAttestations);
+  await db.delete(schema.userRoles);
+  await db.delete(schema.passkeyCredentials);
+  await db.delete(schema.magicLinks);
+  await db.delete(schema.emergencyContacts);
+  await db.delete(schema.sessions);
+  await db.delete(schema.profiles);
+  await db.delete(schema.users);
+});
+
+afterEach(() => {
+  cookieJar.clear();
+});
+
+// ── tests ──────────────────────────────────────────────────────────────
+
+describe("exportMyDataAction", () => {
+  it("rejects unauthenticated callers", async () => {
+    await expect(exportMyDataAction()).rejects.toThrow("Not signed in");
+  });
+
+  it("returns the caller's user, profile, and emergency contacts", async () => {
+    const userId = await seedUser("export@example.com");
+    const db = getDb();
+    await db.insert(schema.emergencyContacts).values({
+      id: `ec_${crypto.randomUUID()}`,
+      userId,
+      name: "Bob",
+      phone: "+15135559999",
+      relationship: "parent",
+    });
+    await signInAs(userId);
+
+    const payload = await exportMyDataAction();
+
+    expect(payload.user?.email).toBe("export@example.com");
+    expect(payload.user?.id).toBe(userId);
+    expect(payload.profile?.preferredName).toBe("Test");
+    expect(payload.emergencyContacts).toHaveLength(1);
+    expect(payload.emergencyContacts[0]?.name).toBe("Bob");
+  });
+
+  it("includes role memberships and waiver attestation history", async () => {
+    const userId = await seedUser("withhistory@example.com");
+    const db = getDb();
+    await db.insert(schema.userRoles).values({ userId, roleId: "role_member" });
+    await db.insert(schema.waiverAttestations).values({
+      id: `wa_${crypto.randomUUID()}`,
+      userId,
+      cycle: "2025-26",
+      version: "v1",
+      attestedAt: new Date(),
+      attestedBy: userId,
+      notes: "First semester",
+    });
+    await signInAs(userId);
+
+    const payload = await exportMyDataAction();
+
+    expect(payload.roles).toContain("role_member");
+    expect(payload.waiverAttestations).toHaveLength(1);
+    expect(payload.waiverAttestations[0]?.cycle).toBe("2025-26");
+    expect(payload.waiverAttestations[0]?.notes).toBe("First semester");
+  });
+
+  it("excludes passkey credentials even when the user has registered some", async () => {
+    const userId = await seedUser("withpasskey@example.com");
+    const db = getDb();
+    await db.insert(schema.passkeyCredentials).values({
+      id: `pk_${crypto.randomUUID()}`,
+      userId,
+      credentialId: "secret-credential-id",
+      publicKey: "secret-public-key",
+      counter: 5,
+      transports: "internal",
+      nickname: "iPhone",
+    });
+    await signInAs(userId);
+
+    const payload = await exportMyDataAction();
+
+    // No passkey-shaped key on the bundle, and the documented
+    // exclusion list calls out the omission.
+    expect(payload).not.toHaveProperty("passkeys");
+    expect(payload).not.toHaveProperty("passkeyCredentials");
+    expect(
+      payload.excluded.some((s) => s.toLowerCase().includes("passkey")),
+    ).toBe(true);
+
+    // Round-trip through JSON.stringify to make sure no nested object
+    // sneaks the secret credential id back into the dump.
+    const serialized = JSON.stringify(payload);
+    expect(serialized).not.toContain("secret-credential-id");
+    expect(serialized).not.toContain("secret-public-key");
+  });
+
+  it("excludes magic-link token hashes even when present", async () => {
+    const userId = await seedUser("withmagic@example.com");
+    const db = getDb();
+    await db.insert(schema.magicLinks).values({
+      tokenHash: "secret-token-hash",
+      email: "withmagic@example.com",
+      intent: "login",
+      createdAt: new Date(),
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    await signInAs(userId);
+
+    const payload = await exportMyDataAction();
+
+    expect(payload).not.toHaveProperty("magicLinks");
+    const serialized = JSON.stringify(payload);
+    expect(serialized).not.toContain("secret-token-hash");
+    expect(
+      payload.excluded.some((s) => s.toLowerCase().includes("magic")),
+    ).toBe(true);
+  });
+
+  it("scopes results to the caller — does not leak other users' data", async () => {
+    const meId = await seedUser("me@example.com");
+    const otherId = await seedUser("other@example.com");
+    const db = getDb();
+    await db.insert(schema.emergencyContacts).values({
+      id: `ec_${crypto.randomUUID()}`,
+      userId: otherId,
+      name: "Other's Mom",
+      phone: "+15555550000",
+      relationship: "parent",
+    });
+    await signInAs(meId);
+
+    const payload = await exportMyDataAction();
+
+    expect(payload.user?.id).toBe(meId);
+    expect(payload.user?.email).toBe("me@example.com");
+    expect(payload.emergencyContacts).toHaveLength(0);
+    expect(JSON.stringify(payload)).not.toContain("Other's Mom");
+  });
+
+  it("includes a stable schemaVersion + ISO exportedAt", async () => {
+    const userId = await seedUser("shape@example.com");
+    await signInAs(userId);
+
+    const payload = await exportMyDataAction();
+
+    expect(payload.schemaVersion).toBe(1);
+    expect(typeof payload.exportedAt).toBe("string");
+    expect(() => new Date(payload.exportedAt).toISOString()).not.toThrow();
+  });
+});

--- a/apps/web/src/features/auth/server/magic-link-actions.server.ts
+++ b/apps/web/src/features/auth/server/magic-link-actions.server.ts
@@ -205,6 +205,164 @@ export async function signOutAction(): Promise<{ ok: true }> {
   return { ok: true };
 }
 
+/**
+ * Bundles every piece of data the site stores about the caller into a
+ * single plain-JSON shape — used by the `/api/account/export` route
+ * handler to back the "download my data" promise on /privacy.
+ *
+ * Excludes:
+ *   - passkey public-key material + counters (not useful to the
+ *     member; dumping authenticator metadata is a foothold for a
+ *     stolen-account scenario, not a recovery aid),
+ *   - magic-link token hashes (one-shot auth state, never user-facing).
+ *
+ * Caller-auth is the responsibility of the route handler — it knows
+ * how to return a 401 Response. Throwing here would force the
+ * handler to translate, which adds a layer for no reason.
+ */
+export async function exportMyDataAction(): Promise<{
+  exportedAt: string;
+  schemaVersion: 1;
+  user: typeof schema.users.$inferSelect | null;
+  profile: typeof schema.profiles.$inferSelect | null;
+  emergencyContacts: Array<{
+    name: string;
+    phone: string;
+    relationship: schema.ContactRelationship;
+    createdAt: Date;
+  }>;
+  roles: string[];
+  waiverAttestations: Array<{
+    cycle: string;
+    version: string;
+    attestedAt: Date;
+    attestedBy: string;
+    revokedAt: Date | null;
+    revokedBy: string | null;
+    revocationReason: string | null;
+    notes: string | null;
+  }>;
+  excluded: string[];
+}> {
+  const principal = await loadCurrentPrincipal();
+  if (!principal) {
+    throw new Error("Not signed in");
+  }
+
+  const db = getDb();
+  const userId = principal.userId;
+
+  const [user, profile, emergencyContacts, userRoles, attestations] =
+    await Promise.all([
+      db.query.users.findFirst({ where: eq(schema.users.id, userId) }),
+      db.query.profiles.findFirst({
+        where: eq(schema.profiles.userId, userId),
+      }),
+      db
+        .select({
+          name: schema.emergencyContacts.name,
+          phone: schema.emergencyContacts.phone,
+          relationship: schema.emergencyContacts.relationship,
+          createdAt: schema.emergencyContacts.createdAt,
+        })
+        .from(schema.emergencyContacts)
+        .where(eq(schema.emergencyContacts.userId, userId)),
+      db
+        .select({ roleId: schema.userRoles.roleId })
+        .from(schema.userRoles)
+        .where(eq(schema.userRoles.userId, userId)),
+      db
+        .select({
+          cycle: schema.waiverAttestations.cycle,
+          version: schema.waiverAttestations.version,
+          attestedAt: schema.waiverAttestations.attestedAt,
+          attestedBy: schema.waiverAttestations.attestedBy,
+          revokedAt: schema.waiverAttestations.revokedAt,
+          revokedBy: schema.waiverAttestations.revokedBy,
+          revocationReason: schema.waiverAttestations.revocationReason,
+          notes: schema.waiverAttestations.notes,
+        })
+        .from(schema.waiverAttestations)
+        .where(eq(schema.waiverAttestations.userId, userId)),
+    ]);
+
+  return {
+    exportedAt: new Date().toISOString(),
+    schemaVersion: 1,
+    user: user ?? null,
+    profile: profile ?? null,
+    emergencyContacts,
+    roles: userRoles.map((r) => r.roleId),
+    waiverAttestations: attestations,
+    excluded: [
+      "Passkey credentials (public keys, counters, transports)",
+      "Magic-link token hashes",
+    ],
+  };
+}
+
+/**
+ * Self-serve hard delete. Removes the caller's user row and cascades
+ * through profiles, emergency_contacts, sessions, passkey_credentials,
+ * user_roles, and waiver_attestations (the ON DELETE CASCADE rules in
+ * schema.ts handle each child table). Explicitly deletes the caller's
+ * avatar from R2 — Drizzle cascades only cover relational rows, not
+ * blob storage. Closes the session cookie before returning so the
+ * browser redirects to a signed-out state.
+ *
+ * Self-protection: if the caller is the only `system_admin` left, we
+ * refuse — deleting the last admin would leave the platform with no
+ * way to grant `system_admin` to anyone else without a manual D1
+ * intervention. Officers in that position should promote a successor
+ * via /members/roles before deleting their own account.
+ */
+export async function deleteMyAccountAction(): Promise<{ ok: true }> {
+  const principal = await loadCurrentPrincipal();
+  if (!principal) {
+    throw new Error("Not signed in");
+  }
+
+  const db = getDb();
+
+  // Last-system-admin guard. system_admin is granted via a
+  // user_roles row with roleId=role_system_admin; if exactly one
+  // such row exists and it points at us, refuse. Off-by-one here
+  // would silently leave the platform admin-less, so the comparison
+  // is intentionally a strict count + identity check.
+  if (principal.roles.includes("system_admin")) {
+    const rows = await db
+      .select({ userId: schema.userRoles.userId })
+      .from(schema.userRoles)
+      .where(eq(schema.userRoles.roleId, "role_system_admin"));
+    if (rows.length === 1 && rows[0]?.userId === principal.userId) {
+      throw new Error(
+        "Cannot delete the only remaining system_admin. Promote a successor via /members/roles first.",
+      );
+    }
+  }
+
+  // Delete the avatar object from R2 before the row goes away. The
+  // R2 helper is a no-op if the key doesn't exist.
+  if (principal.avatarKey) {
+    const { deleteAvatar } = await import("#/server/r2/avatars.server");
+    await deleteAvatar(principal.avatarKey);
+  }
+
+  // Drop the user row. Foreign-key cascades in schema.ts handle:
+  //   profiles, emergency_contacts, sessions, passkey_credentials,
+  //   user_roles, waiver_attestations.
+  // announcements.created_by is ON DELETE SET NULL, so authored
+  // announcements stay but lose the author attribution.
+  await db.delete(schema.users).where(eq(schema.users.id, principal.userId));
+
+  // Clear the session cookie. closeSession would also try to delete a
+  // sessions row by id, but the cascade above already removed it; the
+  // cookie clear is the part that matters here.
+  await closeSession();
+
+  return { ok: true };
+}
+
 export async function submitProfileAction(
   data: RegistrationInput,
 ): Promise<{ ok: true }> {

--- a/apps/web/src/features/auth/server/server-fns.ts
+++ b/apps/web/src/features/auth/server/server-fns.ts
@@ -129,6 +129,21 @@ export const signOutFn = createServerFn({ method: "POST" }).handler(
   },
 );
 
+/**
+ * Hard-delete the caller's account. Cascades through profile, emergency
+ * contacts, sessions, passkeys, role assignments, and waiver
+ * attestations (per the ON DELETE CASCADE rules in schema.ts), drops
+ * the avatar from R2, and clears the session cookie. Refuses for the
+ * last `system_admin` to avoid bricking the platform.
+ */
+export const deleteMyAccountFn = createServerFn({ method: "POST" }).handler(
+  async (): Promise<{ ok: true }> => {
+    const { deleteMyAccountAction } =
+      await import("#/features/auth/server/magic-link-actions.server");
+    return deleteMyAccountAction();
+  },
+);
+
 export type Profile = typeof schema.profiles.$inferSelect;
 
 export interface EmergencyContactRow {

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -10,15 +10,20 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as WaiverRouteImport } from './routes/waiver'
+import { Route as TermsRouteImport } from './routes/terms'
 import { Route as SignInRouteImport } from './routes/sign-in'
+import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as OpenSourceRouteImport } from './routes/open-source'
 import { Route as NondiscriminationRouteImport } from './routes/nondiscrimination'
+import { Route as MembershipRouteImport } from './routes/membership'
 import { Route as MembersRouteImport } from './routes/members'
+import { Route as LegalRouteImport } from './routes/legal'
 import { Route as HealthRouteImport } from './routes/health'
 import { Route as DisclaimerRouteImport } from './routes/disclaimer'
 import { Route as DeactivatedRouteImport } from './routes/deactivated'
 import { Route as AntiHazingRouteImport } from './routes/anti-hazing'
 import { Route as AccountRouteImport } from './routes/account'
+import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as MembersIndexRouteImport } from './routes/members.index'
 import { Route as AnnouncementsIndexRouteImport } from './routes/announcements.index'
@@ -43,9 +48,19 @@ const WaiverRoute = WaiverRouteImport.update({
   path: '/waiver',
   getParentRoute: () => rootRouteImport,
 } as any)
+const TermsRoute = TermsRouteImport.update({
+  id: '/terms',
+  path: '/terms',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SignInRoute = SignInRouteImport.update({
   id: '/sign-in',
   path: '/sign-in',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PrivacyRoute = PrivacyRouteImport.update({
+  id: '/privacy',
+  path: '/privacy',
   getParentRoute: () => rootRouteImport,
 } as any)
 const OpenSourceRoute = OpenSourceRouteImport.update({
@@ -58,9 +73,19 @@ const NondiscriminationRoute = NondiscriminationRouteImport.update({
   path: '/nondiscrimination',
   getParentRoute: () => rootRouteImport,
 } as any)
+const MembershipRoute = MembershipRouteImport.update({
+  id: '/membership',
+  path: '/membership',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MembersRoute = MembersRouteImport.update({
   id: '/members',
   path: '/members',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LegalRoute = LegalRouteImport.update({
+  id: '/legal',
+  path: '/legal',
   getParentRoute: () => rootRouteImport,
 } as any)
 const HealthRoute = HealthRouteImport.update({
@@ -86,6 +111,11 @@ const AntiHazingRoute = AntiHazingRouteImport.update({
 const AccountRoute = AccountRouteImport.update({
   id: '/account',
   path: '/account',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AboutRoute = AboutRouteImport.update({
+  id: '/about',
+  path: '/about',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -181,15 +211,20 @@ const ApiAvatarsSplatRoute = ApiAvatarsSplatRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/about': typeof AboutRoute
   '/account': typeof AccountRouteWithChildren
   '/anti-hazing': typeof AntiHazingRoute
   '/deactivated': typeof DeactivatedRoute
   '/disclaimer': typeof DisclaimerRoute
   '/health': typeof HealthRoute
+  '/legal': typeof LegalRoute
   '/members': typeof MembersRouteWithChildren
+  '/membership': typeof MembershipRoute
   '/nondiscrimination': typeof NondiscriminationRoute
   '/open-source': typeof OpenSourceRoute
+  '/privacy': typeof PrivacyRoute
   '/sign-in': typeof SignInRoute
+  '/terms': typeof TermsRoute
   '/waiver': typeof WaiverRoute
   '/account/details': typeof AccountDetailsRoute
   '/account/preferences': typeof AccountPreferencesRoute
@@ -211,13 +246,18 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/about': typeof AboutRoute
   '/anti-hazing': typeof AntiHazingRoute
   '/deactivated': typeof DeactivatedRoute
   '/disclaimer': typeof DisclaimerRoute
   '/health': typeof HealthRoute
+  '/legal': typeof LegalRoute
+  '/membership': typeof MembershipRoute
   '/nondiscrimination': typeof NondiscriminationRoute
   '/open-source': typeof OpenSourceRoute
+  '/privacy': typeof PrivacyRoute
   '/sign-in': typeof SignInRoute
+  '/terms': typeof TermsRoute
   '/waiver': typeof WaiverRoute
   '/account/details': typeof AccountDetailsRoute
   '/account/preferences': typeof AccountPreferencesRoute
@@ -240,15 +280,20 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/about': typeof AboutRoute
   '/account': typeof AccountRouteWithChildren
   '/anti-hazing': typeof AntiHazingRoute
   '/deactivated': typeof DeactivatedRoute
   '/disclaimer': typeof DisclaimerRoute
   '/health': typeof HealthRoute
+  '/legal': typeof LegalRoute
   '/members': typeof MembersRouteWithChildren
+  '/membership': typeof MembershipRoute
   '/nondiscrimination': typeof NondiscriminationRoute
   '/open-source': typeof OpenSourceRoute
+  '/privacy': typeof PrivacyRoute
   '/sign-in': typeof SignInRoute
+  '/terms': typeof TermsRoute
   '/waiver': typeof WaiverRoute
   '/account/details': typeof AccountDetailsRoute
   '/account/preferences': typeof AccountPreferencesRoute
@@ -272,15 +317,20 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/about'
     | '/account'
     | '/anti-hazing'
     | '/deactivated'
     | '/disclaimer'
     | '/health'
+    | '/legal'
     | '/members'
+    | '/membership'
     | '/nondiscrimination'
     | '/open-source'
+    | '/privacy'
     | '/sign-in'
+    | '/terms'
     | '/waiver'
     | '/account/details'
     | '/account/preferences'
@@ -302,13 +352,18 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/about'
     | '/anti-hazing'
     | '/deactivated'
     | '/disclaimer'
     | '/health'
+    | '/legal'
+    | '/membership'
     | '/nondiscrimination'
     | '/open-source'
+    | '/privacy'
     | '/sign-in'
+    | '/terms'
     | '/waiver'
     | '/account/details'
     | '/account/preferences'
@@ -330,15 +385,20 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/about'
     | '/account'
     | '/anti-hazing'
     | '/deactivated'
     | '/disclaimer'
     | '/health'
+    | '/legal'
     | '/members'
+    | '/membership'
     | '/nondiscrimination'
     | '/open-source'
+    | '/privacy'
     | '/sign-in'
+    | '/terms'
     | '/waiver'
     | '/account/details'
     | '/account/preferences'
@@ -361,15 +421,20 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AboutRoute: typeof AboutRoute
   AccountRoute: typeof AccountRouteWithChildren
   AntiHazingRoute: typeof AntiHazingRoute
   DeactivatedRoute: typeof DeactivatedRoute
   DisclaimerRoute: typeof DisclaimerRoute
   HealthRoute: typeof HealthRoute
+  LegalRoute: typeof LegalRoute
   MembersRoute: typeof MembersRouteWithChildren
+  MembershipRoute: typeof MembershipRoute
   NondiscriminationRoute: typeof NondiscriminationRoute
   OpenSourceRoute: typeof OpenSourceRoute
+  PrivacyRoute: typeof PrivacyRoute
   SignInRoute: typeof SignInRoute
+  TermsRoute: typeof TermsRoute
   WaiverRoute: typeof WaiverRoute
   AuthCallbackRoute: typeof AuthCallbackRoute
   RegisterPendingRoute: typeof RegisterPendingRoute
@@ -388,11 +453,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WaiverRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/terms': {
+      id: '/terms'
+      path: '/terms'
+      fullPath: '/terms'
+      preLoaderRoute: typeof TermsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/sign-in': {
       id: '/sign-in'
       path: '/sign-in'
       fullPath: '/sign-in'
       preLoaderRoute: typeof SignInRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/privacy': {
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/open-source': {
@@ -409,11 +488,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof NondiscriminationRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/membership': {
+      id: '/membership'
+      path: '/membership'
+      fullPath: '/membership'
+      preLoaderRoute: typeof MembershipRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/members': {
       id: '/members'
       path: '/members'
       fullPath: '/members'
       preLoaderRoute: typeof MembersRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/legal': {
+      id: '/legal'
+      path: '/legal'
+      fullPath: '/legal'
+      preLoaderRoute: typeof LegalRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/health': {
@@ -449,6 +542,13 @@ declare module '@tanstack/react-router' {
       path: '/account'
       fullPath: '/account'
       preLoaderRoute: typeof AccountRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/about': {
+      id: '/about'
+      path: '/about'
+      fullPath: '/about'
+      preLoaderRoute: typeof AboutRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -622,15 +722,20 @@ const MembersRouteWithChildren =
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AboutRoute: AboutRoute,
   AccountRoute: AccountRouteWithChildren,
   AntiHazingRoute: AntiHazingRoute,
   DeactivatedRoute: DeactivatedRoute,
   DisclaimerRoute: DisclaimerRoute,
   HealthRoute: HealthRoute,
+  LegalRoute: LegalRoute,
   MembersRoute: MembersRouteWithChildren,
+  MembershipRoute: MembershipRoute,
   NondiscriminationRoute: NondiscriminationRoute,
   OpenSourceRoute: OpenSourceRoute,
+  PrivacyRoute: PrivacyRoute,
   SignInRoute: SignInRoute,
+  TermsRoute: TermsRoute,
   WaiverRoute: WaiverRoute,
   AuthCallbackRoute: AuthCallbackRoute,
   RegisterPendingRoute: RegisterPendingRoute,

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -42,6 +42,7 @@ import { Route as AccountDetailsRouteImport } from './routes/account.details'
 import { Route as MembersRolesRoleIdRouteImport } from './routes/members.roles_.$roleId'
 import { Route as ApiLandingSplatRouteImport } from './routes/api/landing.$'
 import { Route as ApiAvatarsSplatRouteImport } from './routes/api/avatars.$'
+import { Route as ApiAccountExportRouteImport } from './routes/api/account.export'
 
 const WaiverRoute = WaiverRouteImport.update({
   id: '/waiver',
@@ -208,6 +209,11 @@ const ApiAvatarsSplatRoute = ApiAvatarsSplatRouteImport.update({
   path: '/api/avatars/$',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiAccountExportRoute = ApiAccountExportRouteImport.update({
+  id: '/api/account/export',
+  path: '/api/account/export',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -240,6 +246,7 @@ export interface FileRoutesByFullPath {
   '/account/': typeof AccountIndexRoute
   '/announcements/': typeof AnnouncementsIndexRoute
   '/members/': typeof MembersIndexRoute
+  '/api/account/export': typeof ApiAccountExportRoute
   '/api/avatars/$': typeof ApiAvatarsSplatRoute
   '/api/landing/$': typeof ApiLandingSplatRoute
   '/members/roles/$roleId': typeof MembersRolesRoleIdRoute
@@ -273,6 +280,7 @@ export interface FileRoutesByTo {
   '/account': typeof AccountIndexRoute
   '/announcements': typeof AnnouncementsIndexRoute
   '/members': typeof MembersIndexRoute
+  '/api/account/export': typeof ApiAccountExportRoute
   '/api/avatars/$': typeof ApiAvatarsSplatRoute
   '/api/landing/$': typeof ApiLandingSplatRoute
   '/members/roles/$roleId': typeof MembersRolesRoleIdRoute
@@ -309,6 +317,7 @@ export interface FileRoutesById {
   '/account/': typeof AccountIndexRoute
   '/announcements/': typeof AnnouncementsIndexRoute
   '/members/': typeof MembersIndexRoute
+  '/api/account/export': typeof ApiAccountExportRoute
   '/api/avatars/$': typeof ApiAvatarsSplatRoute
   '/api/landing/$': typeof ApiLandingSplatRoute
   '/members/roles_/$roleId': typeof MembersRolesRoleIdRoute
@@ -346,6 +355,7 @@ export interface FileRouteTypes {
     | '/account/'
     | '/announcements/'
     | '/members/'
+    | '/api/account/export'
     | '/api/avatars/$'
     | '/api/landing/$'
     | '/members/roles/$roleId'
@@ -379,6 +389,7 @@ export interface FileRouteTypes {
     | '/account'
     | '/announcements'
     | '/members'
+    | '/api/account/export'
     | '/api/avatars/$'
     | '/api/landing/$'
     | '/members/roles/$roleId'
@@ -414,6 +425,7 @@ export interface FileRouteTypes {
     | '/account/'
     | '/announcements/'
     | '/members/'
+    | '/api/account/export'
     | '/api/avatars/$'
     | '/api/landing/$'
     | '/members/roles_/$roleId'
@@ -440,6 +452,7 @@ export interface RootRouteChildren {
   RegisterPendingRoute: typeof RegisterPendingRoute
   RegisterProfileRoute: typeof RegisterProfileRoute
   AnnouncementsIndexRoute: typeof AnnouncementsIndexRoute
+  ApiAccountExportRoute: typeof ApiAccountExportRoute
   ApiAvatarsSplatRoute: typeof ApiAvatarsSplatRoute
   ApiLandingSplatRoute: typeof ApiLandingSplatRoute
 }
@@ -677,6 +690,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiAvatarsSplatRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/account/export': {
+      id: '/api/account/export'
+      path: '/api/account/export'
+      fullPath: '/api/account/export'
+      preLoaderRoute: typeof ApiAccountExportRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -741,6 +761,7 @@ const rootRouteChildren: RootRouteChildren = {
   RegisterPendingRoute: RegisterPendingRoute,
   RegisterProfileRoute: RegisterProfileRoute,
   AnnouncementsIndexRoute: AnnouncementsIndexRoute,
+  ApiAccountExportRoute: ApiAccountExportRoute,
   ApiAvatarsSplatRoute: ApiAvatarsSplatRoute,
   ApiLandingSplatRoute: ApiLandingSplatRoute,
 }

--- a/apps/web/src/routes/about.tsx
+++ b/apps/web/src/routes/about.tsx
@@ -1,0 +1,28 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { LegalSections } from "#/components/legal/legal-section";
+import { ABOUT_BODY } from "#/config/legal";
+
+/**
+ * Public "about UCMC" page. Frames the club, the open-membership
+ * Article III §3.2 invariant, and the additive-not-canonical
+ * relationship to CampusLINK. The colophon-style "/open-source" page
+ * is a sibling that covers the *site* rather than the *club*.
+ */
+export const Route = createFileRoute("/about")({
+  component: AboutPage,
+});
+
+function AboutPage() {
+  return (
+    <main id="main" className="mx-auto w-full max-w-2xl space-y-8 px-6 py-12">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">About UCMC</h1>
+        <p className="text-sm text-muted-foreground">
+          Who we are, how we operate, and how this site fits in.
+        </p>
+      </header>
+      <LegalSections sections={ABOUT_BODY} />
+    </main>
+  );
+}

--- a/apps/web/src/routes/account.security.tsx
+++ b/apps/web/src/routes/account.security.tsx
@@ -1,10 +1,27 @@
 import { useQuery } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
+import { toast } from "sonner";
 
 import { passkeyListQueryOptions } from "#/features/auth/api/queries";
+import { useDeleteMyAccount } from "#/features/auth/api/use-delete-my-account";
 import { useRemovePasskey } from "#/features/auth/api/use-remove-passkey";
+import { useAuth } from "#/features/auth/api/use-auth";
 import { AddPasskeyButton } from "#/features/auth/components/passkey-button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "#/components/ui/alert-dialog";
 import { Button } from "#/components/ui/button";
+import { Input } from "#/components/ui/input";
+import { Label } from "#/components/ui/label";
 import { requireAuth } from "#/features/auth/guards";
 
 /**
@@ -95,6 +112,120 @@ function SecurityPage() {
         <h2 className="text-lg font-semibold">Add a passkey</h2>
         <AddPasskeyButton />
       </section>
+
+      <DataAndDeletionSection />
     </div>
+  );
+}
+
+/**
+ * Data export + account deletion. Both honor the promises on /privacy:
+ * download a JSON copy of everything we have on you, and hard-delete
+ * the account immediately. Deletion is gated by typing the email on
+ * file — defends against accidental clicks more than it does against
+ * deliberate misuse (a hostile actor with the session can already type
+ * the email).
+ */
+function DataAndDeletionSection() {
+  const { principal } = useAuth();
+  const navigate = useNavigate();
+  const deletion = useDeleteMyAccount();
+  const [open, setOpen] = useState(false);
+  const [confirmEmail, setConfirmEmail] = useState("");
+
+  const expectedEmail = principal?.email ?? "";
+  const matches = confirmEmail.trim().toLowerCase() === expectedEmail;
+
+  const onConfirm = () => {
+    deletion.mutate(undefined, {
+      onSuccess: async () => {
+        toast.success("Account deleted");
+        setOpen(false);
+        await navigate({ to: "/" });
+      },
+      onError: (err) => {
+        toast.error(
+          err instanceof Error ? err.message : "Couldn't delete the account",
+        );
+      },
+    });
+  };
+
+  return (
+    <>
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold">Your data</h2>
+        <p className="text-sm text-muted-foreground">
+          Download a JSON copy of everything this site stores about you — your
+          profile, emergency contacts, role memberships, and waiver attestation
+          history. The export does not include passkey credentials or magic-link
+          tokens.
+        </p>
+        <Button asChild variant="outline">
+          <a href="/api/account/export" download>
+            Download my data
+          </a>
+        </Button>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold text-destructive">
+          Delete account
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Permanently delete your account, profile, emergency contacts,
+          passkeys, sessions, and waiver attestation history. This is immediate
+          and irreversible — there is no recovery on the other side. Authored
+          announcements stay (anonymized) so the timeline for other members
+          remains intact.
+        </p>
+        <AlertDialog open={open} onOpenChange={setOpen}>
+          <AlertDialogTrigger asChild>
+            <Button variant="destructive">Delete my account</Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete your account?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This is permanent. Type{" "}
+                <strong className="font-mono">{expectedEmail}</strong> to
+                confirm.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <div className="space-y-2 py-2">
+              <Label htmlFor="confirm-delete-email" className="text-sm">
+                Email
+              </Label>
+              <Input
+                id="confirm-delete-email"
+                type="email"
+                autoComplete="off"
+                value={confirmEmail}
+                onChange={(e) => setConfirmEmail(e.target.value)}
+                placeholder={expectedEmail}
+              />
+            </div>
+            <AlertDialogFooter>
+              <AlertDialogCancel
+                onClick={() => setConfirmEmail("")}
+                disabled={deletion.isPending}
+              >
+                Cancel
+              </AlertDialogCancel>
+              <AlertDialogAction
+                onClick={(e) => {
+                  e.preventDefault();
+                  onConfirm();
+                }}
+                disabled={!matches || deletion.isPending}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                {deletion.isPending ? "Deleting…" : "Delete forever"}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </section>
+    </>
   );
 }

--- a/apps/web/src/routes/api/account.export.ts
+++ b/apps/web/src/routes/api/account.export.ts
@@ -1,0 +1,42 @@
+/**
+ * Self-serve data export. Returns a downloadable JSON bundle of every
+ * piece of data the site stores about the caller — the implementation
+ * of the "download my data" promise on /privacy.
+ *
+ * The data assembly + exclusion policy lives in
+ * `exportMyDataAction` (`magic-link-actions.server.ts`) so it's
+ * unit-testable; this route handler is just the HTTP envelope (auth
+ * 401 + Content-Disposition: attachment).
+ */
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/api/account/export")({
+  server: {
+    handlers: {
+      GET: async () => {
+        const { exportMyDataAction } =
+          await import("#/features/auth/server/magic-link-actions.server");
+
+        let payload;
+        try {
+          payload = await exportMyDataAction();
+        } catch (err) {
+          if (err instanceof Error && err.message === "Not signed in") {
+            return new Response("Unauthorized", { status: 401 });
+          }
+          throw err;
+        }
+
+        const filename = `ucmc-export-${payload.user?.email ?? "account"}-${new Date().toISOString().slice(0, 10)}.json`;
+
+        return new Response(JSON.stringify(payload, null, 2), {
+          headers: {
+            "Content-Type": "application/json; charset=utf-8",
+            "Content-Disposition": `attachment; filename="${filename.replace(/"/g, "")}"`,
+            "Cache-Control": "private, no-store",
+          },
+        });
+      },
+    },
+  },
+});

--- a/apps/web/src/routes/legal.tsx
+++ b/apps/web/src/routes/legal.tsx
@@ -1,0 +1,44 @@
+import { Link, createFileRoute } from "@tanstack/react-router";
+
+import { LEGAL_INDEX_LINKS } from "#/config/legal";
+
+/**
+ * Public index of every legal/policy page on the site. Useful as a
+ * single landing pad ("what's the official line on X?") rather than
+ * making a visitor scan the footer link bar.
+ */
+export const Route = createFileRoute("/legal")({
+  component: LegalIndexPage,
+});
+
+function LegalIndexPage() {
+  return (
+    <main id="main" className="mx-auto w-full max-w-2xl space-y-8 px-6 py-12">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">Legal</h1>
+        <p className="text-sm text-muted-foreground">
+          Every disclosure, policy, and reference document this site publishes,
+          in one place.
+        </p>
+      </header>
+
+      <ul className="space-y-4">
+        {LEGAL_INDEX_LINKS.map((entry) => (
+          <li
+            key={entry.href}
+            className="rounded-lg border bg-card p-4 transition-colors hover:bg-muted/40"
+          >
+            <Link to={entry.href} className="block space-y-1 no-underline">
+              <span className="block text-base font-medium text-foreground underline underline-offset-2">
+                {entry.label}
+              </span>
+              <span className="block text-sm text-muted-foreground">
+                {entry.description}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/apps/web/src/routes/membership.tsx
+++ b/apps/web/src/routes/membership.tsx
@@ -1,0 +1,29 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { LegalSections } from "#/components/legal/legal-section";
+import { MEMBERSHIP_BODY } from "#/config/legal";
+
+/**
+ * Public membership / eligibility / dues / how-to-join page. The
+ * verification-not-gatekeeping framing of the registration approval
+ * queue lives here, mirroring the constitutional invariant from
+ * Article III §3.2.
+ */
+export const Route = createFileRoute("/membership")({
+  component: MembershipPage,
+});
+
+function MembershipPage() {
+  return (
+    <main id="main" className="mx-auto w-full max-w-2xl space-y-8 px-6 py-12">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">Membership</h1>
+        <p className="text-sm text-muted-foreground">
+          Who can join, how dues work, and what the registration approval queue
+          actually checks.
+        </p>
+      </header>
+      <LegalSections sections={MEMBERSHIP_BODY} />
+    </main>
+  );
+}

--- a/apps/web/src/routes/privacy.tsx
+++ b/apps/web/src/routes/privacy.tsx
@@ -1,0 +1,30 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { LegalSections } from "#/components/legal/legal-section";
+import { PRIVACY_BODY } from "#/config/legal";
+
+/**
+ * Public privacy notice. The promises here are kept in lockstep with
+ * the actual data flows by sourcing the prose from
+ * `#/config/legal#PRIVACY_BODY` — when the schema, processors, or
+ * retention policy change, update that constant first and treat the
+ * rest of the change as a follow-on.
+ */
+export const Route = createFileRoute("/privacy")({
+  component: PrivacyPage,
+});
+
+function PrivacyPage() {
+  return (
+    <main id="main" className="mx-auto w-full max-w-2xl space-y-8 px-6 py-12">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">Privacy</h1>
+        <p className="text-sm text-muted-foreground">
+          What this site collects, who it's shared with, how long it's kept, and
+          how to delete it.
+        </p>
+      </header>
+      <LegalSections sections={PRIVACY_BODY} />
+    </main>
+  );
+}

--- a/apps/web/src/routes/terms.tsx
+++ b/apps/web/src/routes/terms.tsx
@@ -1,0 +1,28 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { LegalSections } from "#/components/legal/legal-section";
+import { TERMS_BODY } from "#/config/legal";
+
+/**
+ * Public terms of use for the website itself. Distinct from the
+ * waiver (which covers club activities) — these terms cover use of
+ * the member portal at ucmc.spencerwill.com.
+ */
+export const Route = createFileRoute("/terms")({
+  component: TermsPage,
+});
+
+function TermsPage() {
+  return (
+    <main id="main" className="mx-auto w-full max-w-2xl space-y-8 px-6 py-12">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">Terms of use</h1>
+        <p className="text-sm text-muted-foreground">
+          Acceptable use of this website. Distinct from the UCMC Waiver of
+          Liability, which covers club activities.
+        </p>
+      </header>
+      <LegalSections sections={TERMS_BODY} />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

First Phase B branch. Adds the five remaining public-content routes and makes the privacy promises real with self-serve data export + hard delete.

**Public content routes:**
- `/privacy` — what's collected, what's NOT collected (M-numbers, medical info, payments), processors named, retention windows, your rights, cookie inventory.
- `/terms` — acceptable use of the website itself; Hamilton County / Ohio governing law; distinct from the waiver.
- `/about` — who UCMC is, additive-not-canonical relationship to CampusLINK.
- `/membership` — Article III §3.2 open-eligibility, Bylaw §7.1 dues, verification-not-gatekeeping framing.
- `/legal` — index page surfacing all nine disclosure / policy / reference routes.

Footer legal-nav now exposes About, Membership, Privacy, Terms inline alongside the four constitutional/statutory links.

**Self-serve data export (W-8):**
- `GET /api/account/export` returns a downloadable JSON bundle (user, profile, emergency contacts, role memberships, waiver attestation history). Excludes passkey credentials + magic-link token hashes both because they're not useful to the member and because dumping authenticator metadata makes account-takeover scenarios worse.
- Data assembly lives in `exportMyDataAction` so it's unit-testable; the route handler is just the HTTP envelope (401 on unauthenticated, `Content-Disposition: attachment` otherwise).

**Self-serve hard delete (W-9):**
- `deleteMyAccountAction` removes the user row and cascades through profile, emergency contacts, sessions, passkeys, role assignments, and waiver attestations per the schema's ON DELETE CASCADE rules. Explicitly removes the avatar from R2 (drizzle cascades cover relational rows, not blob storage). Closes the session cookie. Authored announcements are preserved with their `created_by` set to NULL so the timeline stays intact for other members.
- Last-system-admin guard refuses self-deletion when the caller is the only `system_admin`. Officers in that position must promote a successor via `/members/roles` before deleting their own account, otherwise the platform would be left admin-less.
- UI on `/account/security` with an `AlertDialog` requiring the user to re-type their email before the destructive action enables.

## Test plan

- [ ] `pnpm --filter ucmc-web typecheck` — clean
- [ ] `pnpm --filter ucmc-web test` — 232 passing (14 new)
- [ ] `pnpm --filter ucmc-web lint` — 0 errors
- [ ] `pnpm --filter ucmc-web build` — succeeds
- [ ] Visit `/privacy`, `/terms`, `/about`, `/membership`, `/legal` and confirm content + cross-links resolve
- [ ] Sign in, hit `/account/security`, click "Download my data" — JSON file downloads with `ucmc-export-{email}-{date}.json` filename
- [ ] In the JSON, verify no passkey credential ids or magic-link token hashes appear
- [ ] On `/account/security`, click "Delete my account" → AlertDialog appears, button stays disabled until email matches → confirm deletion → sign-in is required again, account is gone
- [ ] Try deleting from a system_admin account that has no co-admin — surfaces the "only remaining system_admin" error toast

## Out of scope

- A11y baseline (jsx-a11y + axe-core e2e gating in CI) — separate follow-up
- Documentation updates (D-1, D-4, D-5)
- Audit log / retention crons (Phase C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)