### PR TITLE
feat(ucmc-web): daily retention cron + R2 orphan GC

### DIFF
--- a/apps/web/drizzle/migrations/0019_user_rejected_deactivated_timestamps.sql
+++ b/apps/web/drizzle/migrations/0019_user_rejected_deactivated_timestamps.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `users` ADD `rejected_at` integer;--> statement-breakpoint
+ALTER TABLE `users` ADD `deactivated_at` integer;

--- a/apps/web/drizzle/migrations/meta/0019_snapshot.json
+++ b/apps/web/drizzle/migrations/meta/0019_snapshot.json
@@ -1,0 +1,1168 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a4fa313f-e0ea-43e4-8885-0d36aa0e5fb3",
+  "prevId": "6389dbf9-1537-4567-a1c7-add410e188d2",
+  "tables": {
+    "announcements": {
+      "name": "announcements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "announcements_published_at_idx": {
+          "name": "announcements_published_at_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "announcements_created_by_users_id_fk": {
+          "name": "announcements_created_by_users_id_fk",
+          "tableFrom": "announcements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "emergency_contacts": {
+      "name": "emergency_contacts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "emergency_contacts_user_id_users_id_fk": {
+          "name": "emergency_contacts_user_id_users_id_fk",
+          "tableFrom": "emergency_contacts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "landing_activities": {
+      "name": "landing_activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blurb": {
+          "name": "blurb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "landing_activities_sort_idx": {
+          "name": "landing_activities_sort_idx",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "landing_faq_items": {
+      "name": "landing_faq_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "landing_faq_items_sort_idx": {
+          "name": "landing_faq_items_sort_idx",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "landing_hero_slides": {
+      "name": "landing_hero_slides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "landing_hero_slides_sort_idx": {
+          "name": "landing_hero_slides_sort_idx",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "landing_settings": {
+      "name": "landing_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "landing_settings_updated_by_users_id_fk": {
+          "name": "landing_settings_updated_by_users_id_fk",
+          "tableFrom": "landing_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_links": {
+      "name": "magic_links",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey_credentials": {
+      "name": "passkey_credentials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkey_credential_id_unique": {
+          "name": "passkey_credential_id_unique",
+          "columns": [
+            "credential_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "passkey_credentials_user_id_users_id_fk": {
+          "name": "passkey_credentials_user_id_users_id_fk",
+          "tableFrom": "passkey_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "permissions": {
+      "name": "permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "permissions_name_unique": {
+          "name": "permissions_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "profiles": {
+      "name": "profiles",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preferred_name": {
+          "name": "preferred_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uc_affiliation": {
+          "name": "uc_affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_key": {
+          "name": "avatar_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policies_acknowledged_at": {
+          "name": "policies_acknowledged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policies_version": {
+          "name": "policies_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_user_id_users_id_fk": {
+          "name": "profiles_user_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "role_permissions": {
+      "name": "role_permissions",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_id_pk": {
+          "columns": [
+            "role_id",
+            "permission_id"
+          ],
+          "name": "role_permissions_role_id_permission_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "roles": {
+      "name": "roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_roles": {
+      "name": "user_roles",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "columns": [
+            "user_id",
+            "role_id"
+          ],
+          "name": "user_roles_user_id_role_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_read_announcements_at": {
+          "name": "last_read_announcements_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_public_id_unique": {
+          "name": "users_public_id_unique",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "waiver_attestations": {
+      "name": "waiver_attestations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attested_at": {
+          "name": "attested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "attested_by": {
+          "name": "attested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "waiver_attestations_user_cycle": {
+          "name": "waiver_attestations_user_cycle",
+          "columns": [
+            "user_id",
+            "cycle"
+          ],
+          "isUnique": false
+        },
+        "waiver_attestations_cycle_version_revoked": {
+          "name": "waiver_attestations_cycle_version_revoked",
+          "columns": [
+            "cycle",
+            "version",
+            "revoked_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "waiver_attestations_user_id_users_id_fk": {
+          "name": "waiver_attestations_user_id_users_id_fk",
+          "tableFrom": "waiver_attestations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "waiver_attestations_attested_by_users_id_fk": {
+          "name": "waiver_attestations_attested_by_users_id_fk",
+          "tableFrom": "waiver_attestations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "attested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "waiver_attestations_revoked_by_users_id_fk": {
+          "name": "waiver_attestations_revoked_by_users_id_fk",
+          "tableFrom": "waiver_attestations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/web/drizzle/migrations/meta/_journal.json
+++ b/apps/web/drizzle/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1777774270043,
       "tag": "0018_waiver_attestedby_set_null",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1777777804644,
+      "tag": "0019_user_rejected_deactivated_timestamps",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/drizzle/schema.ts
+++ b/apps/web/drizzle/schema.ts
@@ -43,6 +43,14 @@ export const users = sqliteTable(
       .default(sql`(unixepoch() * 1000)`),
     approvedAt: timestamp("approved_at"),
     approvedBy: text("approved_by"),
+    // Set when an approver clicks Reject. Drives the retention cron's
+    // 30-day rejected-registration purge. NULL on rows that pre-date
+    // this column — the cron skips NULL so historical rejections never
+    // auto-purge retroactively; an admin can clean those up by hand.
+    rejectedAt: timestamp("rejected_at"),
+    // Set when a member is deactivated. Drives the 12-month
+    // deactivated-account purge. Same NULL-skip rule.
+    deactivatedAt: timestamp("deactivated_at"),
     lastReadAnnouncementsAt: timestamp("last_read_announcements_at"),
   },
   (t) => [uniqueIndex("users_email_unique").on(t.email)],

--- a/apps/web/src/config/legal.ts
+++ b/apps/web/src/config/legal.ts
@@ -285,9 +285,10 @@ export const PRIVACY_BODY: readonly LegalSection[] = [
     heading: "Retention",
     bullets: [
       "Active member data is retained as long as your account is active.",
-      "Pending registrations not approved within 30 days may be purged.",
-      "Deactivated accounts may be purged after 12 months of inactivity.",
-      "Waiver attestation records (metadata only — not the paper waiver) may be retained for up to 7 years post-cycle for liability documentation.",
+      "Rejected registrations are deleted 30 days after rejection. (If you re-register and are approved before then, the original row is reset and the clock starts over.)",
+      "Deactivated accounts are deleted 12 months after deactivation. Reactivation before then resets the clock.",
+      "Waiver attestation records (metadata only — not the paper waiver) are retained while still in effect; revoked attestations are deleted 90 days after revocation.",
+      "Avatar images and landing-page images stored in object storage are reconciled against the database daily; any object no longer referenced by an active row is deleted.",
       "You can delete your account immediately at any time via the controls on /account; this also removes your avatar from R2 and signs you out everywhere.",
     ],
   },

--- a/apps/web/src/features/members/server/member-actions.server.ts
+++ b/apps/web/src/features/members/server/member-actions.server.ts
@@ -490,7 +490,7 @@ export async function rejectRegistrationsAction(
 
   await getDb()
     .update(schema.users)
-    .set({ status: "rejected" })
+    .set({ status: "rejected", rejectedAt: new Date() })
     .where(inArray(schema.users.id, userIds));
 
   // TODO: send rejection notification emails (per-user).
@@ -514,7 +514,7 @@ export async function deactivateMembersAction(
   // Only deactivate users that are currently approved.
   await db
     .update(schema.users)
-    .set({ status: "deactivated" })
+    .set({ status: "deactivated", deactivatedAt: new Date() })
     .where(
       and(
         inArray(schema.users.id, userIds),
@@ -538,13 +538,16 @@ export async function reactivateMembersAction(
   const approver = await requireMembersManager();
   const db = getDb();
 
-  // Only reactivate users that are currently deactivated.
+  // Only reactivate users that are currently deactivated. Clear
+  // `deactivatedAt` so a future deactivation gets a fresh retention
+  // clock rather than counting from the *first* deactivation.
   await db
     .update(schema.users)
     .set({
       status: "approved",
       approvedAt: new Date(),
       approvedBy: approver.userId,
+      deactivatedAt: null,
     })
     .where(
       and(
@@ -569,10 +572,12 @@ export async function unrejectMembersAction(
 ): Promise<{ ok: true }> {
   await requireMembersManager();
 
-  // Move rejected users back to pending so they re-enter the approval queue.
+  // Move rejected users back to pending so they re-enter the approval
+  // queue. Clear `rejectedAt` so a future rejection gets a fresh
+  // retention clock rather than counting from the *first* rejection.
   await getDb()
     .update(schema.users)
-    .set({ status: "pending" })
+    .set({ status: "pending", rejectedAt: null })
     .where(
       and(
         inArray(schema.users.id, userIds),

--- a/apps/web/src/server-entry.ts
+++ b/apps/web/src/server-entry.ts
@@ -1,0 +1,37 @@
+/**
+ * Cloudflare Worker entry point. Wraps TanStack Start's default server
+ * entry (which provides `fetch`) with a `scheduled` handler so cron
+ * triggers declared in `wrangler.jsonc` reach our retention sweeps.
+ *
+ * `wrangler.jsonc` `main` points here instead of straight at the
+ * TanStack package; the only meaningful difference is the additional
+ * scheduled export.
+ */
+import startEntry from "@tanstack/react-start/server-entry";
+
+// `ExportedHandler<WorkerEnv>` from @cloudflare/workers-types declares
+// `fetch` with a Request shape that doesn't match the one TanStack
+// Start's handler expects (the latter omits a few standard Fetch
+// properties). Spreading the Start handler and adding a `scheduled`
+// key gives us the right runtime shape; we annotate `scheduled`
+// individually so the cron contract is type-checked without fighting
+// TypeScript over the fetch signature.
+export default {
+  ...startEntry,
+
+  async scheduled(_event, _env, ctx) {
+    // Server-only import. Lazy-loaded so the worker entry's static
+    // module graph stays small and matches the dynamic-import pattern
+    // used by the server-fn shells.
+    const { runRetentionSweeps } =
+      await import("./server/cron/retention.server");
+    ctx.waitUntil(runRetentionSweeps());
+  },
+} satisfies {
+  fetch: typeof startEntry.fetch;
+  scheduled: (
+    event: ScheduledEvent,
+    env: unknown,
+    ctx: ExecutionContext,
+  ) => Promise<void>;
+};

--- a/apps/web/src/server/cron/__tests__/retention.test.ts
+++ b/apps/web/src/server/cron/__tests__/retention.test.ts
@@ -228,6 +228,10 @@ describe("sweepRevokedWaiverAttestations", () => {
   });
 });
 
+// Tests pass `minOrphanAgeMs: 0` so freshly-`put`-ed Miniflare objects
+// (whose `uploaded` timestamp is the test's wall clock) aren't skipped
+// by the production 5-minute upload-race guard. The guard behavior
+// itself has a dedicated test at the bottom of this describe block.
 describe("sweepOrphanR2Keys", () => {
   it("deletes objects under avatars/ that aren't referenced by any profile", async () => {
     const userId = await seedUser({ status: "approved" });
@@ -246,7 +250,7 @@ describe("sweepOrphanR2Keys", () => {
       avatarKey: liveKey,
     });
 
-    const count = await sweepOrphanR2Keys();
+    const count = await sweepOrphanR2Keys(NOW, 0);
 
     expect(count).toBe(1);
     expect(await bucket.head(liveKey)).not.toBeNull();
@@ -269,7 +273,7 @@ describe("sweepOrphanR2Keys", () => {
         sortOrder: 0,
       });
 
-    const count = await sweepOrphanR2Keys();
+    const count = await sweepOrphanR2Keys(NOW, 0);
 
     expect(count).toBe(1);
     expect(await bucket.head(liveKey)).not.toBeNull();
@@ -292,7 +296,7 @@ describe("sweepOrphanR2Keys", () => {
         { key: "meeting.image_key", valueJson: JSON.stringify(meetingKey) },
       ]);
 
-    const count = await sweepOrphanR2Keys();
+    const count = await sweepOrphanR2Keys(NOW, 0);
 
     expect(count).toBe(1);
     expect(await bucket.head(aboutKey)).not.toBeNull();
@@ -311,10 +315,27 @@ describe("sweepOrphanR2Keys", () => {
 
     // Should not throw — sweep continues, treating the malformed row as
     // "no live key found" and orphaning the bucket object.
-    const count = await sweepOrphanR2Keys();
+    const count = await sweepOrphanR2Keys(NOW, 0);
 
     expect(count).toBe(1);
     expect(await bucket.head(orphanKey)).toBeNull();
+  });
+
+  it("skips R2 objects newer than minOrphanAgeMs (PUT/UPDATE race guard)", async () => {
+    // Simulates a member upload caught mid-flight: R2 PUT has landed
+    // but the corresponding profile.avatar_key UPDATE hasn't yet, so
+    // the cron sees the key as unreferenced. The age guard must keep
+    // it for the next sweep instead of clipping a real upload.
+    const orphanKey = "avatars/inflight/upload.webp";
+    const bucket = getBucket();
+    await bucket.put(orphanKey, new Uint8Array([7]));
+
+    // 5-minute guard, run "now" — the just-uploaded object is well
+    // inside the skip window.
+    const count = await sweepOrphanR2Keys(new Date(), 5 * 60 * 1000);
+
+    expect(count).toBe(0);
+    expect(await bucket.head(orphanKey)).not.toBeNull();
   });
 });
 
@@ -336,7 +357,10 @@ describe("runRetentionSweeps", () => {
     });
     await getBucket().put("avatars/orphan/x.webp", new Uint8Array([0]));
 
-    const counts = await runRetentionSweeps(NOW);
+    // minOrphanAgeMs: 0 — bypass the orphan-GC upload-race guard so
+    // the just-`put`-ed fixture object isn't held back; the guard
+    // itself is exercised in `sweepOrphanR2Keys` tests.
+    const counts = await runRetentionSweeps(NOW, { minOrphanAgeMs: 0 });
 
     expect(counts).toEqual({
       rejectedRegistrations: 1,

--- a/apps/web/src/server/cron/__tests__/retention.test.ts
+++ b/apps/web/src/server/cron/__tests__/retention.test.ts
@@ -1,0 +1,360 @@
+import { eq } from "drizzle-orm";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getDb, schema } from "#/server/db";
+import { getBucket } from "#/server/r2";
+import {
+  runRetentionSweeps,
+  sweepDeactivatedAccounts,
+  sweepOrphanR2Keys,
+  sweepRejectedRegistrations,
+  sweepRevokedWaiverAttestations,
+} from "#/server/cron/retention.server";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = new Date("2026-06-01T00:00:00Z");
+
+// Random suffix for ID uniqueness across tests sharing the worker DB.
+function uid(prefix: string): string {
+  return `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+async function seedUser(opts: {
+  status: schema.UserStatus;
+  rejectedAt?: Date | null;
+  deactivatedAt?: Date | null;
+}): Promise<string> {
+  const id = uid("u");
+  await getDb()
+    .insert(schema.users)
+    .values({
+      id,
+      publicId: id,
+      email: `${id}@example.com`,
+      status: opts.status,
+      rejectedAt: opts.rejectedAt ?? null,
+      deactivatedAt: opts.deactivatedAt ?? null,
+    });
+  return id;
+}
+
+async function seedWaiverAttestation(opts: {
+  userId: string;
+  revokedAt: Date | null;
+}): Promise<string> {
+  const id = uid("w");
+  await getDb()
+    .insert(schema.waiverAttestations)
+    .values({
+      id,
+      userId: opts.userId,
+      cycle: "2025-26",
+      version: "v1",
+      attestedAt: new Date("2025-09-01T00:00:00Z"),
+      attestedBy: null,
+      revokedAt: opts.revokedAt,
+    });
+  return id;
+}
+
+afterEach(async () => {
+  // Each suite seeds its own rows; clean slate avoids interactions
+  // between tests that both delete from `users`.
+  const db = getDb();
+  await db.delete(schema.waiverAttestations);
+  await db.delete(schema.profiles);
+  await db.delete(schema.landingHeroSlides);
+  await db.delete(schema.landingActivities);
+  await db.delete(schema.landingSettings);
+  await db.delete(schema.users);
+
+  // R2 cleanup — list everything and delete. Bounded by what tests
+  // put in.
+  const bucket = getBucket();
+  for (const prefix of ["avatars/", "landing/"] as const) {
+    let cursor: string | undefined;
+    let truncated = true;
+    while (truncated) {
+      const page = await bucket.list({ prefix, cursor, limit: 1000 });
+      if (page.objects.length > 0) {
+        await bucket.delete(page.objects.map((o) => o.key));
+      }
+      truncated = page.truncated;
+      cursor = page.truncated ? page.cursor : undefined;
+    }
+  }
+});
+
+describe("sweepRejectedRegistrations", () => {
+  it("deletes rows older than 30 days", async () => {
+    const id = await seedUser({
+      status: "rejected",
+      rejectedAt: new Date(NOW.getTime() - 31 * DAY_MS),
+    });
+
+    const count = await sweepRejectedRegistrations(NOW);
+
+    expect(count).toBe(1);
+    const remaining = await getDb()
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.id, id));
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("leaves rows younger than 30 days", async () => {
+    const id = await seedUser({
+      status: "rejected",
+      rejectedAt: new Date(NOW.getTime() - 29 * DAY_MS),
+    });
+
+    const count = await sweepRejectedRegistrations(NOW);
+
+    expect(count).toBe(0);
+    const remaining = await getDb()
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.id, id));
+    expect(remaining).toHaveLength(1);
+  });
+
+  it("skips NULL rejected_at (pre-migration rows)", async () => {
+    const id = await seedUser({ status: "rejected", rejectedAt: null });
+
+    const count = await sweepRejectedRegistrations(NOW);
+
+    expect(count).toBe(0);
+    const remaining = await getDb()
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.id, id));
+    expect(remaining).toHaveLength(1);
+  });
+
+  it("ignores users with other statuses even if rejected_at is set", async () => {
+    // Defensive: rejectedAt should be cleared on un-reject, but if a
+    // bug ever leaves it stamped on a non-rejected row, the cron must
+    // not delete the user.
+    const id = await seedUser({
+      status: "approved",
+      rejectedAt: new Date(NOW.getTime() - 100 * DAY_MS),
+    });
+
+    const count = await sweepRejectedRegistrations(NOW);
+
+    expect(count).toBe(0);
+    const remaining = await getDb()
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.id, id));
+    expect(remaining).toHaveLength(1);
+  });
+});
+
+describe("sweepDeactivatedAccounts", () => {
+  it("deletes rows older than 365 days", async () => {
+    const id = await seedUser({
+      status: "deactivated",
+      deactivatedAt: new Date(NOW.getTime() - 366 * DAY_MS),
+    });
+
+    const count = await sweepDeactivatedAccounts(NOW);
+
+    expect(count).toBe(1);
+    const remaining = await getDb()
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.id, id));
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("leaves rows younger than 365 days", async () => {
+    await seedUser({
+      status: "deactivated",
+      deactivatedAt: new Date(NOW.getTime() - 364 * DAY_MS),
+    });
+
+    const count = await sweepDeactivatedAccounts(NOW);
+
+    expect(count).toBe(0);
+  });
+
+  it("skips NULL deactivated_at", async () => {
+    await seedUser({ status: "deactivated", deactivatedAt: null });
+
+    const count = await sweepDeactivatedAccounts(NOW);
+
+    expect(count).toBe(0);
+  });
+});
+
+describe("sweepRevokedWaiverAttestations", () => {
+  it("deletes rows revoked more than 90 days ago", async () => {
+    const userId = await seedUser({ status: "approved" });
+    const attId = await seedWaiverAttestation({
+      userId,
+      revokedAt: new Date(NOW.getTime() - 91 * DAY_MS),
+    });
+
+    const count = await sweepRevokedWaiverAttestations(NOW);
+
+    expect(count).toBe(1);
+    const remaining = await getDb()
+      .select()
+      .from(schema.waiverAttestations)
+      .where(eq(schema.waiverAttestations.id, attId));
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("leaves non-revoked attestations alone", async () => {
+    const userId = await seedUser({ status: "approved" });
+    await seedWaiverAttestation({ userId, revokedAt: null });
+
+    const count = await sweepRevokedWaiverAttestations(NOW);
+
+    expect(count).toBe(0);
+  });
+
+  it("leaves recently-revoked attestations alone", async () => {
+    const userId = await seedUser({ status: "approved" });
+    await seedWaiverAttestation({
+      userId,
+      revokedAt: new Date(NOW.getTime() - 89 * DAY_MS),
+    });
+
+    const count = await sweepRevokedWaiverAttestations(NOW);
+
+    expect(count).toBe(0);
+  });
+});
+
+describe("sweepOrphanR2Keys", () => {
+  it("deletes objects under avatars/ that aren't referenced by any profile", async () => {
+    const userId = await seedUser({ status: "approved" });
+    const liveKey = `avatars/${userId}/live123.webp`;
+    const orphanKey = `avatars/${userId}/orphan456.webp`;
+    const bucket = getBucket();
+    await bucket.put(liveKey, new Uint8Array([1, 2, 3]));
+    await bucket.put(orphanKey, new Uint8Array([4, 5, 6]));
+
+    await getDb().insert(schema.profiles).values({
+      userId,
+      fullName: "Test User",
+      preferredName: "Test",
+      phone: "+15555555555",
+      ucAffiliation: "student",
+      avatarKey: liveKey,
+    });
+
+    const count = await sweepOrphanR2Keys();
+
+    expect(count).toBe(1);
+    expect(await bucket.head(liveKey)).not.toBeNull();
+    expect(await bucket.head(orphanKey)).toBeNull();
+  });
+
+  it("treats landing hero slide image keys as live", async () => {
+    const liveKey = "landing/hero/live789.webp";
+    const orphanKey = "landing/hero/orphanabc.webp";
+    const bucket = getBucket();
+    await bucket.put(liveKey, new Uint8Array([1]));
+    await bucket.put(orphanKey, new Uint8Array([2]));
+
+    await getDb()
+      .insert(schema.landingHeroSlides)
+      .values({
+        id: uid("hs"),
+        imageKey: liveKey,
+        alt: "live slide",
+        sortOrder: 0,
+      });
+
+    const count = await sweepOrphanR2Keys();
+
+    expect(count).toBe(1);
+    expect(await bucket.head(liveKey)).not.toBeNull();
+    expect(await bucket.head(orphanKey)).toBeNull();
+  });
+
+  it("parses about.image_key / meeting.image_key from landing_settings JSON", async () => {
+    const aboutKey = "landing/about/aboutdef.webp";
+    const meetingKey = "landing/meeting/meetghi.webp";
+    const orphanKey = "landing/about/orphanjkl.webp";
+    const bucket = getBucket();
+    await bucket.put(aboutKey, new Uint8Array([1]));
+    await bucket.put(meetingKey, new Uint8Array([2]));
+    await bucket.put(orphanKey, new Uint8Array([3]));
+
+    await getDb()
+      .insert(schema.landingSettings)
+      .values([
+        { key: "about.image_key", valueJson: JSON.stringify(aboutKey) },
+        { key: "meeting.image_key", valueJson: JSON.stringify(meetingKey) },
+      ]);
+
+    const count = await sweepOrphanR2Keys();
+
+    expect(count).toBe(1);
+    expect(await bucket.head(aboutKey)).not.toBeNull();
+    expect(await bucket.head(meetingKey)).not.toBeNull();
+    expect(await bucket.head(orphanKey)).toBeNull();
+  });
+
+  it("tolerates malformed JSON in landing_settings without failing the sweep", async () => {
+    const orphanKey = "landing/about/orphan.webp";
+    const bucket = getBucket();
+    await bucket.put(orphanKey, new Uint8Array([1]));
+
+    await getDb()
+      .insert(schema.landingSettings)
+      .values({ key: "about.image_key", valueJson: "{not valid json" });
+
+    // Should not throw — sweep continues, treating the malformed row as
+    // "no live key found" and orphaning the bucket object.
+    const count = await sweepOrphanR2Keys();
+
+    expect(count).toBe(1);
+    expect(await bucket.head(orphanKey)).toBeNull();
+  });
+});
+
+describe("runRetentionSweeps", () => {
+  it("aggregates counts across all four sweeps", async () => {
+    // Seed one row that each sweep will pick up.
+    const rejectedId = await seedUser({
+      status: "rejected",
+      rejectedAt: new Date(NOW.getTime() - 31 * DAY_MS),
+    });
+    const deactivatedId = await seedUser({
+      status: "deactivated",
+      deactivatedAt: new Date(NOW.getTime() - 366 * DAY_MS),
+    });
+    const userForWaiver = await seedUser({ status: "approved" });
+    await seedWaiverAttestation({
+      userId: userForWaiver,
+      revokedAt: new Date(NOW.getTime() - 91 * DAY_MS),
+    });
+    await getBucket().put("avatars/orphan/x.webp", new Uint8Array([0]));
+
+    const counts = await runRetentionSweeps(NOW);
+
+    expect(counts).toEqual({
+      rejectedRegistrations: 1,
+      deactivatedAccounts: 1,
+      revokedWaivers: 1,
+      orphanR2Keys: 1,
+    });
+
+    // Verify side effects landed.
+    const remaining = await getDb()
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.id, rejectedId));
+    expect(remaining).toHaveLength(0);
+    const remainingDeact = await getDb()
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.id, deactivatedId));
+    expect(remainingDeact).toHaveLength(0);
+  });
+});

--- a/apps/web/src/server/cron/retention.server.ts
+++ b/apps/web/src/server/cron/retention.server.ts
@@ -31,6 +31,19 @@ const REJECTED_RETENTION_DAYS = 30;
 const DEACTIVATED_RETENTION_DAYS = 365;
 const REVOKED_WAIVER_RETENTION_DAYS = 90;
 
+// Skip orphan-GC for any R2 object uploaded in the last 5 minutes.
+// Avatars are uploaded in two steps (PUT R2, then UPDATE D1); a cron
+// pass that snapshots both the bucket and the DB while a member's
+// upload is in flight could otherwise treat the freshly-PUT R2 key
+// as orphan and clip it. 5 minutes is many orders of magnitude longer
+// than any plausible PUT→UPDATE gap, so a real upload is never within
+// the skip window. Any genuine orphan younger than 5 minutes simply
+// gets picked up on the next day's sweep — never lost, just delayed.
+const DEFAULT_MIN_ORPHAN_AGE_MS = 5 * 60 * 1000;
+
+// R2's batch-delete API accepts up to 1000 keys per call.
+const R2_BATCH_DELETE_LIMIT = 1000;
+
 // R2 prefixes the cron is allowed to GC. Any object outside these
 // prefixes (e.g. a future `static/` bucket layout) is left alone.
 const GC_PREFIXES = ["avatars/", "landing/"] as const;
@@ -96,37 +109,78 @@ export async function sweepRevokedWaiverAttestations(
 }
 
 /**
- * Walks every R2 object under the GC prefixes, builds the set of keys
- * still referenced by D1, and deletes anything outside that set.
+ * Snapshots the bucket and the DB live-key set, then deletes any R2
+ * object that's (a) not referenced by any DB row AND (b) older than
+ * `minOrphanAgeMs`.
  *
- * Pagination via `cursor` so we don't materialize the entire bucket
- * in memory; the live-keys set IS held in memory but it's a cap of
- * (member count + landing slides + activities + ~2 settings rows),
- * which is bounded by how many users the club has ever had.
+ * **Race-safety design.** Avatar / landing-image uploads do PUT R2
+ * first, then UPDATE D1 — there's a sub-second window where the new
+ * R2 key exists but no DB row references it yet. A naive "DB-then-R2"
+ * cron could mistake an in-flight upload for an orphan. Two
+ * mitigations together make this impossible:
+ *
+ *   1. **R2-first ordering.** List the bucket fully, *then* read the
+ *      DB live set. A new key uploaded after the R2 list isn't in our
+ *      snapshot, so we never consider it. A key uploaded before the
+ *      list with its UPDATE happening before the DB read shows up in
+ *      both — kept correctly.
+ *
+ *   2. **Age guard.** Skip any object whose `uploaded` timestamp is
+ *      within the last `minOrphanAgeMs`. Even if the cron runs slow,
+ *      the PUT-to-UPDATE gap (sub-second in practice) can never
+ *      exceed five minutes.
+ *
+ * Memory: collects all R2 keys + the DB live set in memory. Bounded
+ * by club membership + landing assets — a few hundred KB at worst.
  */
-export async function sweepOrphanR2Keys(): Promise<number> {
-  const liveKeys = await loadReferencedR2Keys();
+export async function sweepOrphanR2Keys(
+  now: Date = new Date(),
+  minOrphanAgeMs: number = DEFAULT_MIN_ORPHAN_AGE_MS,
+): Promise<number> {
   const bucket = getBucket();
 
-  let deleted = 0;
+  // 1. List every key under the GC prefixes BEFORE reading the DB.
+  const r2Objects: R2Object[] = [];
   for (const prefix of GC_PREFIXES) {
     let cursor: string | undefined;
     let truncated = true;
     while (truncated) {
-      const page = await bucket.list({ prefix, cursor, limit: 1000 });
-      const orphans = page.objects
-        .map((o) => o.key)
-        .filter((key) => !liveKeys.has(key));
-
-      if (orphans.length > 0) {
-        // R2's delete() accepts a string array up to 1000 keys.
-        await bucket.delete(orphans);
-        deleted += orphans.length;
-      }
-
+      const page = await bucket.list({
+        prefix,
+        cursor,
+        limit: R2_BATCH_DELETE_LIMIT,
+      });
+      r2Objects.push(...page.objects);
       truncated = page.truncated;
       cursor = page.truncated ? page.cursor : undefined;
     }
+  }
+
+  // 2. Read the DB live set after R2 listing, so any key visible in
+  //    R2 has either also landed in DB (no-op) or is too new for the
+  //    age guard (skipped).
+  const liveKeys = await loadReferencedR2Keys();
+  const ageCutoffMs = now.getTime() - minOrphanAgeMs;
+
+  const orphans: string[] = [];
+  for (const object of r2Objects) {
+    if (liveKeys.has(object.key)) {
+      continue;
+    }
+    if (object.uploaded.getTime() >= ageCutoffMs) {
+      // Skip — within the upload-race window. Next sweep picks it up
+      // if it's still unreferenced then.
+      continue;
+    }
+    orphans.push(object.key);
+  }
+
+  // 3. Batch-delete in chunks of 1000 (R2's API limit).
+  let deleted = 0;
+  for (let i = 0; i < orphans.length; i += R2_BATCH_DELETE_LIMIT) {
+    const batch = orphans.slice(i, i + R2_BATCH_DELETE_LIMIT);
+    await bucket.delete(batch);
+    deleted += batch.length;
   }
   return deleted;
 }
@@ -187,8 +241,19 @@ async function loadReferencedR2Keys(): Promise<Set<string>> {
   return live;
 }
 
+export interface RunRetentionSweepsOptions {
+  /**
+   * Override for the orphan-GC age guard (default: 5 minutes). The
+   * scheduled handler in production never sets this — only tests
+   * pass `0` so freshly-uploaded fixture objects don't fall into the
+   * upload-race skip window.
+   */
+  minOrphanAgeMs?: number;
+}
+
 export async function runRetentionSweeps(
   now: Date = new Date(),
+  options: RunRetentionSweepsOptions = {},
 ): Promise<SweepCounts> {
   const counts: SweepCounts = {
     rejectedRegistrations: 0,
@@ -210,7 +275,10 @@ export async function runRetentionSweeps(
     },
     { name: "deactivatedAccounts", run: () => sweepDeactivatedAccounts(now) },
     { name: "revokedWaivers", run: () => sweepRevokedWaiverAttestations(now) },
-    { name: "orphanR2Keys", run: () => sweepOrphanR2Keys() },
+    {
+      name: "orphanR2Keys",
+      run: () => sweepOrphanR2Keys(now, options.minOrphanAgeMs),
+    },
   ];
 
   for (const sweep of sweeps) {

--- a/apps/web/src/server/cron/retention.server.ts
+++ b/apps/web/src/server/cron/retention.server.ts
@@ -1,0 +1,233 @@
+/**
+ * Daily retention sweeps run by the worker's `scheduled` handler.
+ * Closes the four promises the privacy notice makes:
+ *
+ *   - rejected registrations purged 30 days after rejection
+ *   - deactivated accounts purged 12 months after deactivation
+ *   - revoked waiver attestations dropped 90 days after revocation
+ *   - R2 objects (avatars + landing images) not referenced by any DB
+ *     row are deleted from the bucket
+ *
+ * NULL-skip discipline: rows whose timestamp column is NULL are
+ * deliberately ignored. `rejected_at` / `deactivated_at` were added in
+ * migration 0019, so historical rejections / deactivations don't have
+ * a known transition date — we don't auto-purge them retroactively.
+ * An admin can clean those up manually, or future re-rejections will
+ * stamp the column and the next sweep will pick them up.
+ *
+ * All four sweeps are independent — failure of one (e.g. R2 down)
+ * doesn't prevent the others from running. The orchestrator
+ * `runRetentionSweeps()` runs them sequentially and aggregates a
+ * structured result that the scheduled handler logs.
+ */
+import { and, eq, inArray, isNotNull, lt } from "drizzle-orm";
+
+import { getDb, schema } from "#/server/db";
+import { getBucket } from "#/server/r2";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const REJECTED_RETENTION_DAYS = 30;
+const DEACTIVATED_RETENTION_DAYS = 365;
+const REVOKED_WAIVER_RETENTION_DAYS = 90;
+
+// R2 prefixes the cron is allowed to GC. Any object outside these
+// prefixes (e.g. a future `static/` bucket layout) is left alone.
+const GC_PREFIXES = ["avatars/", "landing/"] as const;
+
+// Settings keys whose JSON value is an R2 image key. `landingSettings`
+// is a singleton key/value store; the about + meeting sections store
+// their image as `value_json: JSON.stringify("landing/about/abc.webp")`.
+const SETTINGS_IMAGE_KEYS = ["about.image_key", "meeting.image_key"];
+
+export interface SweepCounts {
+  rejectedRegistrations: number;
+  deactivatedAccounts: number;
+  revokedWaivers: number;
+  orphanR2Keys: number;
+}
+
+export async function sweepRejectedRegistrations(now: Date): Promise<number> {
+  const cutoff = new Date(now.getTime() - REJECTED_RETENTION_DAYS * DAY_MS);
+  const deleted = await getDb()
+    .delete(schema.users)
+    .where(
+      and(
+        eq(schema.users.status, "rejected"),
+        isNotNull(schema.users.rejectedAt),
+        lt(schema.users.rejectedAt, cutoff),
+      ),
+    )
+    .returning({ id: schema.users.id });
+  return deleted.length;
+}
+
+export async function sweepDeactivatedAccounts(now: Date): Promise<number> {
+  const cutoff = new Date(now.getTime() - DEACTIVATED_RETENTION_DAYS * DAY_MS);
+  const deleted = await getDb()
+    .delete(schema.users)
+    .where(
+      and(
+        eq(schema.users.status, "deactivated"),
+        isNotNull(schema.users.deactivatedAt),
+        lt(schema.users.deactivatedAt, cutoff),
+      ),
+    )
+    .returning({ id: schema.users.id });
+  return deleted.length;
+}
+
+export async function sweepRevokedWaiverAttestations(
+  now: Date,
+): Promise<number> {
+  const cutoff = new Date(
+    now.getTime() - REVOKED_WAIVER_RETENTION_DAYS * DAY_MS,
+  );
+  const deleted = await getDb()
+    .delete(schema.waiverAttestations)
+    .where(
+      and(
+        isNotNull(schema.waiverAttestations.revokedAt),
+        lt(schema.waiverAttestations.revokedAt, cutoff),
+      ),
+    )
+    .returning({ id: schema.waiverAttestations.id });
+  return deleted.length;
+}
+
+/**
+ * Walks every R2 object under the GC prefixes, builds the set of keys
+ * still referenced by D1, and deletes anything outside that set.
+ *
+ * Pagination via `cursor` so we don't materialize the entire bucket
+ * in memory; the live-keys set IS held in memory but it's a cap of
+ * (member count + landing slides + activities + ~2 settings rows),
+ * which is bounded by how many users the club has ever had.
+ */
+export async function sweepOrphanR2Keys(): Promise<number> {
+  const liveKeys = await loadReferencedR2Keys();
+  const bucket = getBucket();
+
+  let deleted = 0;
+  for (const prefix of GC_PREFIXES) {
+    let cursor: string | undefined;
+    let truncated = true;
+    while (truncated) {
+      const page = await bucket.list({ prefix, cursor, limit: 1000 });
+      const orphans = page.objects
+        .map((o) => o.key)
+        .filter((key) => !liveKeys.has(key));
+
+      if (orphans.length > 0) {
+        // R2's delete() accepts a string array up to 1000 keys.
+        await bucket.delete(orphans);
+        deleted += orphans.length;
+      }
+
+      truncated = page.truncated;
+      cursor = page.truncated ? page.cursor : undefined;
+    }
+  }
+  return deleted;
+}
+
+async function loadReferencedR2Keys(): Promise<Set<string>> {
+  const db = getDb();
+  const live = new Set<string>();
+
+  const avatars = await db
+    .select({ key: schema.profiles.avatarKey })
+    .from(schema.profiles)
+    .where(isNotNull(schema.profiles.avatarKey));
+  for (const row of avatars) {
+    if (row.key) {
+      live.add(row.key);
+    }
+  }
+
+  const heroes = await db
+    .select({ key: schema.landingHeroSlides.imageKey })
+    .from(schema.landingHeroSlides);
+  for (const row of heroes) {
+    live.add(row.key);
+  }
+
+  const activities = await db
+    .select({ key: schema.landingActivities.imageKey })
+    .from(schema.landingActivities)
+    .where(isNotNull(schema.landingActivities.imageKey));
+  for (const row of activities) {
+    if (row.key) {
+      live.add(row.key);
+    }
+  }
+
+  const settings = await db
+    .select({
+      key: schema.landingSettings.key,
+      valueJson: schema.landingSettings.valueJson,
+    })
+    .from(schema.landingSettings)
+    .where(inArray(schema.landingSettings.key, SETTINGS_IMAGE_KEYS));
+  for (const row of settings) {
+    // valueJson is the JSON-encoded image key (`"landing/about/abc.webp"`)
+    // or the JSON-encoded null for "no image set". Tolerate both shapes
+    // and any malformed JSON (skip the row rather than fail the sweep —
+    // the orphan GC is best-effort).
+    try {
+      const parsed: unknown = JSON.parse(row.valueJson);
+      if (typeof parsed === "string" && parsed.length > 0) {
+        live.add(parsed);
+      }
+    } catch {
+      // Not valid JSON — leave as-is, the GC sweep skips this row.
+    }
+  }
+
+  return live;
+}
+
+export async function runRetentionSweeps(
+  now: Date = new Date(),
+): Promise<SweepCounts> {
+  const counts: SweepCounts = {
+    rejectedRegistrations: 0,
+    deactivatedAccounts: 0,
+    revokedWaivers: 0,
+    orphanR2Keys: 0,
+  };
+
+  // Each sweep is wrapped so an error in one (e.g. R2 outage) doesn't
+  // sink the others. Errors are logged with structured context for the
+  // Workers Logs panel.
+  const sweeps: Array<{
+    name: keyof SweepCounts;
+    run: () => Promise<number>;
+  }> = [
+    {
+      name: "rejectedRegistrations",
+      run: () => sweepRejectedRegistrations(now),
+    },
+    { name: "deactivatedAccounts", run: () => sweepDeactivatedAccounts(now) },
+    { name: "revokedWaivers", run: () => sweepRevokedWaiverAttestations(now) },
+    { name: "orphanR2Keys", run: () => sweepOrphanR2Keys() },
+  ];
+
+  for (const sweep of sweeps) {
+    try {
+      counts[sweep.name] = await sweep.run();
+    } catch (err) {
+      // Structured log goes to Workers Logs (Cloudflare dashboard,
+      // ~7d retention). The cron has no UI; logs are the only signal.
+      // eslint-disable-next-line no-console
+      console.error("retention.sweep_failed", {
+        sweep: sweep.name,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // eslint-disable-next-line no-console
+  console.log("retention.sweeps_complete", counts);
+  return counts;
+}

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -18,7 +18,19 @@
   "name": "ucmc-web-dev",
   "compatibility_date": "2025-09-02",
   "compatibility_flags": ["nodejs_compat"],
-  "main": "@tanstack/react-start/server-entry",
+  // Custom worker module that re-exports TanStack Start's `fetch`
+  // handler and adds a `scheduled` handler so cron triggers below
+  // reach the retention sweeps. See `src/server-entry.ts`.
+  "main": "src/server-entry.ts",
+  // Daily retention sweeps. 08:00 UTC = 03:00 EST / 04:00 EDT —
+  // overnight in the US Midwest, well outside any plausible
+  // member-traffic window. Daily rather than weekly so the
+  // privacy-page promises ("rejected after 30 days", etc.) never
+  // drift by more than a day. Same schedule for dev + prod; dev runs
+  // against an empty bucket most of the time, which is fine.
+  "triggers": {
+    "crons": ["0 8 * * *"],
+  },
   // Workers Logs: structured logs + invocation traces viewable in the
   // Cloudflare dashboard (~7 day retention) and streamable via `wrangler
   // tail`. `head_sampling_rate: 1` logs 100% of invocations — fine at our
@@ -100,6 +112,12 @@
       "observability": {
         "enabled": true,
         "head_sampling_rate": 1,
+      },
+      // Inherit retention-cron schedule from the top-level config.
+      // Cloudflare doesn't merge `triggers` from parent env, so this
+      // has to be repeated explicitly per env.
+      "triggers": {
+        "crons": ["0 8 * * *"],
       },
       "d1_databases": [
         {


### PR DESCRIPTION
## Summary

Closes the four retention promises on the privacy notice with a Cloudflare cron trigger that runs daily at 08:00 UTC (03:00 EST / 04:00 EDT — overnight in the US Midwest).

Roadmap: closes W-10 + I-2 from the compliance plan.

Two commits:

1. **`feat: stamp rejected_at / deactivated_at on user status transitions`** — Adds two nullable timestamps to `users` so the cron has something concrete to compare against. Reject/deactivate stamp them; un-reject/reactivate clear them so a re-rejection gets a fresh retention clock instead of counting from the *first* rejection.
2. **`feat: daily retention cron + R2 orphan GC`** — The actual sweeps + cron wiring + privacy copy correction.

## What it does

| Sweep | Trigger | Threshold |
| --- | --- | --- |
| Rejected registrations | `rejected_at < now - 30d` AND `status = 'rejected'` | 30 days |
| Deactivated accounts | `deactivated_at < now - 365d` AND `status = 'deactivated'` | 12 months |
| Revoked waiver attestations | `revoked_at < now - 90d` | 90 days |
| Orphan R2 keys | Object key not referenced by any of: `profiles.avatar_key`, `landing_hero_slides.image_key`, `landing_activities.image_key`, or `landing_settings.value_json` for the about/meeting image rows | every run |

NULL-skip discipline on the timestamp columns: pre-migration rows stay NULL and are deliberately ignored, so historical rejections / deactivations don't auto-purge retroactively. An admin can clean those up by hand.

Each sweep is wrapped in try/catch — an R2 outage doesn't sink the D1 sweeps, and vice versa. Errors are structured-logged to Workers Logs.

## Worker entry change

`wrangler.jsonc` `main` flips from `@tanstack/react-start/server-entry` to `src/server-entry.ts`, a thin wrapper that spreads TanStack Start's default handler and adds `scheduled`. **Verified this is the canonical TanStack + Cloudflare pattern** before writing it (TanStack Start docs + Cloudflare's framework guide both prescribe this approach; both vite plugins compose correctly when `main` is a user-authored path). The retention module is dynamic-imported so the scheduled handler doesn't pull D1/R2 helpers into the fetch hot path.

`triggers.crons` declared on top-level (dev) and repeated under `env.production` — Cloudflare doesn't merge triggers across env boundaries.

## Privacy copy correction

The retention bullets in `legal.ts` were slightly off — said "Pending registrations not approved within 30 days may be purged" when actually we keep pending forever and only purge **rejected** ones. Reworded each bullet to match what the cron actually does, including a new bullet about R2 orphan reconciliation running daily.

## Test plan

- [x] `pnpm --filter ucmc-web lint` — 0 errors (12 pre-existing `no-shadow` warnings unchanged)
- [x] `pnpm --filter ucmc-web typecheck` — clean
- [x] `pnpm --filter ucmc-web test` — 255 tests pass, including 15 new retention sweep tests covering each positive/negative/NULL-skip path + the orchestrator
- [x] `pnpm --filter ucmc-web build` — worker bundles cleanly; `runRetentionSweeps` lands in its own chunk via the dynamic import
- [x] `db:migrate:local` — migration applies cleanly to the existing local D1
- [ ] Manual post-merge: confirm `wrangler tail` shows `retention.sweeps_complete` log line on the first cron firing in dev (`08:00 UTC`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)