### PR TITLE
fix(ucmc-web): close #32 + #24 — waiver-attestation FK + export filename injection

### DIFF
--- a/apps/web/drizzle/migrations/0018_waiver_attestedby_set_null.sql
+++ b/apps/web/drizzle/migrations/0018_waiver_attestedby_set_null.sql
@@ -1,0 +1,23 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_waiver_attestations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`cycle` text NOT NULL,
+	`version` text NOT NULL,
+	`attested_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`attested_by` text,
+	`revoked_at` integer,
+	`revoked_by` text,
+	`revocation_reason` text,
+	`notes` text,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`attested_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`revoked_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+INSERT INTO `__new_waiver_attestations`("id", "user_id", "cycle", "version", "attested_at", "attested_by", "revoked_at", "revoked_by", "revocation_reason", "notes") SELECT "id", "user_id", "cycle", "version", "attested_at", "attested_by", "revoked_at", "revoked_by", "revocation_reason", "notes" FROM `waiver_attestations`;--> statement-breakpoint
+DROP TABLE `waiver_attestations`;--> statement-breakpoint
+ALTER TABLE `__new_waiver_attestations` RENAME TO `waiver_attestations`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `waiver_attestations_user_cycle` ON `waiver_attestations` (`user_id`,`cycle`);--> statement-breakpoint
+CREATE INDEX `waiver_attestations_cycle_version_revoked` ON `waiver_attestations` (`cycle`,`version`,`revoked_at`);

--- a/apps/web/drizzle/migrations/meta/0018_snapshot.json
+++ b/apps/web/drizzle/migrations/meta/0018_snapshot.json
@@ -1,0 +1,1154 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6389dbf9-1537-4567-a1c7-add410e188d2",
+  "prevId": "6ccce179-484b-4c57-aa5f-c9abafc9ab77",
+  "tables": {
+    "announcements": {
+      "name": "announcements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "announcements_published_at_idx": {
+          "name": "announcements_published_at_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "announcements_created_by_users_id_fk": {
+          "name": "announcements_created_by_users_id_fk",
+          "tableFrom": "announcements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "emergency_contacts": {
+      "name": "emergency_contacts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "emergency_contacts_user_id_users_id_fk": {
+          "name": "emergency_contacts_user_id_users_id_fk",
+          "tableFrom": "emergency_contacts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "landing_activities": {
+      "name": "landing_activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blurb": {
+          "name": "blurb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "landing_activities_sort_idx": {
+          "name": "landing_activities_sort_idx",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "landing_faq_items": {
+      "name": "landing_faq_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "landing_faq_items_sort_idx": {
+          "name": "landing_faq_items_sort_idx",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "landing_hero_slides": {
+      "name": "landing_hero_slides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "landing_hero_slides_sort_idx": {
+          "name": "landing_hero_slides_sort_idx",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "landing_settings": {
+      "name": "landing_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "landing_settings_updated_by_users_id_fk": {
+          "name": "landing_settings_updated_by_users_id_fk",
+          "tableFrom": "landing_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_links": {
+      "name": "magic_links",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey_credentials": {
+      "name": "passkey_credentials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkey_credential_id_unique": {
+          "name": "passkey_credential_id_unique",
+          "columns": [
+            "credential_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "passkey_credentials_user_id_users_id_fk": {
+          "name": "passkey_credentials_user_id_users_id_fk",
+          "tableFrom": "passkey_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "permissions": {
+      "name": "permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "permissions_name_unique": {
+          "name": "permissions_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "profiles": {
+      "name": "profiles",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preferred_name": {
+          "name": "preferred_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uc_affiliation": {
+          "name": "uc_affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_key": {
+          "name": "avatar_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policies_acknowledged_at": {
+          "name": "policies_acknowledged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policies_version": {
+          "name": "policies_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_user_id_users_id_fk": {
+          "name": "profiles_user_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "role_permissions": {
+      "name": "role_permissions",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_id_pk": {
+          "columns": [
+            "role_id",
+            "permission_id"
+          ],
+          "name": "role_permissions_role_id_permission_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "roles": {
+      "name": "roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_roles": {
+      "name": "user_roles",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "columns": [
+            "user_id",
+            "role_id"
+          ],
+          "name": "user_roles_user_id_role_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_read_announcements_at": {
+          "name": "last_read_announcements_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_public_id_unique": {
+          "name": "users_public_id_unique",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "waiver_attestations": {
+      "name": "waiver_attestations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attested_at": {
+          "name": "attested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "attested_by": {
+          "name": "attested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "waiver_attestations_user_cycle": {
+          "name": "waiver_attestations_user_cycle",
+          "columns": [
+            "user_id",
+            "cycle"
+          ],
+          "isUnique": false
+        },
+        "waiver_attestations_cycle_version_revoked": {
+          "name": "waiver_attestations_cycle_version_revoked",
+          "columns": [
+            "cycle",
+            "version",
+            "revoked_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "waiver_attestations_user_id_users_id_fk": {
+          "name": "waiver_attestations_user_id_users_id_fk",
+          "tableFrom": "waiver_attestations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "waiver_attestations_attested_by_users_id_fk": {
+          "name": "waiver_attestations_attested_by_users_id_fk",
+          "tableFrom": "waiver_attestations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "attested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "waiver_attestations_revoked_by_users_id_fk": {
+          "name": "waiver_attestations_revoked_by_users_id_fk",
+          "tableFrom": "waiver_attestations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/web/drizzle/migrations/meta/_journal.json
+++ b/apps/web/drizzle/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1777761742187,
       "tag": "0017_waiver_attestations_queue_index",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1777774270043,
+      "tag": "0018_waiver_attestedby_set_null",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/drizzle/schema.ts
+++ b/apps/web/drizzle/schema.ts
@@ -165,11 +165,19 @@ export const waiverAttestations = sqliteTable(
     attestedAt: timestamp("attested_at")
       .notNull()
       .default(sql`(unixepoch() * 1000)`),
-    attestedBy: text("attested_by")
-      .notNull()
-      .references(() => users.id),
+    // Officer who attested. Nullable + ON DELETE SET NULL so an officer
+    // who has attested another member's waiver can later self-delete
+    // without an FK violation. The attestation row survives (audit
+    // trail), it just loses the officer's identity. Mirrors the
+    // pattern `announcements.created_by` already uses.
+    attestedBy: text("attested_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
     revokedAt: timestamp("revoked_at"),
-    revokedBy: text("revoked_by").references(() => users.id),
+    // Same pattern: nullable already, just adds the SET NULL clause.
+    revokedBy: text("revoked_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
     revocationReason: text("revocation_reason"),
     notes: text("notes"),
   },

--- a/apps/web/src/features/auth/server/__tests__/delete-my-account.test.ts
+++ b/apps/web/src/features/auth/server/__tests__/delete-my-account.test.ts
@@ -252,4 +252,73 @@ describe("deleteMyAccountAction", () => {
     expect(remaining).toHaveLength(1);
     expect(remaining[0]?.createdBy).toBeNull();
   });
+
+  // Regression: an officer who has attested another member's waiver
+  // used to fail self-delete with a foreign-key violation on
+  // waiver_attestations.attested_by (issue #32). After
+  // 0018_waiver_attestedby_set_null.sql the FK is ON DELETE SET NULL,
+  // so the officer's row goes away cleanly and the attestation
+  // survives with attested_by = null (rendered as "(deleted user)"
+  // in the UI).
+  it("preserves another member's attestation when the attesting officer self-deletes", async () => {
+    const officerId = await seedUser("officer@example.com");
+    const memberId = await seedUser("member@example.com");
+    const db = getDb();
+    const attestationId = `wa_${crypto.randomUUID()}`;
+    await db.insert(schema.waiverAttestations).values({
+      id: attestationId,
+      userId: memberId,
+      cycle: "2025-26",
+      version: "v1",
+      attestedAt: new Date(),
+      attestedBy: officerId,
+    });
+    await signInAs(officerId);
+
+    await expect(deleteMyAccountAction()).resolves.toEqual({ ok: true });
+
+    // The officer is gone…
+    expect(
+      await db.query.users.findFirst({
+        where: eq(schema.users.id, officerId),
+      }),
+    ).toBeUndefined();
+    // …but the attestation row survives, with attested_by nulled.
+    const attestation = await db.query.waiverAttestations.findFirst({
+      where: eq(schema.waiverAttestations.id, attestationId),
+    });
+    expect(attestation).toBeDefined();
+    expect(attestation?.attestedBy).toBeNull();
+  });
+
+  it("preserves another member's revoked attestation when the revoking officer self-deletes", async () => {
+    const officerId = await seedUser("revoker@example.com");
+    const memberId = await seedUser("member@example.com");
+    const db = getDb();
+    const attestationId = `wa_${crypto.randomUUID()}`;
+    await db.insert(schema.waiverAttestations).values({
+      id: attestationId,
+      userId: memberId,
+      cycle: "2025-26",
+      version: "v1",
+      attestedAt: new Date(),
+      attestedBy: memberId,
+      revokedAt: new Date(),
+      revokedBy: officerId,
+      revocationReason: "wrong member",
+    });
+    await signInAs(officerId);
+
+    await expect(deleteMyAccountAction()).resolves.toEqual({ ok: true });
+
+    const attestation = await db.query.waiverAttestations.findFirst({
+      where: eq(schema.waiverAttestations.id, attestationId),
+    });
+    expect(attestation).toBeDefined();
+    expect(attestation?.revokedBy).toBeNull();
+    // The revocation reason + timestamp survive the officer's
+    // deletion — the audit trail loses identity, not the event.
+    expect(attestation?.revokedAt).not.toBeNull();
+    expect(attestation?.revocationReason).toBe("wrong member");
+  });
 });

--- a/apps/web/src/features/auth/server/magic-link-actions.server.ts
+++ b/apps/web/src/features/auth/server/magic-link-actions.server.ts
@@ -236,7 +236,10 @@ export async function exportMyDataAction(): Promise<{
     cycle: string;
     version: string;
     attestedAt: Date;
-    attestedBy: string;
+    // attestedBy + revokedBy can be null when the officer who acted
+    // on the row has since deleted their account (FK ON DELETE SET
+    // NULL, see 0018_waiver_attestedby_set_null.sql).
+    attestedBy: string | null;
     revokedAt: Date | null;
     revokedBy: string | null;
     revocationReason: string | null;

--- a/apps/web/src/features/auth/server/waiver-actions.server.ts
+++ b/apps/web/src/features/auth/server/waiver-actions.server.ts
@@ -51,9 +51,14 @@ export interface WaiverAttestationSummary {
   cycle: string;
   version: string;
   attestedAt: Date;
-  attestedByUserId: string;
+  // All attestor-side identity fields are nullable because the FK is
+  // `ON DELETE SET NULL` (0018_waiver_attestedby_set_null.sql) — when
+  // an officer self-deletes, their prior attestations survive but
+  // lose the officer's identity. UI renders "(deleted user)" in that
+  // case. Same shape applies to revoker-side fields.
+  attestedByUserId: string | null;
   attestedByPreferredName: string | null;
-  attestedByEmail: string;
+  attestedByEmail: string | null;
   revokedAt: Date | null;
   revokedByUserId: string | null;
   revocationReason: string | null;
@@ -326,7 +331,11 @@ async function loadAttestationHistory(
       notes: att.notes,
     })
     .from(att)
-    .innerJoin(attestor, eq(attestor.id, att.attestedBy))
+    // Both joins are LEFT — when attestedBy is NULL (officer was
+    // deleted), the attestation row still surfaces and the
+    // attestor-side fields come back as null, which the UI renders
+    // as "(deleted user)".
+    .leftJoin(attestor, eq(attestor.id, att.attestedBy))
     .leftJoin(profile, eq(profile.userId, att.attestedBy))
     .where(eq(att.userId, userId))
     .orderBy(desc(att.attestedAt));
@@ -358,7 +367,11 @@ async function loadCurrentAttestation(
       notes: att.notes,
     })
     .from(att)
-    .innerJoin(attestor, eq(attestor.id, att.attestedBy))
+    // Both joins are LEFT — when attestedBy is NULL (officer was
+    // deleted), the attestation row still surfaces and the
+    // attestor-side fields come back as null, which the UI renders
+    // as "(deleted user)".
+    .leftJoin(attestor, eq(attestor.id, att.attestedBy))
     .leftJoin(profile, eq(profile.userId, att.attestedBy))
     .where(
       and(

--- a/apps/web/src/lib/__tests__/sanitize-filename.test.ts
+++ b/apps/web/src/lib/__tests__/sanitize-filename.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeFilenameSegment } from "#/lib/sanitize-filename";
+
+describe("sanitizeFilenameSegment", () => {
+  it("passes through plain alphanumerics, dot, underscore, dash", () => {
+    expect(sanitizeFilenameSegment("alice.example_1-2")).toBe(
+      "alice.example_1-2",
+    );
+  });
+
+  it("replaces an `@` with `_` so plain emails round-trip readably", () => {
+    expect(sanitizeFilenameSegment("alice@example.com")).toBe(
+      "alice_example.com",
+    );
+  });
+
+  it("strips characters that would break Content-Disposition", () => {
+    // ; = " \r \n — the separators that matter for header injection.
+    expect(sanitizeFilenameSegment('a;filename="evil"')).toBe(
+      "a_filename__evil_",
+    );
+    expect(sanitizeFilenameSegment("a\r\nb")).toBe("a__b");
+    expect(sanitizeFilenameSegment("a=b;c=d")).toBe("a_b_c_d");
+  });
+
+  it("strips path separators", () => {
+    expect(sanitizeFilenameSegment("a/b\\c")).toBe("a_b_c");
+    // `.` is allowed in filenames, so `..` survives — that's fine
+    // here because the segment is interpolated into a
+    // Content-Disposition header, not a filesystem path. Only `/` and
+    // `\` would be header-injection concerns or browser-side
+    // confusion, and both are stripped.
+    expect(sanitizeFilenameSegment("../../etc/passwd")).toBe(
+      ".._.._etc_passwd",
+    );
+  });
+
+  it("collapses unicode and control characters", () => {
+    expect(sanitizeFilenameSegment("héllo")).toBe("h_llo");
+    expect(sanitizeFilenameSegment("a\x00b")).toBe("a_b");
+    expect(sanitizeFilenameSegment("a\tb")).toBe("a_b");
+  });
+
+  it("returns an empty string unchanged", () => {
+    expect(sanitizeFilenameSegment("")).toBe("");
+  });
+});

--- a/apps/web/src/lib/sanitize-filename.ts
+++ b/apps/web/src/lib/sanitize-filename.ts
@@ -1,0 +1,15 @@
+/**
+ * Whitelists the characters allowed in a filename segment that's
+ * being interpolated into a `Content-Disposition` response header.
+ * Defends against header injection if the source string ever turns
+ * out to contain `;`, CR/LF, `=`, `"`, or other separators —
+ * treating the input as untrusted at the header boundary is the
+ * right discipline even when upstream validation should have caught
+ * it.
+ *
+ * Replaces every non-allowed character with `_`. Allowed:
+ * `A-Z a-z 0-9 . _ -`.
+ */
+export function sanitizeFilenameSegment(input: string): string {
+  return input.replace(/[^A-Za-z0-9._-]/g, "_");
+}

--- a/apps/web/src/routes/account.waiver.tsx
+++ b/apps/web/src/routes/account.waiver.tsx
@@ -78,7 +78,9 @@ function CurrentStatusCard({
           </div>
           <p className="text-sm">
             Marked attested by{" "}
-            {attestation.attestedByPreferredName ?? attestation.attestedByEmail}{" "}
+            {attestation.attestedByPreferredName ??
+              attestation.attestedByEmail ??
+              "(deleted user)"}{" "}
             on{" "}
             <time dateTime={new Date(attestation.attestedAt).toISOString()}>
               {new Date(attestation.attestedAt).toLocaleDateString()}
@@ -170,7 +172,9 @@ function HistoryCard({ history }: { history: WaiverAttestationSummary[] }) {
               </div>
               <p className="text-muted-foreground">
                 {new Date(row.attestedAt).toLocaleDateString()} by{" "}
-                {row.attestedByPreferredName ?? row.attestedByEmail}
+                {row.attestedByPreferredName ??
+                  row.attestedByEmail ??
+                  "(deleted user)"}
                 {row.notes ? ` — "${row.notes}"` : null}
               </p>
               {row.revokedAt ? (

--- a/apps/web/src/routes/api/account.export.ts
+++ b/apps/web/src/routes/api/account.export.ts
@@ -10,6 +10,8 @@
  */
 import { createFileRoute } from "@tanstack/react-router";
 
+import { sanitizeFilenameSegment } from "#/lib/sanitize-filename";
+
 export const Route = createFileRoute("/api/account/export")({
   server: {
     handlers: {
@@ -27,12 +29,16 @@ export const Route = createFileRoute("/api/account/export")({
           throw err;
         }
 
-        const filename = `ucmc-export-${payload.user?.email ?? "account"}-${new Date().toISOString().slice(0, 10)}.json`;
+        const safeIdentifier = sanitizeFilenameSegment(
+          payload.user?.email ?? "account",
+        );
+        const date = new Date().toISOString().slice(0, 10);
+        const filename = `ucmc-export-${safeIdentifier}-${date}.json`;
 
         return new Response(JSON.stringify(payload, null, 2), {
           headers: {
             "Content-Type": "application/json; charset=utf-8",
-            "Content-Disposition": `attachment; filename="${filename.replace(/"/g, "")}"`,
+            "Content-Disposition": `attachment; filename="${filename}"`,
             "Cache-Control": "private, no-store",
           },
         });


### PR DESCRIPTION
Two bug fixes against code that just merged in PR #19/#23.

## Closes #32 — `deleteMyAccountAction` FK violation

`waiver_attestations.attested_by` was `notNull` and referenced `users.id` with no `onDelete` clause, so SQLite's `NO ACTION` default fired any time an officer tried to self-delete after having attested another member's waiver. Repro: officer attests member B, officer signs in, clicks Delete on `/account/security` → 500 + toast.

**Migration `0018_waiver_attestedby_set_null.sql`** drops `NOT NULL` on `attested_by` and adds `ON DELETE SET NULL` to both `attested_by` and `revoked_by` — same pattern `announcements.created_by` already uses. Audit history survives the officer's deletion; only the officer's identity on the row is cleared.

**Code follow-on:**
- `WaiverAttestationSummary.attestedByUserId/Email` widened to nullable.
- Internals switched from `innerJoin` to `leftJoin` on the attestor side so `attested_by = null` rows stay in the result set instead of being silently dropped.
- `/account/waiver` renders `(deleted user)` via an extended nullish-coalesce when both `attestedByPreferredName` and `attestedByEmail` are null.
- Export bundle's `waiverAttestations[].attestedBy` also nullable in the public type.

**Two regression tests** in `delete-my-account.test.ts`:
- Officer self-deletes after attesting another member → succeeds; row survives with `attested_by = null`.
- Officer self-deletes after revoking another's attestation → succeeds; revocation reason + timestamp survive, `revoked_by` null.

## Closes #24 — Export filename header-injection vector

The handler used to interpolate `payload.user?.email` straight into `Content-Disposition` with only `"` stripped. An email containing `;`, `=`, or CR/LF could in principle have manipulated the header. zod's `z.email()` rejects those today, but treating the email as untrusted at the header boundary is the right discipline.

- New `apps/web/src/lib/sanitize-filename.ts` — whitelist `[A-Za-z0-9._-]`, replace everything else with `_`.
- Route handler at `/api/account/export` imports the helper for the email segment.
- 6 unit tests covering: passthrough, `@` replacement, `;filename=evil`, CRLF, `=`, path separators, unicode, control bytes, empty input.

## Test plan

- [x] `pnpm --filter ucmc-web typecheck` — clean
- [x] `pnpm --filter ucmc-web test` — 240 passing (8 new)
- [x] `pnpm --filter ucmc-web lint` — 0 errors
- [x] `pnpm --filter ucmc-web build` — succeeds
- [x] Local D1: `0018_waiver_attestedby_set_null.sql` applies cleanly
- [ ] Manual smoke: assign yourself the seeded `treasurer` role, attest another approved member's waiver from `/members/waivers`, then go to `/account/security` and delete your account — should succeed with no FK error; the other member's attestation history page renders "(deleted user)" for the attestor.
- [ ] Manual smoke: download the export, verify the filename contains underscores in place of the `@` from your email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)