### PR TITLE
feat(ucmc-web): append-only audit log + /audit viewer

### DIFF
--- a/apps/web/drizzle/migrations/0020_audit_log.sql
+++ b/apps/web/drizzle/migrations/0020_audit_log.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `audit_log` (
+	`id` text PRIMARY KEY NOT NULL,
+	`actor_user_id` text,
+	`action` text NOT NULL,
+	`target_user_id` text,
+	`target_type` text,
+	`target_id` text,
+	`metadata_json` text,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`actor_user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`target_user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `audit_log_created_at_idx` ON `audit_log` (`created_at`);--> statement-breakpoint
+CREATE INDEX `audit_log_actor_idx` ON `audit_log` (`actor_user_id`);--> statement-breakpoint
+CREATE INDEX `audit_log_target_user_idx` ON `audit_log` (`target_user_id`);--> statement-breakpoint
+CREATE INDEX `audit_log_action_idx` ON `audit_log` (`action`);

--- a/apps/web/drizzle/migrations/0021_audit_view_permission_seed.sql
+++ b/apps/web/drizzle/migrations/0021_audit_view_permission_seed.sql
@@ -1,0 +1,17 @@
+-- Seed the audit:view permission for the /members/audit viewer.
+-- system_admin auto-grants every permission via the bypass in
+-- principal.server.ts, so no explicit role_permissions row is needed
+-- for it. Advisor gets it by default — the constitutional CSA reporter
+-- needs read access to incident-relevant events without needing a
+-- system_admin elevation. Treasurer + President do NOT get it; their
+-- constitutional duties (waiver attestation, financial actions) don't
+-- require browsing the audit log.
+
+INSERT OR IGNORE INTO permissions (id, name, description) VALUES
+  ('perm_audit_view',
+   'audit:view',
+   'Read the append-only audit log of admin / officer actions at /members/audit');
+--> statement-breakpoint
+
+INSERT OR IGNORE INTO role_permissions (role_id, permission_id) VALUES
+  ('role_advisor', 'perm_audit_view');

--- a/apps/web/drizzle/migrations/0021_audit_view_permission_seed.sql
+++ b/apps/web/drizzle/migrations/0021_audit_view_permission_seed.sql
@@ -10,7 +10,7 @@
 INSERT OR IGNORE INTO permissions (id, name, description) VALUES
   ('perm_audit_view',
    'audit:view',
-   'Read the append-only audit log of admin / officer actions at /members/audit');
+   'Read the append-only audit log of admin / officer actions at /audit');
 --> statement-breakpoint
 
 INSERT OR IGNORE INTO role_permissions (role_id, permission_id) VALUES

--- a/apps/web/drizzle/migrations/meta/0020_snapshot.json
+++ b/apps/web/drizzle/migrations/meta/0020_snapshot.json
@@ -1,0 +1,1291 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8e864d3f-3275-4898-bde5-6368e66cc4dc",
+  "prevId": "a4fa313f-e0ea-43e4-8885-0d36aa0e5fb3",
+  "tables": {
+    "announcements": {
+      "name": "announcements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "announcements_published_at_idx": {
+          "name": "announcements_published_at_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "announcements_created_by_users_id_fk": {
+          "name": "announcements_created_by_users_id_fk",
+          "tableFrom": "announcements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            "actor_user_id"
+          ],
+          "isUnique": false
+        },
+        "audit_log_target_user_idx": {
+          "name": "audit_log_target_user_idx",
+          "columns": [
+            "target_user_id"
+          ],
+          "isUnique": false
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_log_target_user_id_users_id_fk": {
+          "name": "audit_log_target_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "emergency_contacts": {
+      "name": "emergency_contacts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "emergency_contacts_user_id_users_id_fk": {
+          "name": "emergency_contacts_user_id_users_id_fk",
+          "tableFrom": "emergency_contacts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "landing_activities": {
+      "name": "landing_activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blurb": {
+          "name": "blurb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "landing_activities_sort_idx": {
+          "name": "landing_activities_sort_idx",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "landing_faq_items": {
+      "name": "landing_faq_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "landing_faq_items_sort_idx": {
+          "name": "landing_faq_items_sort_idx",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "landing_hero_slides": {
+      "name": "landing_hero_slides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "landing_hero_slides_sort_idx": {
+          "name": "landing_hero_slides_sort_idx",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "landing_settings": {
+      "name": "landing_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "landing_settings_updated_by_users_id_fk": {
+          "name": "landing_settings_updated_by_users_id_fk",
+          "tableFrom": "landing_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_links": {
+      "name": "magic_links",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey_credentials": {
+      "name": "passkey_credentials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkey_credential_id_unique": {
+          "name": "passkey_credential_id_unique",
+          "columns": [
+            "credential_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "passkey_credentials_user_id_users_id_fk": {
+          "name": "passkey_credentials_user_id_users_id_fk",
+          "tableFrom": "passkey_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "permissions": {
+      "name": "permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "permissions_name_unique": {
+          "name": "permissions_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "profiles": {
+      "name": "profiles",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preferred_name": {
+          "name": "preferred_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uc_affiliation": {
+          "name": "uc_affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_key": {
+          "name": "avatar_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policies_acknowledged_at": {
+          "name": "policies_acknowledged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policies_version": {
+          "name": "policies_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_user_id_users_id_fk": {
+          "name": "profiles_user_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "role_permissions": {
+      "name": "role_permissions",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_id_pk": {
+          "columns": [
+            "role_id",
+            "permission_id"
+          ],
+          "name": "role_permissions_role_id_permission_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "roles": {
+      "name": "roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_roles": {
+      "name": "user_roles",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "columns": [
+            "user_id",
+            "role_id"
+          ],
+          "name": "user_roles_user_id_role_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_read_announcements_at": {
+          "name": "last_read_announcements_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_public_id_unique": {
+          "name": "users_public_id_unique",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "waiver_attestations": {
+      "name": "waiver_attestations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attested_at": {
+          "name": "attested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "attested_by": {
+          "name": "attested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "waiver_attestations_user_cycle": {
+          "name": "waiver_attestations_user_cycle",
+          "columns": [
+            "user_id",
+            "cycle"
+          ],
+          "isUnique": false
+        },
+        "waiver_attestations_cycle_version_revoked": {
+          "name": "waiver_attestations_cycle_version_revoked",
+          "columns": [
+            "cycle",
+            "version",
+            "revoked_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "waiver_attestations_user_id_users_id_fk": {
+          "name": "waiver_attestations_user_id_users_id_fk",
+          "tableFrom": "waiver_attestations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "waiver_attestations_attested_by_users_id_fk": {
+          "name": "waiver_attestations_attested_by_users_id_fk",
+          "tableFrom": "waiver_attestations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "attested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "waiver_attestations_revoked_by_users_id_fk": {
+          "name": "waiver_attestations_revoked_by_users_id_fk",
+          "tableFrom": "waiver_attestations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/web/drizzle/migrations/meta/_journal.json
+++ b/apps/web/drizzle/migrations/meta/_journal.json
@@ -141,6 +141,20 @@
       "when": 1777777804644,
       "tag": "0019_user_rejected_deactivated_timestamps",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "6",
+      "when": 1777781252251,
+      "tag": "0020_audit_log",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1777781252252,
+      "tag": "0021_audit_view_permission_seed",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/drizzle/schema.ts
+++ b/apps/web/drizzle/schema.ts
@@ -344,6 +344,94 @@ export const landingActivities = sqliteTable(
   (t) => [index("landing_activities_sort_idx").on(t.sortOrder)],
 );
 
+/**
+ * Append-only audit log of admin / officer actions. Constitutionally
+ * load-bearing now that the retention cron auto-deletes user rows: a
+ * member rejected for cause and then purged 30 days later leaves zero
+ * trace anywhere else; the audit row is the only surviving record of
+ * who did what.
+ *
+ * **Append-only.** Nothing in the app is allowed to UPDATE or DELETE
+ * rows here. The retention cron explicitly skips this table. If a
+ * particular event needs to be redacted (e.g. legal hold lifted),
+ * that's a manual SQL operation, not a feature.
+ *
+ * **PII discipline.** `metadata_json` is for non-PII context only —
+ * role names, status transitions, decision text, counts. Identifying
+ * info (email, phone, full name) is reachable via the `actor_user_id`
+ * / `target_user_id` FKs while those rows still exist; once they're
+ * hard-deleted, the SET NULL preserves the action's existence without
+ * leaking PII through this surface. Never put email/phone/name in the
+ * JSON blob.
+ */
+export const auditAction = [
+  // Membership lifecycle (status transitions on `users`).
+  "registration.approved",
+  "registration.rejected",
+  "registration.unrejected",
+  "member.deactivated",
+  "member.reactivated",
+  "member.hard_deleted",
+  "member.self_deleted",
+  "profile.force_edited",
+  // RBAC.
+  "role.created",
+  "role.deleted",
+  "role.permissions_set",
+  "role.assigned",
+  "role.unassigned",
+  // Waivers — paper attestations are constitutionally significant.
+  "waiver.attested",
+  "waiver.revoked",
+  // Landing-page edits — officer-published club voice; worth a record.
+  "landing.settings_edited",
+  "landing.hero_slide_edited",
+  "landing.activity_edited",
+  "landing.faq_edited",
+  // Announcements — same reasoning as landing.
+  "announcement.published",
+  "announcement.deleted",
+] as const;
+export type AuditAction = (typeof auditAction)[number];
+
+export const auditLog = sqliteTable(
+  "audit_log",
+  {
+    id: text("id").primaryKey(),
+    // Actor (the user who performed the action). Nullable + SET NULL
+    // so an admin who has audit rows can later self-delete without
+    // FK violation; the row survives, just loses the actor identity.
+    actorUserId: text("actor_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    action: text("action", { enum: auditAction }).notNull(),
+    // The common case is a user-targeted action (approve / reject /
+    // role assignment). Typed FK so we can join when present.
+    targetUserId: text("target_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    // For non-user targets — role IDs, landing setting keys,
+    // announcement IDs. Loose `text` because the universe of types
+    // grows as features land; the action enum disambiguates.
+    targetType: text("target_type"),
+    targetId: text("target_id"),
+    // Non-PII context only. See the table doc-comment.
+    metadataJson: text("metadata_json"),
+    createdAt: timestamp("created_at")
+      .notNull()
+      .default(sql`(unixepoch() * 1000)`),
+  },
+  (t) => [
+    // Default chronological view (newest first) on the audit page.
+    index("audit_log_created_at_idx").on(t.createdAt),
+    // "What did this admin do?" / "What happened to this member?" —
+    // both common questions when investigating an incident.
+    index("audit_log_actor_idx").on(t.actorUserId),
+    index("audit_log_target_user_idx").on(t.targetUserId),
+    index("audit_log_action_idx").on(t.action),
+  ],
+);
+
 export type User = typeof users.$inferSelect;
 export type Profile = typeof profiles.$inferSelect;
 export type EmergencyContact = typeof emergencyContacts.$inferSelect;
@@ -357,3 +445,4 @@ export type LandingSetting = typeof landingSettings.$inferSelect;
 export type LandingHeroSlide = typeof landingHeroSlides.$inferSelect;
 export type LandingFaqItem = typeof landingFaqItems.$inferSelect;
 export type LandingActivity = typeof landingActivities.$inferSelect;
+export type AuditLogEntry = typeof auditLog.$inferSelect;

--- a/apps/web/drizzle/schema.ts
+++ b/apps/web/drizzle/schema.ts
@@ -363,6 +363,18 @@ export const landingActivities = sqliteTable(
  * hard-deleted, the SET NULL preserves the action's existence without
  * leaking PII through this surface. Never put email/phone/name in the
  * JSON blob.
+ *
+ * **One exception:** `member.self_deleted` deliberately captures the
+ * deleting user's `email + userId` in `metadata` because the FK
+ * cascade nulls both `actor_user_id` and `target_user_id` on the same
+ * row. Without that exception the audit row would survive with no
+ * way to identify the account, defeating the audit's whole purpose.
+ * No other action type follows this pattern; the helper module
+ * doc-comment in `src/server/audit/audit-log.server.ts` is the
+ * canonical statement of the rule.
+ *
+ * Adding a new action here requires it to actually be written by some
+ * code path — empty enum entries pollute the viewer's filter UI.
  */
 export const auditAction = [
   // Membership lifecycle (status transitions on `users`).
@@ -371,7 +383,6 @@ export const auditAction = [
   "registration.unrejected",
   "member.deactivated",
   "member.reactivated",
-  "member.hard_deleted",
   "member.self_deleted",
   "profile.force_edited",
   // RBAC.
@@ -388,9 +399,6 @@ export const auditAction = [
   "landing.hero_slide_edited",
   "landing.activity_edited",
   "landing.faq_edited",
-  // Announcements — same reasoning as landing.
-  "announcement.published",
-  "announcement.deleted",
 ] as const;
 export type AuditAction = (typeof auditAction)[number];
 

--- a/apps/web/drizzle/schema.ts
+++ b/apps/web/drizzle/schema.ts
@@ -384,6 +384,11 @@ export const auditAction = [
   "member.deactivated",
   "member.reactivated",
   "member.self_deleted",
+  // Officer-initiated termination of another member's active
+  // sessions. Distinct from deactivation (which terminates sessions
+  // as a side effect of the status change) — this one keeps the
+  // member approved.
+  "member.sessions_revoked",
   "profile.force_edited",
   // RBAC.
   "role.created",

--- a/apps/web/src/components/layouts/app-layout.tsx
+++ b/apps/web/src/components/layouts/app-layout.tsx
@@ -4,6 +4,7 @@ import { Link } from "@tanstack/react-router";
 import {
   ChevronRight,
   Eye,
+  History,
   Mail,
   ScrollText,
   Shield,
@@ -166,13 +167,15 @@ function SidebarNav() {
   const canApproveRegistrations = hasPermission("registrations:approve");
   const canManageRoles = hasPermission("roles:manage");
   const canVerifyWaivers = hasPermission("waivers:verify");
+  const canViewAudit = hasPermission("audit:view");
 
   if (!isApproved) {
     return null;
   }
 
   // Sub-items gated by permission. If none are visible, the Members
-  // link still renders but without the collapsible chevron.
+  // link still renders but without the collapsible chevron. Audit is
+  // intentionally NOT in this set — it's a top-level sibling below.
   const hasSubItems =
     canApproveRegistrations || canManageRoles || canVerifyWaivers;
 
@@ -237,6 +240,24 @@ function SidebarNav() {
             ) : null}
           </SidebarMenuItem>
         </Collapsible>
+
+        {/*
+         * Audit log is intentionally a sibling of Members rather than
+         * a sub-item: it covers landing edits, role changes, waiver
+         * attestations, account deletions — i.e. everything the audit
+         * action enum lists. Nesting it under Members would imply
+         * "audit of members specifically", which it isn't.
+         */}
+        {canViewAudit ? (
+          <SidebarMenuItem>
+            <SidebarMenuButton asChild tooltip="Audit log">
+              <Link to="/audit">
+                <History />
+                <span>Audit log</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        ) : null}
       </SidebarMenu>
     </SidebarGroup>
   );

--- a/apps/web/src/features/auth/server/__tests__/delete-my-account.test.ts
+++ b/apps/web/src/features/auth/server/__tests__/delete-my-account.test.ts
@@ -321,4 +321,70 @@ describe("deleteMyAccountAction", () => {
     expect(attestation?.revokedAt).not.toBeNull();
     expect(attestation?.revocationReason).toBe("wrong member");
   });
+
+  // Guards the audit-ordering fix from PR #41 review: the audit row
+  // must be written AFTER the destructive work succeeds, not before,
+  // so a failed avatar/user delete doesn't leave a false-positive
+  // "this account was deleted" entry behind.
+  describe("audit log: member.self_deleted", () => {
+    it("writes a self_deleted row on success with null FKs and metadata-captured identity", async () => {
+      const userId = await seedUser("selfdeleter@example.com");
+      await signInAs(userId);
+
+      await deleteMyAccountAction();
+
+      const auditRows = await getDb()
+        .select()
+        .from(schema.auditLog)
+        .where(eq(schema.auditLog.action, "member.self_deleted"));
+      expect(auditRows).toHaveLength(1);
+
+      // Both FKs are null (the user row is gone, so the cascade
+      // would have nulled them anyway — the action sets them
+      // explicitly to avoid relying on cascade timing).
+      expect(auditRows[0]?.actorUserId).toBeNull();
+      expect(auditRows[0]?.targetUserId).toBeNull();
+
+      // Metadata carries the documented PII exception so the row
+      // stays meaningful after the FKs are gone.
+      expect(auditRows[0]?.metadataJson).not.toBeNull();
+      const meta = JSON.parse(auditRows[0]?.metadataJson ?? "") as {
+        userId: string;
+        email: string;
+      };
+      expect(meta.userId).toBe(userId);
+      expect(meta.email).toBe("selfdeleter@example.com");
+    });
+
+    it("writes NO audit row if the avatar delete throws", async () => {
+      const userId = await seedUser("avatarboom@example.com", {
+        avatarKey: "avatars/avatarboom/abc.webp",
+      });
+      await signInAs(userId);
+
+      // Force the R2 helper to throw — simulates a transient R2
+      // outage during the delete flow.
+      deleteAvatarSpy.mockImplementationOnce(() => {
+        throw new Error("R2 unavailable");
+      });
+
+      await expect(deleteMyAccountAction()).rejects.toThrow("R2 unavailable");
+
+      // Pre-fix, the action wrote the audit row before this throw,
+      // leaving a "selfdeleted" entry for an account that still
+      // exists. Post-fix, no audit row should be present.
+      const auditRows = await getDb()
+        .select()
+        .from(schema.auditLog)
+        .where(eq(schema.auditLog.action, "member.self_deleted"));
+      expect(auditRows).toHaveLength(0);
+
+      // And the user row is also still present (the throw aborts
+      // before the DELETE).
+      const user = await getDb().query.users.findFirst({
+        where: eq(schema.users.id, userId),
+      });
+      expect(user).toBeDefined();
+    });
+  });
 });

--- a/apps/web/src/features/auth/server/magic-link-actions.server.ts
+++ b/apps/web/src/features/auth/server/magic-link-actions.server.ts
@@ -344,23 +344,16 @@ export async function deleteMyAccountAction(): Promise<{ ok: true }> {
     }
   }
 
-  // Record the audit event BEFORE the user row goes away. The
-  // user-deletion FK cascade sets both `actorUserId` and
-  // `targetUserId` to NULL on this audit row; capturing the original
-  // userId + email in metadata preserves attribution. This is a
-  // documented exception to the no-PII-in-metadata rule (see
-  // `audit-log.server.ts`'s module doc-comment) — no other event
-  // type follows this pattern.
-  const { recordAuditEvent } = await import("#/server/audit/audit-log.server");
-  await recordAuditEvent({
-    actorUserId: principal.userId,
-    action: "member.self_deleted",
-    targetUserId: principal.userId,
-    metadata: {
-      userId: principal.userId,
-      email: principal.email,
-    },
-  });
+  // Capture the identifying info we'll need on the audit row BEFORE
+  // the user is gone — once the FK cascade fires, both
+  // `actorUserId` and `targetUserId` go to NULL and the row would
+  // otherwise have no way to identify whose account was deleted.
+  // This is a documented exception to the no-PII-in-metadata rule;
+  // see `audit-log.server.ts`'s module doc-comment.
+  const auditMetadata = {
+    userId: principal.userId,
+    email: principal.email,
+  };
 
   // Delete the avatar object from R2 before the row goes away. The
   // R2 helper is a no-op if the key doesn't exist.
@@ -375,6 +368,19 @@ export async function deleteMyAccountAction(): Promise<{ ok: true }> {
   // announcements.created_by is ON DELETE SET NULL, so authored
   // announcements stay but lose the author attribution.
   await db.delete(schema.users).where(eq(schema.users.id, principal.userId));
+
+  // Audit AFTER the destructive work succeeds — recording before
+  // would leave a false-positive row if the avatar cleanup or the
+  // user-row delete threw. Both `actorUserId` and `targetUserId`
+  // are NULL because the user is already gone; the captured
+  // metadata is the surviving attribution.
+  const { recordAuditEvent } = await import("#/server/audit/audit-log.server");
+  await recordAuditEvent({
+    actorUserId: null,
+    action: "member.self_deleted",
+    targetUserId: null,
+    metadata: auditMetadata,
+  });
 
   // Clear the session cookie. closeSession would also try to delete a
   // sessions row by id, but the cascade above already removed it; the

--- a/apps/web/src/features/auth/server/magic-link-actions.server.ts
+++ b/apps/web/src/features/auth/server/magic-link-actions.server.ts
@@ -344,6 +344,24 @@ export async function deleteMyAccountAction(): Promise<{ ok: true }> {
     }
   }
 
+  // Record the audit event BEFORE the user row goes away. The
+  // user-deletion FK cascade sets both `actorUserId` and
+  // `targetUserId` to NULL on this audit row; capturing the original
+  // userId + email in metadata preserves attribution. This is a
+  // documented exception to the no-PII-in-metadata rule (see
+  // `audit-log.server.ts`'s module doc-comment) — no other event
+  // type follows this pattern.
+  const { recordAuditEvent } = await import("#/server/audit/audit-log.server");
+  await recordAuditEvent({
+    actorUserId: principal.userId,
+    action: "member.self_deleted",
+    targetUserId: principal.userId,
+    metadata: {
+      userId: principal.userId,
+      email: principal.email,
+    },
+  });
+
   // Delete the avatar object from R2 before the row goes away. The
   // R2 helper is a no-op if the key doesn't exist.
   if (principal.avatarKey) {

--- a/apps/web/src/features/auth/server/waiver-actions.server.ts
+++ b/apps/web/src/features/auth/server/waiver-actions.server.ts
@@ -327,16 +327,18 @@ export async function revokeWaiverAttestationAction(input: {
     })
     .where(eq(schema.waiverAttestations.id, input.attestationId));
 
-  // Reason text is officer-authored decision text (not member PII) —
-  // safe to capture verbatim in metadata so the audit page can show
-  // why a revocation happened without an extra DB hop.
+  // Don't put `reason` in the audit metadata — it's officer-entered
+  // free text and can plausibly include a member's name, medical
+  // detail, or other PII. The reason is already persisted on the
+  // waiver_attestations row (`revocationReason` column) which the
+  // viewer can join to when needed; no need to duplicate it on the
+  // audit-log surface, where the PII discipline is stricter.
   await recordAuditEvent({
     actorUserId: officer.userId,
     action: "waiver.revoked",
     targetUserId: existing.userId,
     targetType: "waiver_attestation",
     targetId: existing.id,
-    metadata: { reason },
   });
 
   return { ok: true };

--- a/apps/web/src/features/auth/server/waiver-actions.server.ts
+++ b/apps/web/src/features/auth/server/waiver-actions.server.ts
@@ -14,6 +14,10 @@ import { uuidv7 } from "uuidv7";
 
 import { WAIVER_VERSION } from "#/config/legal";
 import { currentWaiverCycle } from "#/config/waiver-cycle";
+import {
+  recordAuditEvent,
+  recordAuditEvents,
+} from "#/server/audit/audit-log.server";
 import type { Principal } from "#/server/auth/principal.server";
 import { loadCurrentPrincipal } from "#/server/auth/session.server";
 import { getDb, schema } from "#/server/db";
@@ -193,14 +197,23 @@ export async function attestWaiverAction(input: {
   }
 
   const id = `wa_${uuidv7()}`;
+  const cycle = currentWaiverCycle();
   await db.insert(schema.waiverAttestations).values({
     id,
     userId: input.userId,
-    cycle: currentWaiverCycle(),
+    cycle,
     version: WAIVER_VERSION,
     attestedAt: new Date(),
     attestedBy: officer.userId,
     notes: input.notes?.trim() || null,
+  });
+  await recordAuditEvent({
+    actorUserId: officer.userId,
+    action: "waiver.attested",
+    targetUserId: input.userId,
+    targetType: "waiver_attestation",
+    targetId: id,
+    metadata: { cycle, version: WAIVER_VERSION },
   });
   return { id };
 }
@@ -264,6 +277,17 @@ export async function bulkAttestWaiversAction(input: {
   }));
   await db.insert(schema.waiverAttestations).values(rows);
 
+  await recordAuditEvents(
+    rows.map((row) => ({
+      actorUserId: officer.userId,
+      action: "waiver.attested",
+      targetUserId: row.userId,
+      targetType: "waiver_attestation",
+      targetId: row.id,
+      metadata: { cycle, version: WAIVER_VERSION, bulk: true },
+    })),
+  );
+
   return { count: rows.length };
 }
 
@@ -285,7 +309,7 @@ export async function revokeWaiverAttestationAction(input: {
 
   const existing = await db.query.waiverAttestations.findFirst({
     where: eq(schema.waiverAttestations.id, input.attestationId),
-    columns: { id: true, revokedAt: true },
+    columns: { id: true, userId: true, revokedAt: true },
   });
   if (!existing) {
     throw new Error("Attestation not found");
@@ -302,6 +326,18 @@ export async function revokeWaiverAttestationAction(input: {
       revocationReason: reason,
     })
     .where(eq(schema.waiverAttestations.id, input.attestationId));
+
+  // Reason text is officer-authored decision text (not member PII) —
+  // safe to capture verbatim in metadata so the audit page can show
+  // why a revocation happened without an extra DB hop.
+  await recordAuditEvent({
+    actorUserId: officer.userId,
+    action: "waiver.revoked",
+    targetUserId: existing.userId,
+    targetType: "waiver_attestation",
+    targetId: existing.id,
+    metadata: { reason },
+  });
 
   return { ok: true };
 }

--- a/apps/web/src/features/landing/server/__tests__/landing-actions.test.ts
+++ b/apps/web/src/features/landing/server/__tests__/landing-actions.test.ts
@@ -28,6 +28,7 @@ const {
   createFaqItemAction,
   createHeroSlideAction,
   deleteActivityAction,
+  deleteFaqItemAction,
   deleteHeroSlideAction,
   getLandingContentAction,
   removeAboutImageAction,
@@ -311,6 +312,36 @@ describe("faq items", () => {
     const content = await getLandingContentAction();
     expect(content.faqItems).toHaveLength(1);
     expect(content.faqItems[0].answer).toBe("Sometimes.");
+  });
+
+  // Guards the existence-check fix from PR #41 review: the repo's
+  // updateFaqItem/deleteFaqItem silently no-op on missing IDs, which
+  // (without a guard) would emit a `landing.faq_edited` audit row for
+  // an edit that never happened.
+  it("updateFaqItemAction does not write an audit row for a nonexistent id", async () => {
+    await signInAsAdmin();
+    await updateFaqItemAction({
+      id: "faq_does_not_exist",
+      question: "Q?",
+      answer: "A.",
+    });
+
+    const auditRows = await getDb()
+      .select({ id: schema.auditLog.id })
+      .from(schema.auditLog)
+      .where(eq(schema.auditLog.action, "landing.faq_edited"));
+    expect(auditRows).toHaveLength(0);
+  });
+
+  it("deleteFaqItemAction does not write an audit row for a nonexistent id", async () => {
+    await signInAsAdmin();
+    await deleteFaqItemAction({ id: "faq_does_not_exist" });
+
+    const auditRows = await getDb()
+      .select({ id: schema.auditLog.id })
+      .from(schema.auditLog)
+      .where(eq(schema.auditLog.action, "landing.faq_edited"));
+    expect(auditRows).toHaveLength(0);
   });
 });
 

--- a/apps/web/src/features/landing/server/landing-actions.server.ts
+++ b/apps/web/src/features/landing/server/landing-actions.server.ts
@@ -17,6 +17,7 @@ import {
   deleteFaqItem,
   deleteHeroSlide,
   getActivity,
+  getFaqItem,
   getHeroSlide,
   insertActivity,
   insertFaqItem,
@@ -316,6 +317,13 @@ export async function updateFaqItemAction(
   input: FaqUpdateInput,
 ): Promise<{ ok: true }> {
   const principal = await requireLandingEditor();
+  // The repo's UPDATE silently no-ops on a missing id; audit only
+  // when the row actually exists so a stale request can't produce a
+  // false-positive `faq_edited` row.
+  const existing = await getFaqItem(input.id);
+  if (!existing) {
+    return { ok: true };
+  }
   await updateFaqItem(input);
   await recordAuditEvent({
     actorUserId: principal.userId,
@@ -331,6 +339,12 @@ export async function deleteFaqItemAction(input: {
   id: string;
 }): Promise<{ ok: true }> {
   const principal = await requireLandingEditor();
+  // Same existence guard as update — the repo's DELETE silently
+  // no-ops on missing rows, and we don't want phantom audit entries.
+  const existing = await getFaqItem(input.id);
+  if (!existing) {
+    return { ok: true };
+  }
   await deleteFaqItem(input.id);
   await recordAuditEvent({
     actorUserId: principal.userId,

--- a/apps/web/src/features/landing/server/landing-actions.server.ts
+++ b/apps/web/src/features/landing/server/landing-actions.server.ts
@@ -59,6 +59,7 @@ import type {
   UpdateHeroSlideInput,
   UpdateSettingInput,
 } from "#/features/landing/server/landing-schemas";
+import { recordAuditEvent } from "#/server/audit/audit-log.server";
 import type { Principal } from "#/server/auth/principal.server";
 import { loadCurrentPrincipal } from "#/server/auth/session.server";
 
@@ -174,6 +175,12 @@ export async function updateSettingAction(
 ): Promise<{ ok: true }> {
   const principal = await requireLandingEditor();
   await upsertSetting(input.key, JSON.stringify(input.value), principal.userId);
+  await recordAuditEvent({
+    actorUserId: principal.userId,
+    action: "landing.settings_edited",
+    targetType: "landing_setting",
+    targetId: input.key,
+  });
   return { ok: true };
 }
 
@@ -182,7 +189,7 @@ export async function updateSettingAction(
 export async function createHeroSlideAction(
   input: CreateHeroSlideInput,
 ): Promise<{ id: string; imageKey: string }> {
-  await requireLandingEditor();
+  const principal = await requireLandingEditor();
   const { contentType, bytes } = decodeImageDataUrl(input.dataUrl);
   const hash = await shortContentHash(bytes);
   const imageKey = landingImageKey("hero", hash, contentType);
@@ -191,13 +198,21 @@ export async function createHeroSlideAction(
   const id = `hslide_${uuidv7()}`;
   const sortOrder = await nextHeroSlideSortOrder();
   await insertHeroSlide({ id, imageKey, alt: input.alt, sortOrder });
+
+  await recordAuditEvent({
+    actorUserId: principal.userId,
+    action: "landing.hero_slide_edited",
+    targetType: "landing_hero_slide",
+    targetId: id,
+    metadata: { op: "create" },
+  });
   return { id, imageKey };
 }
 
 export async function updateHeroSlideAction(
   input: UpdateHeroSlideInput,
 ): Promise<{ ok: true }> {
-  await requireLandingEditor();
+  const principal = await requireLandingEditor();
   const existing = await getHeroSlide(input.id);
   if (!existing) {
     throw new Error("Hero slide not found");
@@ -226,13 +241,20 @@ export async function updateHeroSlideAction(
     }
   }
 
+  await recordAuditEvent({
+    actorUserId: principal.userId,
+    action: "landing.hero_slide_edited",
+    targetType: "landing_hero_slide",
+    targetId: input.id,
+    metadata: { op: "update", imageReplaced: Boolean(nextImageKey) },
+  });
   return { ok: true };
 }
 
 export async function deleteHeroSlideAction(input: {
   id: string;
 }): Promise<{ ok: true }> {
-  await requireLandingEditor();
+  const principal = await requireLandingEditor();
   const existing = await getHeroSlide(input.id);
   if (!existing) {
     return { ok: true };
@@ -242,6 +264,13 @@ export async function deleteHeroSlideAction(input: {
   if (remaining === 0) {
     await deleteLandingImage(existing.imageKey);
   }
+  await recordAuditEvent({
+    actorUserId: principal.userId,
+    action: "landing.hero_slide_edited",
+    targetType: "landing_hero_slide",
+    targetId: input.id,
+    metadata: { op: "delete" },
+  });
   return { ok: true };
 }
 
@@ -258,7 +287,7 @@ export async function reorderHeroSlidesAction(
 export async function createFaqItemAction(
   input: FaqInput,
 ): Promise<{ id: string }> {
-  await requireLandingEditor();
+  const principal = await requireLandingEditor();
   const existing = await countFaqItems();
   if (existing >= LANDING_LIMITS.faqItemCount.max) {
     throw new Error(
@@ -273,22 +302,43 @@ export async function createFaqItemAction(
     answer: input.answer,
     sortOrder,
   });
+  await recordAuditEvent({
+    actorUserId: principal.userId,
+    action: "landing.faq_edited",
+    targetType: "landing_faq_item",
+    targetId: id,
+    metadata: { op: "create" },
+  });
   return { id };
 }
 
 export async function updateFaqItemAction(
   input: FaqUpdateInput,
 ): Promise<{ ok: true }> {
-  await requireLandingEditor();
+  const principal = await requireLandingEditor();
   await updateFaqItem(input);
+  await recordAuditEvent({
+    actorUserId: principal.userId,
+    action: "landing.faq_edited",
+    targetType: "landing_faq_item",
+    targetId: input.id,
+    metadata: { op: "update" },
+  });
   return { ok: true };
 }
 
 export async function deleteFaqItemAction(input: {
   id: string;
 }): Promise<{ ok: true }> {
-  await requireLandingEditor();
+  const principal = await requireLandingEditor();
   await deleteFaqItem(input.id);
+  await recordAuditEvent({
+    actorUserId: principal.userId,
+    action: "landing.faq_edited",
+    targetType: "landing_faq_item",
+    targetId: input.id,
+    metadata: { op: "delete" },
+  });
   return { ok: true };
 }
 
@@ -323,7 +373,7 @@ async function maybeDeleteActivityImage(key: string | null): Promise<void> {
 export async function createActivityAction(
   input: ActivityInput,
 ): Promise<{ id: string; imageKey: string | null }> {
-  await requireLandingEditor();
+  const principal = await requireLandingEditor();
   const imageKey = input.dataUrl
     ? await uploadActivityImage(input.dataUrl)
     : null;
@@ -337,13 +387,20 @@ export async function createActivityAction(
     imageKey,
     sortOrder,
   });
+  await recordAuditEvent({
+    actorUserId: principal.userId,
+    action: "landing.activity_edited",
+    targetType: "landing_activity",
+    targetId: id,
+    metadata: { op: "create" },
+  });
   return { id, imageKey };
 }
 
 export async function updateActivityAction(
   input: ActivityUpdateInput,
 ): Promise<{ ok: true }> {
-  await requireLandingEditor();
+  const principal = await requireLandingEditor();
   if (input.dataUrl && input.removeImage) {
     throw new Error("Cannot both replace and remove the image");
   }
@@ -373,19 +430,33 @@ export async function updateActivityAction(
   if (oldKeyToCleanup && oldKeyToCleanup !== imageKeyChange) {
     await maybeDeleteActivityImage(oldKeyToCleanup);
   }
+  await recordAuditEvent({
+    actorUserId: principal.userId,
+    action: "landing.activity_edited",
+    targetType: "landing_activity",
+    targetId: input.id,
+    metadata: { op: "update" },
+  });
   return { ok: true };
 }
 
 export async function deleteActivityAction(input: {
   id: string;
 }): Promise<{ ok: true }> {
-  await requireLandingEditor();
+  const principal = await requireLandingEditor();
   const existing = await getActivity(input.id);
   if (!existing) {
     return { ok: true };
   }
   await deleteActivity(input.id);
   await maybeDeleteActivityImage(existing.imageKey);
+  await recordAuditEvent({
+    actorUserId: principal.userId,
+    action: "landing.activity_edited",
+    targetType: "landing_activity",
+    targetId: input.id,
+    metadata: { op: "delete" },
+  });
   return { ok: true };
 }
 
@@ -443,40 +514,72 @@ export async function setAboutImageAction(
   input: SetSectionImageInput,
 ): Promise<{ ok: true; imageKey: string }> {
   const principal = await requireLandingEditor();
-  return setSectionImage(
+  const result = await setSectionImage(
     LANDING_SETTING_KEYS.aboutImageKey,
     "about",
     input,
     principal.userId,
   );
+  await recordAuditEvent({
+    actorUserId: principal.userId,
+    action: "landing.settings_edited",
+    targetType: "landing_setting",
+    targetId: LANDING_SETTING_KEYS.aboutImageKey,
+    metadata: { op: "set_image" },
+  });
+  return result;
 }
 
 export async function removeAboutImageAction(): Promise<{ ok: true }> {
   const principal = await requireLandingEditor();
-  return removeSectionImage(
+  const result = await removeSectionImage(
     LANDING_SETTING_KEYS.aboutImageKey,
     principal.userId,
   );
+  await recordAuditEvent({
+    actorUserId: principal.userId,
+    action: "landing.settings_edited",
+    targetType: "landing_setting",
+    targetId: LANDING_SETTING_KEYS.aboutImageKey,
+    metadata: { op: "remove_image" },
+  });
+  return result;
 }
 
 export async function setMeetingImageAction(
   input: SetSectionImageInput,
 ): Promise<{ ok: true; imageKey: string }> {
   const principal = await requireLandingEditor();
-  return setSectionImage(
+  const result = await setSectionImage(
     LANDING_SETTING_KEYS.meetingImageKey,
     "meeting",
     input,
     principal.userId,
   );
+  await recordAuditEvent({
+    actorUserId: principal.userId,
+    action: "landing.settings_edited",
+    targetType: "landing_setting",
+    targetId: LANDING_SETTING_KEYS.meetingImageKey,
+    metadata: { op: "set_image" },
+  });
+  return result;
 }
 
 export async function removeMeetingImageAction(): Promise<{ ok: true }> {
   const principal = await requireLandingEditor();
-  return removeSectionImage(
+  const result = await removeSectionImage(
     LANDING_SETTING_KEYS.meetingImageKey,
     principal.userId,
   );
+  await recordAuditEvent({
+    actorUserId: principal.userId,
+    action: "landing.settings_edited",
+    targetType: "landing_setting",
+    targetId: LANDING_SETTING_KEYS.meetingImageKey,
+    metadata: { op: "remove_image" },
+  });
+  return result;
 }
 
 export async function reorderActivitiesAction(

--- a/apps/web/src/features/landing/server/landing-repo.server.ts
+++ b/apps/web/src/features/landing/server/landing-repo.server.ts
@@ -162,6 +162,17 @@ export async function listFaqItems() {
     );
 }
 
+export async function getFaqItem(
+  id: string,
+): Promise<schema.LandingFaqItem | null> {
+  const rows = await getDb()
+    .select()
+    .from(schema.landingFaqItems)
+    .where(eq(schema.landingFaqItems.id, id))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
 export async function insertFaqItem(input: {
   id: string;
   question: string;

--- a/apps/web/src/features/members/server/__tests__/member-actions.test.ts
+++ b/apps/web/src/features/members/server/__tests__/member-actions.test.ts
@@ -32,6 +32,7 @@ const {
   listMembersAction,
   getMemberDetailAction,
   rejectRegistrationsAction,
+  approveRegistrationsAction,
 } = await import("#/features/members/server/member-actions.server");
 const { openSession, loadCurrentPrincipal } =
   await import("#/server/auth/session.server");
@@ -822,5 +823,81 @@ describe("audit log: bulk lifecycle audits transitions, not requests", () => {
 
     expect(auditRows).toHaveLength(1);
     expect(auditRows[0]?.targetUserId).toBe(rejectedId);
+  });
+
+  it("approveRegistrationsAction: dedupes and ignores nonexistent IDs in the audit log", async () => {
+    await signInAsAdmin();
+    const pendingId = await seedUser("pending-approve@example.com", {
+      status: "pending",
+    });
+
+    // Pass the same pending id twice plus a bogus id. The fix routes
+    // through `.returning({ id })`, which means the UPDATE returns the
+    // affected row once (per existing `pendingId`) regardless of how
+    // many times the caller sent it, and skips the bogus id entirely.
+    await approveRegistrationsAction([
+      pendingId,
+      pendingId,
+      "user_does_not_exist",
+    ]);
+
+    const approvedRows = await getDb()
+      .select({ targetUserId: schema.auditLog.targetUserId })
+      .from(schema.auditLog)
+      .where(eq(schema.auditLog.action, "registration.approved"));
+
+    expect(approvedRows).toHaveLength(1);
+    expect(approvedRows[0]?.targetUserId).toBe(pendingId);
+  });
+
+  it("revokeUserSessionsAction: writes a member.sessions_revoked audit row with revokedCount metadata", async () => {
+    const adminId = await signInAsAdmin();
+    const targetId = await seedUser("revoke-target@example.com");
+    const db = getDb();
+
+    // Seed two sessions for the target so we can verify the count is
+    // captured and not just the existence of the action.
+    await db.insert(schema.sessions).values([
+      {
+        id: "sess_revoke_1",
+        userId: targetId,
+        createdAt: new Date(),
+        lastSeenAt: new Date(),
+        expiresAt: new Date(Date.now() + 86_400_000),
+      },
+      {
+        id: "sess_revoke_2",
+        userId: targetId,
+        createdAt: new Date(),
+        lastSeenAt: new Date(),
+        expiresAt: new Date(Date.now() + 86_400_000),
+      },
+    ]);
+
+    await revokeUserSessionsAction(targetId);
+
+    const auditRows = await db
+      .select()
+      .from(schema.auditLog)
+      .where(eq(schema.auditLog.action, "member.sessions_revoked"));
+    expect(auditRows).toHaveLength(1);
+    expect(auditRows[0]?.actorUserId).toBe(adminId);
+    expect(auditRows[0]?.targetUserId).toBe(targetId);
+    expect(JSON.parse(auditRows[0]?.metadataJson ?? "")).toEqual({
+      revokedCount: 2,
+    });
+  });
+
+  it("revokeUserSessionsAction: writes NO audit row when the user had no active sessions", async () => {
+    await signInAsAdmin();
+    const targetId = await seedUser("revoke-empty@example.com");
+
+    await revokeUserSessionsAction(targetId);
+
+    const auditRows = await getDb()
+      .select()
+      .from(schema.auditLog)
+      .where(eq(schema.auditLog.action, "member.sessions_revoked"));
+    expect(auditRows).toHaveLength(0);
   });
 });

--- a/apps/web/src/features/members/server/__tests__/member-actions.test.ts
+++ b/apps/web/src/features/members/server/__tests__/member-actions.test.ts
@@ -31,6 +31,7 @@ const {
   adminUpdateProfileAction,
   listMembersAction,
   getMemberDetailAction,
+  rejectRegistrationsAction,
 } = await import("#/features/members/server/member-actions.server");
 const { openSession, loadCurrentPrincipal } =
   await import("#/server/auth/session.server");
@@ -739,5 +740,87 @@ describe("loadCurrentPrincipal deactivated check", () => {
       .from(schema.sessions)
       .where(eq(schema.sessions.userId, targetId));
     expect(sessions).toHaveLength(0);
+  });
+});
+
+// ── audit-log integration ──────────────────────────────────────────────
+//
+// These tests guard the bulk-lifecycle audit fix from PR #41 review:
+// the audit row count must equal the count of users that ACTUALLY
+// transitioned, not the raw `userIds[]` length. Without `.returning()`
+// on the UPDATE, a stale or malformed request was producing
+// false-positive audit entries for accounts that didn't change state.
+
+describe("audit log: bulk lifecycle audits transitions, not requests", () => {
+  it("rejectRegistrationsAction: nonexistent IDs don't produce audit rows", async () => {
+    await signInAsAdmin();
+    const pendingId = await seedUser("pending@example.com", {
+      status: "pending",
+    });
+
+    // Mix of a valid pending user + a bogus ID. `rejectRegistrationsAction`
+    // doesn't filter on prior status (so it can also operate on an
+    // already-rejected row idempotently), but it MUST refuse to emit
+    // an audit row for an ID the UPDATE didn't touch.
+    await rejectRegistrationsAction([pendingId, "user_does_not_exist"]);
+
+    const rejectedRows = await getDb()
+      .select({ targetUserId: schema.auditLog.targetUserId })
+      .from(schema.auditLog)
+      .where(eq(schema.auditLog.action, "registration.rejected"));
+
+    expect(rejectedRows).toHaveLength(1);
+    expect(rejectedRows[0]?.targetUserId).toBe(pendingId);
+  });
+
+  it("deactivateMembersAction: only audits approved users that actually transitioned", async () => {
+    await signInAsAdmin();
+    const approvedId = await seedUser("approved-bulk@example.com", {
+      status: "approved",
+    });
+    const pendingId = await seedUser("pending-bulk@example.com", {
+      status: "pending",
+    });
+    const rejectedId = await seedUser("rejected-bulk@example.com", {
+      status: "rejected",
+    });
+
+    await deactivateMembersAction([
+      approvedId,
+      pendingId,
+      rejectedId,
+      "user_does_not_exist",
+    ]);
+
+    const auditRows = await getDb()
+      .select({ targetUserId: schema.auditLog.targetUserId })
+      .from(schema.auditLog)
+      .where(eq(schema.auditLog.action, "member.deactivated"));
+
+    // Only the approved user actually transitioned to deactivated;
+    // the audit log must reflect that and not advertise phantom
+    // deactivations for the other three IDs.
+    expect(auditRows).toHaveLength(1);
+    expect(auditRows[0]?.targetUserId).toBe(approvedId);
+  });
+
+  it("unrejectMembersAction: only audits rejected users that actually transitioned", async () => {
+    await signInAsAdmin();
+    const rejectedId = await seedUser("rejected-unreject@example.com", {
+      status: "rejected",
+    });
+    const pendingId = await seedUser("pending-unreject@example.com", {
+      status: "pending",
+    });
+
+    await unrejectMembersAction([rejectedId, pendingId, "user_does_not_exist"]);
+
+    const auditRows = await getDb()
+      .select({ targetUserId: schema.auditLog.targetUserId })
+      .from(schema.auditLog)
+      .where(eq(schema.auditLog.action, "registration.unrejected"));
+
+    expect(auditRows).toHaveLength(1);
+    expect(auditRows[0]?.targetUserId).toBe(rejectedId);
   });
 });

--- a/apps/web/src/features/members/server/member-actions.server.ts
+++ b/apps/web/src/features/members/server/member-actions.server.ts
@@ -500,16 +500,21 @@ export async function rejectRegistrationsAction(
 ): Promise<{ ok: true }> {
   const approver = await requireApprover();
 
-  await getDb()
+  // `.returning({ id })` gives us the rows the UPDATE actually
+  // touched. Audit only those so a stale or malformed request that
+  // includes already-rejected or nonexistent IDs doesn't produce
+  // false-positive audit rows.
+  const updated = await getDb()
     .update(schema.users)
     .set({ status: "rejected", rejectedAt: new Date() })
-    .where(inArray(schema.users.id, userIds));
+    .where(inArray(schema.users.id, userIds))
+    .returning({ id: schema.users.id });
 
   await recordAuditEvents(
-    userIds.map((userId) => ({
+    updated.map(({ id }) => ({
       actorUserId: approver.userId,
       action: "registration.rejected",
-      targetUserId: userId,
+      targetUserId: id,
     })),
   );
 
@@ -531,8 +536,10 @@ export async function deactivateMembersAction(
 
   const db = getDb();
 
-  // Only deactivate users that are currently approved.
-  await db
+  // Only deactivate users that are currently approved. `.returning`
+  // gives the IDs of rows the UPDATE actually touched so the audit
+  // log doesn't claim a deactivation for users in the wrong status.
+  const updated = await db
     .update(schema.users)
     .set({ status: "deactivated", deactivatedAt: new Date() })
     .where(
@@ -540,15 +547,22 @@ export async function deactivateMembersAction(
         inArray(schema.users.id, userIds),
         eq(schema.users.status, "approved"),
       ),
-    );
+    )
+    .returning({ id: schema.users.id });
 
-  // Immediately revoke all sessions so deactivated users are signed out.
-  await db
-    .delete(schema.sessions)
-    .where(inArray(schema.sessions.userId, userIds));
+  // Immediately revoke all sessions so deactivated users are signed
+  // out. Limit to the IDs that actually transitioned — purging
+  // sessions for users we didn't touch would be a surprise side
+  // effect of the bulk endpoint.
+  const updatedIds = updated.map(({ id }) => id);
+  if (updatedIds.length > 0) {
+    await db
+      .delete(schema.sessions)
+      .where(inArray(schema.sessions.userId, updatedIds));
+  }
 
   await recordAuditEvents(
-    userIds.map((userId) => ({
+    updatedIds.map((userId) => ({
       actorUserId: principal.userId,
       action: "member.deactivated",
       targetUserId: userId,
@@ -569,7 +583,9 @@ export async function reactivateMembersAction(
   // Only reactivate users that are currently deactivated. Clear
   // `deactivatedAt` so a future deactivation gets a fresh retention
   // clock rather than counting from the *first* deactivation.
-  await db
+  // `.returning` so the audit + role-grant operate on the rows that
+  // actually transitioned, not the raw request list.
+  const updated = await db
     .update(schema.users)
     .set({
       status: "approved",
@@ -582,16 +598,21 @@ export async function reactivateMembersAction(
         inArray(schema.users.id, userIds),
         eq(schema.users.status, "deactivated"),
       ),
-    );
+    )
+    .returning({ id: schema.users.id });
+  const updatedIds = updated.map(({ id }) => id);
 
-  // Ensure member role is granted (may already exist from prior approval).
-  await db
-    .insert(schema.userRoles)
-    .values(userIds.map((userId) => ({ userId, roleId: "role_member" })))
-    .onConflictDoNothing();
+  // Ensure member role is granted on the rows we actually
+  // reactivated (may already exist from prior approval).
+  if (updatedIds.length > 0) {
+    await db
+      .insert(schema.userRoles)
+      .values(updatedIds.map((userId) => ({ userId, roleId: "role_member" })))
+      .onConflictDoNothing();
+  }
 
   await recordAuditEvents(
-    userIds.map((userId) => ({
+    updatedIds.map((userId) => ({
       actorUserId: approver.userId,
       action: "member.reactivated",
       targetUserId: userId,
@@ -611,7 +632,8 @@ export async function unrejectMembersAction(
   // Move rejected users back to pending so they re-enter the approval
   // queue. Clear `rejectedAt` so a future rejection gets a fresh
   // retention clock rather than counting from the *first* rejection.
-  await getDb()
+  // `.returning` so we only audit rows that actually changed.
+  const updated = await getDb()
     .update(schema.users)
     .set({ status: "pending", rejectedAt: null })
     .where(
@@ -619,13 +641,14 @@ export async function unrejectMembersAction(
         inArray(schema.users.id, userIds),
         eq(schema.users.status, "rejected"),
       ),
-    );
+    )
+    .returning({ id: schema.users.id });
 
   await recordAuditEvents(
-    userIds.map((userId) => ({
+    updated.map(({ id }) => ({
       actorUserId: principal.userId,
       action: "registration.unrejected",
-      targetUserId: userId,
+      targetUserId: id,
     })),
   );
 

--- a/apps/web/src/features/members/server/member-actions.server.ts
+++ b/apps/web/src/features/members/server/member-actions.server.ts
@@ -463,24 +463,31 @@ export async function approveRegistrationsAction(
   const approver = await requireApprover();
   const db = getDb();
 
-  // Single UPDATE for all users.
-  await db
+  // `.returning({ id })` so the audit + role-grant operate on the
+  // rows the UPDATE actually touched, not the raw request list.
+  // This dedupes a buggy caller that repeats the same id and filters
+  // out nonexistent IDs — without it, both cases would emit phantom
+  // `registration.approved` rows.
+  const updated = await db
     .update(schema.users)
     .set({
       status: "approved",
       approvedAt: new Date(),
       approvedBy: approver.userId,
     })
-    .where(inArray(schema.users.id, userIds));
+    .where(inArray(schema.users.id, userIds))
+    .returning({ id: schema.users.id });
+  const updatedIds = updated.map(({ id }) => id);
 
-  // Batch-insert the member role grant for every approved user.
-  await db
-    .insert(schema.userRoles)
-    .values(userIds.map((userId) => ({ userId, roleId: "role_member" })))
-    .onConflictDoNothing();
+  if (updatedIds.length > 0) {
+    await db
+      .insert(schema.userRoles)
+      .values(updatedIds.map((userId) => ({ userId, roleId: "role_member" })))
+      .onConflictDoNothing();
+  }
 
   await recordAuditEvents(
-    userIds.map((userId) => ({
+    updatedIds.map((userId) => ({
       actorUserId: approver.userId,
       action: "registration.approved",
       targetUserId: userId,
@@ -671,9 +678,22 @@ export async function revokeUserSessionsAction(
     throw new Error("Cannot revoke your own sessions (use Sign Out)");
   }
 
-  await getDb()
+  const deleted = await getDb()
     .delete(schema.sessions)
-    .where(eq(schema.sessions.userId, userId));
+    .where(eq(schema.sessions.userId, userId))
+    .returning({ id: schema.sessions.id });
+
+  // Audit only when something was actually revoked. Session count
+  // captured in metadata so the audit page can show the blast
+  // radius without joining back to a now-empty sessions table.
+  if (deleted.length > 0) {
+    await recordAuditEvent({
+      actorUserId: principal.userId,
+      action: "member.sessions_revoked",
+      targetUserId: userId,
+      metadata: { revokedCount: deleted.length },
+    });
+  }
 
   return { ok: true };
 }

--- a/apps/web/src/features/members/server/member-actions.server.ts
+++ b/apps/web/src/features/members/server/member-actions.server.ts
@@ -8,6 +8,10 @@
 import { and, asc, count, desc, eq, gte, inArray, lte } from "drizzle-orm";
 import { uuidv7 } from "uuidv7";
 
+import {
+  recordAuditEvent,
+  recordAuditEvents,
+} from "#/server/audit/audit-log.server";
 import { loadCurrentPrincipal } from "#/server/auth/session.server";
 import type { Principal } from "#/server/auth/principal.server";
 import { getDb, schema } from "#/server/db";
@@ -475,6 +479,14 @@ export async function approveRegistrationsAction(
     .values(userIds.map((userId) => ({ userId, roleId: "role_member" })))
     .onConflictDoNothing();
 
+  await recordAuditEvents(
+    userIds.map((userId) => ({
+      actorUserId: approver.userId,
+      action: "registration.approved",
+      targetUserId: userId,
+    })),
+  );
+
   // TODO: send approval notification emails (per-user; will need a loop
   // or a batch email API call here when email notifications are added).
 
@@ -486,12 +498,20 @@ export async function approveRegistrationsAction(
 export async function rejectRegistrationsAction(
   userIds: string[],
 ): Promise<{ ok: true }> {
-  await requireApprover();
+  const approver = await requireApprover();
 
   await getDb()
     .update(schema.users)
     .set({ status: "rejected", rejectedAt: new Date() })
     .where(inArray(schema.users.id, userIds));
+
+  await recordAuditEvents(
+    userIds.map((userId) => ({
+      actorUserId: approver.userId,
+      action: "registration.rejected",
+      targetUserId: userId,
+    })),
+  );
 
   // TODO: send rejection notification emails (per-user).
 
@@ -526,6 +546,14 @@ export async function deactivateMembersAction(
   await db
     .delete(schema.sessions)
     .where(inArray(schema.sessions.userId, userIds));
+
+  await recordAuditEvents(
+    userIds.map((userId) => ({
+      actorUserId: principal.userId,
+      action: "member.deactivated",
+      targetUserId: userId,
+    })),
+  );
 
   return { ok: true };
 }
@@ -562,6 +590,14 @@ export async function reactivateMembersAction(
     .values(userIds.map((userId) => ({ userId, roleId: "role_member" })))
     .onConflictDoNothing();
 
+  await recordAuditEvents(
+    userIds.map((userId) => ({
+      actorUserId: approver.userId,
+      action: "member.reactivated",
+      targetUserId: userId,
+    })),
+  );
+
   return { ok: true };
 }
 
@@ -570,7 +606,7 @@ export async function reactivateMembersAction(
 export async function unrejectMembersAction(
   userIds: string[],
 ): Promise<{ ok: true }> {
-  await requireMembersManager();
+  const principal = await requireMembersManager();
 
   // Move rejected users back to pending so they re-enter the approval
   // queue. Clear `rejectedAt` so a future rejection gets a fresh
@@ -584,6 +620,14 @@ export async function unrejectMembersAction(
         eq(schema.users.status, "rejected"),
       ),
     );
+
+  await recordAuditEvents(
+    userIds.map((userId) => ({
+      actorUserId: principal.userId,
+      action: "registration.unrejected",
+      targetUserId: userId,
+    })),
+  );
 
   return { ok: true };
 }
@@ -625,7 +669,7 @@ export async function adminUpdateProfileAction(input: {
   }>;
   ucAffiliation: schema.UcAffiliation;
 }): Promise<{ ok: true }> {
-  await requireMembersManager();
+  const principal = await requireMembersManager();
 
   const db = getDb();
   const user = await db.query.users.findFirst({
@@ -661,6 +705,21 @@ export async function adminUpdateProfileAction(input: {
       })),
     );
   }
+
+  // Field names only — never the values themselves (those would be PII
+  // by definition since this action edits a person's identifying info).
+  // The before/after diff lives in the row's history if anyone needs
+  // to investigate; the audit row just establishes that an admin
+  // touched this profile.
+  await recordAuditEvent({
+    actorUserId: principal.userId,
+    action: "profile.force_edited",
+    targetUserId: userId,
+    metadata: {
+      emergencyContactCount: emergencyContacts.length,
+      ucAffiliation: profileData.ucAffiliation,
+    },
+  });
 
   return { ok: true };
 }

--- a/apps/web/src/features/members/server/rbac-actions.server.ts
+++ b/apps/web/src/features/members/server/rbac-actions.server.ts
@@ -5,6 +5,10 @@
  */
 import { count, eq, inArray, max } from "drizzle-orm";
 
+import {
+  recordAuditEvent,
+  recordAuditEvents,
+} from "#/server/audit/audit-log.server";
 import { invalidateAnonymousPermissionsCache } from "#/server/auth/principal.server";
 import type { Principal } from "#/server/auth/principal.server";
 import { loadCurrentPrincipal } from "#/server/auth/session.server";
@@ -179,7 +183,7 @@ export async function createRoleAction(input: {
   name: string;
   description?: string;
 }): Promise<{ roleId: string }> {
-  await requireRolesManager();
+  const principal = await requireRolesManager();
   const db = getDb();
 
   const roleId = `role_${input.name}`;
@@ -204,6 +208,14 @@ export async function createRoleAction(input: {
     name: input.name,
     description: input.description ?? null,
     position: nextPos,
+  });
+
+  await recordAuditEvent({
+    actorUserId: principal.userId,
+    action: "role.created",
+    targetType: "role",
+    targetId: roleId,
+    metadata: { name: input.name },
   });
 
   return { roleId };
@@ -233,7 +245,7 @@ export async function updateRoleAction(input: {
 }
 
 export async function deleteRoleAction(roleId: string): Promise<{ ok: true }> {
-  await requireRolesManager();
+  const principal = await requireRolesManager();
 
   if (PROTECTED_ROLE_IDS.has(roleId)) {
     throw new Error("Cannot delete a protected role");
@@ -242,7 +254,7 @@ export async function deleteRoleAction(roleId: string): Promise<{ ok: true }> {
   const db = getDb();
   const role = await db.query.roles.findFirst({
     where: eq(schema.roles.id, roleId),
-    columns: { id: true },
+    columns: { id: true, name: true },
   });
   if (!role) {
     throw new Error("Role not found");
@@ -250,6 +262,14 @@ export async function deleteRoleAction(roleId: string): Promise<{ ok: true }> {
 
   // Cascade deletes handle role_permissions and user_roles rows.
   await db.delete(schema.roles).where(eq(schema.roles.id, roleId));
+
+  await recordAuditEvent({
+    actorUserId: principal.userId,
+    action: "role.deleted",
+    targetType: "role",
+    targetId: roleId,
+    metadata: { name: role.name },
+  });
 
   return { ok: true };
 }
@@ -277,7 +297,7 @@ export async function setRolePermissionsAction(input: {
   roleId: string;
   permissionIds: string[];
 }): Promise<{ ok: true }> {
-  await requireRolesManager();
+  const principal = await requireRolesManager();
 
   if (input.roleId === SYSTEM_ADMIN_ROLE_ID) {
     throw new Error(
@@ -289,7 +309,7 @@ export async function setRolePermissionsAction(input: {
 
   const role = await db.query.roles.findFirst({
     where: eq(schema.roles.id, input.roleId),
-    columns: { id: true },
+    columns: { id: true, name: true },
   });
   if (!role) {
     throw new Error("Role not found");
@@ -314,6 +334,17 @@ export async function setRolePermissionsAction(input: {
   if (input.roleId === ANONYMOUS_ROLE_ID) {
     await invalidateAnonymousPermissionsCache();
   }
+
+  await recordAuditEvent({
+    actorUserId: principal.userId,
+    action: "role.permissions_set",
+    targetType: "role",
+    targetId: input.roleId,
+    metadata: {
+      roleName: role.name,
+      permissionIds: input.permissionIds,
+    },
+  });
 
   return { ok: true };
 }
@@ -380,6 +411,18 @@ export async function setUserRolesAction(input: {
     }
   }
 
+  // Capture the prior role set so we can audit the diff (assigned /
+  // unassigned), not just the post-state. The viewer cares about
+  // "who got promoted to system_admin?", which is a delta question.
+  const prior = await db
+    .select({ roleId: schema.userRoles.roleId })
+    .from(schema.userRoles)
+    .where(eq(schema.userRoles.userId, input.userId));
+  const priorIds = new Set(prior.map((r) => r.roleId));
+  const nextIds = new Set(roleIds);
+  const assigned = roleIds.filter((id) => !priorIds.has(id));
+  const unassigned = [...priorIds].filter((id) => !nextIds.has(id));
+
   // Replace-all: delete existing assignments, insert new set.
   await db
     .delete(schema.userRoles)
@@ -393,6 +436,26 @@ export async function setUserRolesAction(input: {
       })),
     );
   }
+
+  // One row per added / removed role so the audit page can answer
+  // "who granted X this role?" with a single index lookup.
+  const events = [
+    ...assigned.map((roleId) => ({
+      actorUserId: principal.userId,
+      action: "role.assigned" as const,
+      targetUserId: input.userId,
+      targetType: "role",
+      targetId: roleId,
+    })),
+    ...unassigned.map((roleId) => ({
+      actorUserId: principal.userId,
+      action: "role.unassigned" as const,
+      targetUserId: input.userId,
+      targetType: "role",
+      targetId: roleId,
+    })),
+  ];
+  await recordAuditEvents(events);
 
   return { ok: true };
 }
@@ -451,7 +514,7 @@ export async function reorderRolesAction(input: {
 export async function bulkSetRolePermissionsAction(input: {
   roles: { roleId: string; permissionIds: string[] }[];
 }): Promise<{ ok: true }> {
-  await requireRolesManager();
+  const principal = await requireRolesManager();
 
   if (input.roles.length === 0) {
     return { ok: true };
@@ -504,6 +567,16 @@ export async function bulkSetRolePermissionsAction(input: {
   if (seen.has(ANONYMOUS_ROLE_ID)) {
     await invalidateAnonymousPermissionsCache();
   }
+
+  await recordAuditEvents(
+    input.roles.map((entry) => ({
+      actorUserId: principal.userId,
+      action: "role.permissions_set",
+      targetType: "role",
+      targetId: entry.roleId,
+      metadata: { permissionIds: entry.permissionIds },
+    })),
+  );
 
   return { ok: true };
 }

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as LegalRouteImport } from './routes/legal'
 import { Route as HealthRouteImport } from './routes/health'
 import { Route as DisclaimerRouteImport } from './routes/disclaimer'
 import { Route as DeactivatedRouteImport } from './routes/deactivated'
+import { Route as AuditRouteImport } from './routes/audit'
 import { Route as AntiHazingRouteImport } from './routes/anti-hazing'
 import { Route as AccountRouteImport } from './routes/account'
 import { Route as AboutRouteImport } from './routes/about'
@@ -102,6 +103,11 @@ const DisclaimerRoute = DisclaimerRouteImport.update({
 const DeactivatedRoute = DeactivatedRouteImport.update({
   id: '/deactivated',
   path: '/deactivated',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AuditRoute = AuditRouteImport.update({
+  id: '/audit',
+  path: '/audit',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AntiHazingRoute = AntiHazingRouteImport.update({
@@ -220,6 +226,7 @@ export interface FileRoutesByFullPath {
   '/about': typeof AboutRoute
   '/account': typeof AccountRouteWithChildren
   '/anti-hazing': typeof AntiHazingRoute
+  '/audit': typeof AuditRoute
   '/deactivated': typeof DeactivatedRoute
   '/disclaimer': typeof DisclaimerRoute
   '/health': typeof HealthRoute
@@ -255,6 +262,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/anti-hazing': typeof AntiHazingRoute
+  '/audit': typeof AuditRoute
   '/deactivated': typeof DeactivatedRoute
   '/disclaimer': typeof DisclaimerRoute
   '/health': typeof HealthRoute
@@ -291,6 +299,7 @@ export interface FileRoutesById {
   '/about': typeof AboutRoute
   '/account': typeof AccountRouteWithChildren
   '/anti-hazing': typeof AntiHazingRoute
+  '/audit': typeof AuditRoute
   '/deactivated': typeof DeactivatedRoute
   '/disclaimer': typeof DisclaimerRoute
   '/health': typeof HealthRoute
@@ -329,6 +338,7 @@ export interface FileRouteTypes {
     | '/about'
     | '/account'
     | '/anti-hazing'
+    | '/audit'
     | '/deactivated'
     | '/disclaimer'
     | '/health'
@@ -364,6 +374,7 @@ export interface FileRouteTypes {
     | '/'
     | '/about'
     | '/anti-hazing'
+    | '/audit'
     | '/deactivated'
     | '/disclaimer'
     | '/health'
@@ -399,6 +410,7 @@ export interface FileRouteTypes {
     | '/about'
     | '/account'
     | '/anti-hazing'
+    | '/audit'
     | '/deactivated'
     | '/disclaimer'
     | '/health'
@@ -436,6 +448,7 @@ export interface RootRouteChildren {
   AboutRoute: typeof AboutRoute
   AccountRoute: typeof AccountRouteWithChildren
   AntiHazingRoute: typeof AntiHazingRoute
+  AuditRoute: typeof AuditRoute
   DeactivatedRoute: typeof DeactivatedRoute
   DisclaimerRoute: typeof DisclaimerRoute
   HealthRoute: typeof HealthRoute
@@ -541,6 +554,13 @@ declare module '@tanstack/react-router' {
       path: '/deactivated'
       fullPath: '/deactivated'
       preLoaderRoute: typeof DeactivatedRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/audit': {
+      id: '/audit'
+      path: '/audit'
+      fullPath: '/audit'
+      preLoaderRoute: typeof AuditRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/anti-hazing': {
@@ -745,6 +765,7 @@ const rootRouteChildren: RootRouteChildren = {
   AboutRoute: AboutRoute,
   AccountRoute: AccountRouteWithChildren,
   AntiHazingRoute: AntiHazingRoute,
+  AuditRoute: AuditRoute,
   DeactivatedRoute: DeactivatedRoute,
   DisclaimerRoute: DisclaimerRoute,
   HealthRoute: HealthRoute,

--- a/apps/web/src/routes/audit.tsx
+++ b/apps/web/src/routes/audit.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { format, parseISO } from "date-fns";
 import { CalendarIcon, X } from "lucide-react";
 import { useCallback } from "react";
@@ -45,7 +45,6 @@ const AUDIT_ACTIONS = [
   "registration.unrejected",
   "member.deactivated",
   "member.reactivated",
-  "member.hard_deleted",
   "member.self_deleted",
   "profile.force_edited",
   "role.created",
@@ -59,8 +58,6 @@ const AUDIT_ACTIONS = [
   "landing.hero_slide_edited",
   "landing.activity_edited",
   "landing.faq_edited",
-  "announcement.published",
-  "announcement.deleted",
 ] as const;
 
 const PER_PAGE_OPTIONS = ["25", "50", "100", "200"] as const;
@@ -303,12 +300,15 @@ function DateRangeCalendar({
   onSelect: (range: DateRange | undefined) => void;
 }) {
   const today = new Date();
-  const fiveMonthsAgo = new Date(today.getFullYear(), today.getMonth() - 5, 1);
+  // Unlike the registrations queue (whose source rows are bounded by
+  // the user-retention sweeps), the audit log is intentionally
+  // retained beyond those windows and includes non-user events
+  // (landing edits, role changes) that have no retention sweep at
+  // all. Show three years of history so older incident reviews can
+  // still navigate to the right month — picking an earlier date than
+  // the table actually has is harmless (returns no rows).
+  const startMonth = new Date(today.getFullYear() - 3, today.getMonth(), 1);
 
-  // Audit log only goes as far back as the table was first written
-  // to (migration 0020), and the deactivation retention sweep gives
-  // the practical history a 12-month upper bound. Six visible months
-  // is more than enough for any realistic incident review.
   const scrollRef = useCallback((node: HTMLDivElement | null) => {
     if (node) {
       node.scrollTop = node.scrollHeight;
@@ -316,7 +316,7 @@ function DateRangeCalendar({
   }, []);
 
   return (
-    <div ref={scrollRef} className="max-h-[22rem] overflow-y-auto">
+    <div ref={scrollRef} className="max-h-88 overflow-y-auto">
       <Calendar
         mode="range"
         selected={dateRange}
@@ -325,7 +325,7 @@ function DateRangeCalendar({
         showOutsideDays={false}
         disabled={{ after: today }}
         classNames={{ months: "flex flex-col gap-4" }}
-        startMonth={fiveMonthsAgo}
+        startMonth={startMonth}
         endMonth={today}
         defaultMonth={today}
       />
@@ -350,7 +350,7 @@ function AuditCard({ entry }: { entry: AuditEntrySummary }) {
             {entry.action}
           </Badge>
           <CardTitle className="text-sm font-medium">
-            {describeActor(entry)}
+            <ActorLabel entry={entry} />
           </CardTitle>
         </div>
         <CardDescription className="text-xs">
@@ -360,21 +360,7 @@ function AuditCard({ entry }: { entry: AuditEntrySummary }) {
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-2 text-sm">
-        {entry.target ? (
-          <p>
-            Target:{" "}
-            <span className="font-medium">
-              {entry.target.preferredName ?? entry.target.email}
-            </span>
-          </p>
-        ) : entry.targetType && entry.targetId ? (
-          <p>
-            Target:{" "}
-            <code className="rounded bg-muted px-1 py-0.5 text-xs">
-              {entry.targetType}:{entry.targetId}
-            </code>
-          </p>
-        ) : null}
+        <TargetLabel entry={entry} />
         {entry.metadata ? (
           <pre className="overflow-x-auto rounded bg-muted p-2 text-xs">
             {JSON.stringify(entry.metadata, null, 2)}
@@ -385,9 +371,71 @@ function AuditCard({ entry }: { entry: AuditEntrySummary }) {
   );
 }
 
-function describeActor(entry: AuditEntrySummary): string {
-  if (!entry.actor) {
-    return "(deleted user)";
+function ActorLabel({ entry }: { entry: AuditEntrySummary }) {
+  if (entry.actor) {
+    const name = entry.actor.preferredName ?? entry.actor.email;
+    // Link to the member's profile page — fastest way to investigate
+    // "what else has this person done?".
+    return (
+      <Link
+        to="/members/$publicId"
+        params={{ publicId: entry.actor.publicId }}
+        className="underline-offset-2 hover:underline"
+      >
+        {name}
+      </Link>
+    );
   }
-  return entry.actor.preferredName ?? entry.actor.email;
+  // Actor FK has been cascade-NULLed (user hard-deleted). For
+  // self-delete events the original email is captured in metadata as
+  // a documented exception; surface it so the row remains useful.
+  const meta = entry.metadata;
+  if (typeof meta?.email === "string" && meta.email.length > 0) {
+    return (
+      <span className="text-muted-foreground">{meta.email} (deleted)</span>
+    );
+  }
+  return <span className="text-muted-foreground">(deleted user)</span>;
+}
+
+function TargetLabel({ entry }: { entry: AuditEntrySummary }) {
+  // User target with a live FK — link to their profile.
+  if (entry.target) {
+    const name = entry.target.preferredName ?? entry.target.email;
+    return (
+      <p>
+        Target:{" "}
+        <Link
+          to="/members/$publicId"
+          params={{ publicId: entry.target.publicId }}
+          className="font-medium underline-offset-2 hover:underline"
+        >
+          {name}
+        </Link>
+      </p>
+    );
+  }
+  // User target whose FK has cascaded to NULL — fall back to the
+  // metadata-captured email if the action documented one (today
+  // that's only `member.self_deleted`). Without this fallback, most
+  // historical member-targeted events lose their target label
+  // entirely after retention runs.
+  const meta = entry.metadata;
+  if (typeof meta?.email === "string" && meta.email.length > 0) {
+    return (
+      <p className="text-muted-foreground">Target: {meta.email} (deleted)</p>
+    );
+  }
+  // Non-user target (role / landing setting / waiver attestation).
+  if (entry.targetType && entry.targetId) {
+    return (
+      <p>
+        Target:{" "}
+        <code className="rounded bg-muted px-1 py-0.5 text-xs">
+          {entry.targetType}:{entry.targetId}
+        </code>
+      </p>
+    );
+  }
+  return null;
 }

--- a/apps/web/src/routes/audit.tsx
+++ b/apps/web/src/routes/audit.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { format, parseISO } from "date-fns";
+import { addDays, format, parseISO } from "date-fns";
 import { CalendarIcon, X } from "lucide-react";
 import { useCallback } from "react";
 import type { DateRange } from "react-day-picker";
@@ -46,6 +46,7 @@ const AUDIT_ACTIONS = [
   "member.deactivated",
   "member.reactivated",
   "member.self_deleted",
+  "member.sessions_revoked",
   "profile.force_edited",
   "role.created",
   "role.deleted",
@@ -59,6 +60,27 @@ const AUDIT_ACTIONS = [
   "landing.activity_edited",
   "landing.faq_edited",
 ] as const;
+
+// Actions whose `target_user_id` always points at a member. Used by
+// the viewer when the FK has cascade-NULLed (member hard-deleted) so
+// we can still render a "(deleted user)" placeholder instead of
+// silently dropping the target column. Non-user-targeted actions
+// (role.* on a role row, landing.* on a settings key, etc.) are
+// intentionally absent.
+const USER_TARGETED_ACTIONS = new Set<(typeof AUDIT_ACTIONS)[number]>([
+  "registration.approved",
+  "registration.rejected",
+  "registration.unrejected",
+  "member.deactivated",
+  "member.reactivated",
+  "member.self_deleted",
+  "member.sessions_revoked",
+  "profile.force_edited",
+  "role.assigned",
+  "role.unassigned",
+  "waiver.attested",
+  "waiver.revoked",
+]);
 
 const PER_PAGE_OPTIONS = ["25", "50", "100", "200"] as const;
 const DEFAULT_PER_PAGE = 50;
@@ -89,15 +111,19 @@ function toISODate(d: Date): string {
   return format(d, "yyyy-MM-dd");
 }
 
-// Inclusive `to` parses as start-of-day; the server expects an exclusive
-// upper bound, so add one day to capture events from the user's chosen
-// end date.
+// Inclusive `to` parses as start-of-day in local time; the server
+// expects an exclusive upper bound, so we want the start of the
+// NEXT calendar day. Use `addDays` rather than `+ 24h ms` because a
+// fixed millisecond offset is wrong across DST transitions — the
+// chosen day can be 23 or 25 hours long, and a flat +24h would
+// either include an hour of the next day or drop the last hour of
+// the chosen day. `addDays` does calendar arithmetic correctly.
 function dateRangeToMs(
   from: string | undefined,
   to: string | undefined,
 ): { fromMs: number | undefined; toMs: number | undefined } {
   const fromMs = from ? parseISO(from).getTime() : undefined;
-  const toMs = to ? parseISO(to).getTime() + 24 * 60 * 60 * 1000 : undefined;
+  const toMs = to ? addDays(parseISO(to), 1).getTime() : undefined;
   return { fromMs, toMs };
 }
 
@@ -425,6 +451,15 @@ function TargetLabel({ entry }: { entry: AuditEntrySummary }) {
     return (
       <p className="text-muted-foreground">Target: {meta.email} (deleted)</p>
     );
+  }
+  // User-targeted action whose FK has cascaded AND no email
+  // captured in metadata — e.g. an old `member.deactivated` whose
+  // target was later hard-deleted via the retention sweep. Show a
+  // generic deleted-user placeholder rather than dropping the
+  // target column entirely; otherwise the row reads as if it had
+  // no target at all.
+  if (USER_TARGETED_ACTIONS.has(entry.action)) {
+    return <p className="text-muted-foreground">Target: (deleted user)</p>;
   }
   // Non-user target (role / landing setting / waiver attestation).
   if (entry.targetType && entry.targetId) {

--- a/apps/web/src/routes/audit.tsx
+++ b/apps/web/src/routes/audit.tsx
@@ -1,0 +1,393 @@
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { format, parseISO } from "date-fns";
+import { CalendarIcon, X } from "lucide-react";
+import { useCallback } from "react";
+import type { DateRange } from "react-day-picker";
+import { z } from "zod";
+
+import { Badge } from "#/components/ui/badge";
+import { Button } from "#/components/ui/button";
+import { Calendar } from "#/components/ui/calendar";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "#/components/ui/card";
+import { DataPagination } from "#/components/data-pagination";
+import { Empty, EmptyHeader, EmptyTitle } from "#/components/ui/empty";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "#/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "#/components/ui/select";
+import { cn } from "#/lib/utils";
+import { requirePermission } from "#/features/auth/guards";
+import { listAuditEventsFn } from "#/server/audit/audit-fns";
+import type { AuditEntrySummary } from "#/server/audit/audit-fns";
+
+// Mirrors `auditAction` in `drizzle/schema.ts`. Re-stating here so the
+// route validator + filter UI don't need to import from the schema.
+// Order matters — `Select` renders the options in this order and
+// alphabetizing groups related events (registration.*, role.*, etc.).
+const AUDIT_ACTIONS = [
+  "registration.approved",
+  "registration.rejected",
+  "registration.unrejected",
+  "member.deactivated",
+  "member.reactivated",
+  "member.hard_deleted",
+  "member.self_deleted",
+  "profile.force_edited",
+  "role.created",
+  "role.deleted",
+  "role.permissions_set",
+  "role.assigned",
+  "role.unassigned",
+  "waiver.attested",
+  "waiver.revoked",
+  "landing.settings_edited",
+  "landing.hero_slide_edited",
+  "landing.activity_edited",
+  "landing.faq_edited",
+  "announcement.published",
+  "announcement.deleted",
+] as const;
+
+const PER_PAGE_OPTIONS = ["25", "50", "100", "200"] as const;
+const DEFAULT_PER_PAGE = 50;
+
+const ALL_ACTIONS_VALUE = "__all__";
+
+const auditSearchSchema = z.object({
+  action: z.enum(AUDIT_ACTIONS).optional(),
+  from: z.iso.date().optional(),
+  to: z.iso.date().optional(),
+  page: z.coerce.number().int().min(1).optional(),
+  perPage: z.coerce
+    .number()
+    .int()
+    .refine((n) => (PER_PAGE_OPTIONS as readonly string[]).includes(String(n)))
+    .optional(),
+});
+
+export const Route = createFileRoute("/audit")({
+  validateSearch: auditSearchSchema,
+  beforeLoad: async ({ context }) => {
+    await requirePermission(context.queryClient, "audit:view");
+  },
+  component: AuditPage,
+});
+
+function toISODate(d: Date): string {
+  return format(d, "yyyy-MM-dd");
+}
+
+// Inclusive `to` parses as start-of-day; the server expects an exclusive
+// upper bound, so add one day to capture events from the user's chosen
+// end date.
+function dateRangeToMs(
+  from: string | undefined,
+  to: string | undefined,
+): { fromMs: number | undefined; toMs: number | undefined } {
+  const fromMs = from ? parseISO(from).getTime() : undefined;
+  const toMs = to ? parseISO(to).getTime() + 24 * 60 * 60 * 1000 : undefined;
+  return { fromMs, toMs };
+}
+
+function AuditPage() {
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+
+  const action = search.action;
+  const page = search.page ?? 1;
+  const perPage = search.perPage ?? DEFAULT_PER_PAGE;
+  const { fromMs, toMs } = dateRangeToMs(search.from, search.to);
+
+  const dateRange: DateRange | undefined =
+    (search.from ?? search.to)
+      ? {
+          from: search.from ? parseISO(search.from) : undefined,
+          to: search.to ? parseISO(search.to) : undefined,
+        }
+      : undefined;
+
+  const setDateRange = (range: DateRange | undefined) => {
+    void navigate({
+      search: (prev) => ({
+        ...prev,
+        from: range?.from ? toISODate(range.from) : undefined,
+        to: range?.to ? toISODate(range.to) : undefined,
+        page: undefined, // reset to first page on filter change
+      }),
+    });
+  };
+
+  const setAction = (value: string) => {
+    void navigate({
+      search: (prev) => ({
+        ...prev,
+        action:
+          value === ALL_ACTIONS_VALUE
+            ? undefined
+            : (value as (typeof AUDIT_ACTIONS)[number]),
+        page: undefined,
+      }),
+    });
+  };
+
+  const setPerPage = (value: string) => {
+    void navigate({
+      search: (prev) => ({
+        ...prev,
+        perPage: Number(value),
+        page: undefined,
+      }),
+    });
+  };
+
+  const setPage = (p: number) => {
+    void navigate({
+      search: (prev) => ({
+        ...prev,
+        page: p === 1 ? undefined : p,
+      }),
+    });
+  };
+
+  const clearAll = () => {
+    void navigate({ search: {} });
+  };
+
+  const queryKey = [
+    "audit-events",
+    action ?? null,
+    fromMs ?? null,
+    toMs ?? null,
+    page,
+    perPage,
+  ];
+  const query = useQuery({
+    queryKey,
+    queryFn: () =>
+      listAuditEventsFn({
+        data: {
+          page,
+          perPage,
+          action,
+          from: fromMs,
+          to: toMs,
+        },
+      }),
+  });
+
+  const total = query.data?.totalCount ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / perPage));
+  const entries = query.data?.entries ?? [];
+  const hasFilters = Boolean(action ?? search.from ?? search.to);
+
+  const dateLabel = dateRange?.from
+    ? dateRange.to
+      ? `${formatDateLabel(dateRange.from)} – ${formatDateLabel(dateRange.to)}`
+      : `From ${formatDateLabel(dateRange.from)}`
+    : "Any date";
+
+  return (
+    <div className="space-y-6 p-4 md:p-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">Audit log</h1>
+        <p className="text-sm text-muted-foreground">
+          Append-only record of officer and admin actions: registration
+          decisions, role changes, waiver attestations, landing-page edits,
+          account deletions.
+        </p>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Select value={action ?? ALL_ACTIONS_VALUE} onValueChange={setAction}>
+          <SelectTrigger className="h-9 w-[18rem]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL_ACTIONS_VALUE}>All action types</SelectItem>
+            {AUDIT_ACTIONS.map((a) => (
+              <SelectItem key={a} value={a}>
+                {a}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button
+              variant="outline"
+              className={cn(
+                "h-9 justify-start gap-2 font-normal",
+                !dateRange && "text-muted-foreground",
+              )}
+            >
+              <CalendarIcon className="size-4" />
+              {dateLabel}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0" align="start">
+            <DateRangeCalendar dateRange={dateRange} onSelect={setDateRange} />
+          </PopoverContent>
+        </Popover>
+
+        {hasFilters ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={clearAll}
+            className="h-9 gap-1"
+          >
+            <X className="size-3.5" /> Clear filters
+          </Button>
+        ) : null}
+      </div>
+
+      {query.isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : query.isError ? (
+        <p className="text-sm text-destructive">
+          Couldn&rsquo;t load audit events. Reload the page to try again.
+        </p>
+      ) : entries.length > 0 ? (
+        <>
+          <div className="space-y-3">
+            {entries.map((entry) => (
+              <AuditCard key={entry.id} entry={entry} />
+            ))}
+          </div>
+          <DataPagination
+            page={page}
+            totalPages={totalPages}
+            total={total}
+            perPage={perPage}
+            perPageOptions={PER_PAGE_OPTIONS}
+            onPageChange={setPage}
+            onPerPageChange={setPerPage}
+          />
+        </>
+      ) : (
+        <Empty>
+          <EmptyHeader>
+            <EmptyTitle>
+              {hasFilters
+                ? "No audit events match the current filters"
+                : "No audit events yet"}
+            </EmptyTitle>
+          </EmptyHeader>
+        </Empty>
+      )}
+    </div>
+  );
+}
+
+function DateRangeCalendar({
+  dateRange,
+  onSelect,
+}: {
+  dateRange: DateRange | undefined;
+  onSelect: (range: DateRange | undefined) => void;
+}) {
+  const today = new Date();
+  const fiveMonthsAgo = new Date(today.getFullYear(), today.getMonth() - 5, 1);
+
+  // Audit log only goes as far back as the table was first written
+  // to (migration 0020), and the deactivation retention sweep gives
+  // the practical history a 12-month upper bound. Six visible months
+  // is more than enough for any realistic incident review.
+  const scrollRef = useCallback((node: HTMLDivElement | null) => {
+    if (node) {
+      node.scrollTop = node.scrollHeight;
+    }
+  }, []);
+
+  return (
+    <div ref={scrollRef} className="max-h-[22rem] overflow-y-auto">
+      <Calendar
+        mode="range"
+        selected={dateRange}
+        onSelect={onSelect}
+        numberOfMonths={6}
+        showOutsideDays={false}
+        disabled={{ after: today }}
+        classNames={{ months: "flex flex-col gap-4" }}
+        startMonth={fiveMonthsAgo}
+        endMonth={today}
+        defaultMonth={today}
+      />
+    </div>
+  );
+}
+
+function formatDateLabel(d: Date): string {
+  return d.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function AuditCard({ entry }: { entry: AuditEntrySummary }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <Badge variant="secondary" className="font-mono text-xs">
+            {entry.action}
+          </Badge>
+          <CardTitle className="text-sm font-medium">
+            {describeActor(entry)}
+          </CardTitle>
+        </div>
+        <CardDescription className="text-xs">
+          <time dateTime={new Date(entry.createdAt).toISOString()}>
+            {format(new Date(entry.createdAt), "PPpp")}
+          </time>
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-2 text-sm">
+        {entry.target ? (
+          <p>
+            Target:{" "}
+            <span className="font-medium">
+              {entry.target.preferredName ?? entry.target.email}
+            </span>
+          </p>
+        ) : entry.targetType && entry.targetId ? (
+          <p>
+            Target:{" "}
+            <code className="rounded bg-muted px-1 py-0.5 text-xs">
+              {entry.targetType}:{entry.targetId}
+            </code>
+          </p>
+        ) : null}
+        {entry.metadata ? (
+          <pre className="overflow-x-auto rounded bg-muted p-2 text-xs">
+            {JSON.stringify(entry.metadata, null, 2)}
+          </pre>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function describeActor(entry: AuditEntrySummary): string {
+  if (!entry.actor) {
+    return "(deleted user)";
+  }
+  return entry.actor.preferredName ?? entry.actor.email;
+}

--- a/apps/web/src/server/audit/__tests__/audit-log.test.ts
+++ b/apps/web/src/server/audit/__tests__/audit-log.test.ts
@@ -1,0 +1,388 @@
+import { eq } from "drizzle-orm";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type * as SessionServer from "#/server/auth/session.server";
+import { getDb, schema } from "#/server/db";
+import {
+  recordAuditEvent,
+  recordAuditEvents,
+} from "#/server/audit/audit-log.server";
+
+afterEach(async () => {
+  const db = getDb();
+  await db.delete(schema.auditLog);
+  await db.delete(schema.userRoles);
+  await db.delete(schema.profiles);
+  await db.delete(schema.users);
+});
+
+function uid(prefix: string): string {
+  return `${prefix}_${crypto.randomUUID()}`;
+}
+
+async function seedUser(): Promise<string> {
+  const id = uid("u");
+  await getDb()
+    .insert(schema.users)
+    .values({
+      id,
+      publicId: id,
+      email: `${id}@example.com`,
+      status: "approved",
+    });
+  return id;
+}
+
+describe("recordAuditEvent", () => {
+  it("inserts a row with the supplied fields", async () => {
+    const actor = await seedUser();
+    const target = await seedUser();
+
+    await recordAuditEvent({
+      actorUserId: actor,
+      action: "registration.approved",
+      targetUserId: target,
+    });
+
+    const rows = await getDb()
+      .select()
+      .from(schema.auditLog)
+      .where(eq(schema.auditLog.actorUserId, actor));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.action).toBe("registration.approved");
+    expect(rows[0]?.targetUserId).toBe(target);
+    expect(rows[0]?.metadataJson).toBeNull();
+  });
+
+  it("JSON-serializes metadata", async () => {
+    const actor = await seedUser();
+    await recordAuditEvent({
+      actorUserId: actor,
+      action: "role.permissions_set",
+      targetType: "role",
+      targetId: "role_president",
+      metadata: {
+        permissionIds: ["perm_a", "perm_b"],
+        note: "officer rotation",
+      },
+    });
+
+    const [row] = await getDb()
+      .select()
+      .from(schema.auditLog)
+      .where(eq(schema.auditLog.actorUserId, actor));
+    expect(row.metadataJson).not.toBeNull();
+    expect(JSON.parse(row.metadataJson ?? "")).toEqual({
+      permissionIds: ["perm_a", "perm_b"],
+      note: "officer rotation",
+    });
+  });
+
+  it("supports null actor for system-initiated events", async () => {
+    await recordAuditEvent({
+      actorUserId: null,
+      action: "member.self_deleted",
+      metadata: { userId: "u_gone", email: "gone@example.com" },
+    });
+
+    const rows = await getDb().select().from(schema.auditLog);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.actorUserId).toBeNull();
+  });
+});
+
+describe("recordAuditEvents (bulk)", () => {
+  it("inserts one row per input event", async () => {
+    const actor = await seedUser();
+    const t1 = await seedUser();
+    const t2 = await seedUser();
+    const t3 = await seedUser();
+
+    await recordAuditEvents([
+      { actorUserId: actor, action: "registration.approved", targetUserId: t1 },
+      { actorUserId: actor, action: "registration.approved", targetUserId: t2 },
+      { actorUserId: actor, action: "registration.approved", targetUserId: t3 },
+    ]);
+
+    const rows = await getDb()
+      .select()
+      .from(schema.auditLog)
+      .where(eq(schema.auditLog.actorUserId, actor));
+    expect(rows).toHaveLength(3);
+    expect(new Set(rows.map((r) => r.targetUserId))).toEqual(
+      new Set([t1, t2, t3]),
+    );
+  });
+
+  it("is a no-op on empty input (no `INSERT ... VALUES ()` SQL error)", async () => {
+    await expect(recordAuditEvents([])).resolves.toBeUndefined();
+    const rows = await getDb().select().from(schema.auditLog);
+    expect(rows).toHaveLength(0);
+  });
+});
+
+describe("FK cascade on user delete (the SET NULL invariant)", () => {
+  it("preserves the audit row when the actor is hard-deleted", async () => {
+    const actor = await seedUser();
+    const target = await seedUser();
+    await recordAuditEvent({
+      actorUserId: actor,
+      action: "registration.approved",
+      targetUserId: target,
+    });
+
+    // Delete the actor — schema FK is `ON DELETE SET NULL`.
+    await getDb().delete(schema.users).where(eq(schema.users.id, actor));
+
+    const rows = await getDb()
+      .select()
+      .from(schema.auditLog)
+      .where(eq(schema.auditLog.targetUserId, target));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.actorUserId).toBeNull();
+    expect(rows[0]?.action).toBe("registration.approved");
+  });
+
+  it("preserves the audit row when the target is hard-deleted", async () => {
+    const actor = await seedUser();
+    const target = await seedUser();
+    await recordAuditEvent({
+      actorUserId: actor,
+      action: "member.deactivated",
+      targetUserId: target,
+    });
+
+    await getDb().delete(schema.users).where(eq(schema.users.id, target));
+
+    const rows = await getDb()
+      .select()
+      .from(schema.auditLog)
+      .where(eq(schema.auditLog.actorUserId, actor));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.targetUserId).toBeNull();
+  });
+});
+
+// ── viewer (listAuditEventsAction) ──────────────────────────────────────
+
+const cookieJar = new Map<string, string>();
+vi.mock("@tanstack/react-start/server", () => ({
+  getCookie: (name: string) => cookieJar.get(name),
+  setCookie: (name: string, value: string) => {
+    cookieJar.set(name, value);
+  },
+  deleteCookie: (name: string) => {
+    cookieJar.delete(name);
+  },
+  getRequestHeader: () => undefined,
+}));
+
+vi.mock("#/server/auth/session.server", async () => {
+  const actual = await vi.importActual<typeof SessionServer>(
+    "#/server/auth/session.server",
+  );
+  return {
+    ...actual,
+    loadCurrentPrincipal: vi.fn(actual.loadCurrentPrincipal),
+  };
+});
+
+async function asViewer(
+  permissions: string[] = ["audit:view"],
+): Promise<string> {
+  const userId = await seedUser();
+  const { loadCurrentPrincipal } = await import("#/server/auth/session.server");
+  vi.mocked(loadCurrentPrincipal).mockResolvedValue({
+    userId,
+    email: `${userId}@example.com`,
+    status: "approved",
+    hasProfile: false,
+    avatarKey: null,
+    roles: [],
+    permissions,
+    rolePermissionMap: {},
+  });
+  return userId;
+}
+
+describe("listAuditEventsAction", () => {
+  it("returns events newest-first with totalCount", async () => {
+    await asViewer();
+    const actor = await seedUser();
+    // Insert three events with monotonically increasing timestamps so
+    // we can assert ordering deterministically.
+    await getDb()
+      .insert(schema.auditLog)
+      .values([
+        {
+          id: "audit_1",
+          actorUserId: actor,
+          action: "registration.approved",
+          createdAt: new Date(2026, 0, 1),
+        },
+        {
+          id: "audit_2",
+          actorUserId: actor,
+          action: "registration.rejected",
+          createdAt: new Date(2026, 0, 2),
+        },
+        {
+          id: "audit_3",
+          actorUserId: actor,
+          action: "member.deactivated",
+          createdAt: new Date(2026, 0, 3),
+        },
+      ]);
+
+    const { listAuditEventsAction } =
+      await import("#/server/audit/audit-actions.server");
+    const result = await listAuditEventsAction({});
+
+    expect(result.totalCount).toBe(3);
+    expect(result.entries.map((e) => e.id)).toEqual([
+      "audit_3",
+      "audit_2",
+      "audit_1",
+    ]);
+  });
+
+  it("filters by action", async () => {
+    await asViewer();
+    const actor = await seedUser();
+    await getDb()
+      .insert(schema.auditLog)
+      .values([
+        {
+          id: "audit_a",
+          actorUserId: actor,
+          action: "registration.approved",
+        },
+        {
+          id: "audit_b",
+          actorUserId: actor,
+          action: "landing.faq_edited",
+        },
+      ]);
+
+    const { listAuditEventsAction } =
+      await import("#/server/audit/audit-actions.server");
+    const result = await listAuditEventsAction({
+      action: "landing.faq_edited",
+    });
+
+    expect(result.totalCount).toBe(1);
+    expect(result.entries.map((e) => e.action)).toEqual(["landing.faq_edited"]);
+  });
+
+  it("filters by date range (inclusive `from`, exclusive `to`)", async () => {
+    await asViewer();
+    const actor = await seedUser();
+    await getDb()
+      .insert(schema.auditLog)
+      .values([
+        {
+          id: "audit_before",
+          actorUserId: actor,
+          action: "registration.approved",
+          createdAt: new Date("2026-04-30T23:59:00Z"),
+        },
+        {
+          id: "audit_in",
+          actorUserId: actor,
+          action: "registration.approved",
+          createdAt: new Date("2026-05-01T12:00:00Z"),
+        },
+        {
+          id: "audit_after",
+          actorUserId: actor,
+          action: "registration.approved",
+          createdAt: new Date("2026-05-02T00:00:00Z"),
+        },
+      ]);
+
+    const { listAuditEventsAction } =
+      await import("#/server/audit/audit-actions.server");
+    const result = await listAuditEventsAction({
+      from: new Date("2026-05-01T00:00:00Z").getTime(),
+      to: new Date("2026-05-02T00:00:00Z").getTime(),
+    });
+
+    expect(result.totalCount).toBe(1);
+    expect(result.entries.map((e) => e.id)).toEqual(["audit_in"]);
+  });
+
+  it("paginates with page + perPage", async () => {
+    await asViewer();
+    const actor = await seedUser();
+    const rows = Array.from({ length: 25 }, (_, i) => ({
+      id: `audit_${String(i).padStart(3, "0")}`,
+      actorUserId: actor,
+      action: "registration.approved" as const,
+      createdAt: new Date(2026, 0, 1, 0, i),
+    }));
+    await getDb().insert(schema.auditLog).values(rows);
+
+    const { listAuditEventsAction } =
+      await import("#/server/audit/audit-actions.server");
+    const page1 = await listAuditEventsAction({ page: 1, perPage: 10 });
+    const page2 = await listAuditEventsAction({ page: 2, perPage: 10 });
+    const page3 = await listAuditEventsAction({ page: 3, perPage: 10 });
+
+    expect(page1.totalCount).toBe(25);
+    expect(page1.entries).toHaveLength(10);
+    expect(page2.entries).toHaveLength(10);
+    expect(page3.entries).toHaveLength(5);
+    // No overlap between pages.
+    const ids = new Set([
+      ...page1.entries.map((e) => e.id),
+      ...page2.entries.map((e) => e.id),
+      ...page3.entries.map((e) => e.id),
+    ]);
+    expect(ids.size).toBe(25);
+  });
+
+  it("rejects callers without audit:view", async () => {
+    await asViewer([]); // no permissions
+
+    const { listAuditEventsAction } =
+      await import("#/server/audit/audit-actions.server");
+    await expect(listAuditEventsAction({})).rejects.toThrow(/audit:view/);
+  });
+
+  it("joins actor + target preferred name when profiles exist", async () => {
+    await asViewer();
+    const actorId = await seedUser();
+    const targetId = await seedUser();
+    await getDb()
+      .insert(schema.profiles)
+      .values([
+        {
+          userId: actorId,
+          fullName: "Alice Actor",
+          preferredName: "Alice",
+          phone: "+15555550001",
+          ucAffiliation: "student",
+        },
+        {
+          userId: targetId,
+          fullName: "Bob Target",
+          preferredName: "Bob",
+          phone: "+15555550002",
+          ucAffiliation: "student",
+        },
+      ]);
+    await getDb().insert(schema.auditLog).values({
+      id: "audit_join",
+      actorUserId: actorId,
+      action: "registration.approved",
+      targetUserId: targetId,
+    });
+
+    const { listAuditEventsAction } =
+      await import("#/server/audit/audit-actions.server");
+    const result = await listAuditEventsAction({});
+
+    expect(result.entries[0]?.actor?.preferredName).toBe("Alice");
+    expect(result.entries[0]?.target?.preferredName).toBe("Bob");
+  });
+});

--- a/apps/web/src/server/audit/__tests__/audit-log.test.ts
+++ b/apps/web/src/server/audit/__tests__/audit-log.test.ts
@@ -341,6 +341,58 @@ describe("listAuditEventsAction", () => {
     expect(ids.size).toBe(25);
   });
 
+  // Guards the pagination tiebreaker fix from PR #41 review:
+  // `recordAuditEvents` writes bulk rows with the same default
+  // `createdAt`, so without `desc(id)` as a secondary sort the
+  // page boundary could re-order ties between requests and skip
+  // or duplicate rows. With the tiebreaker, identical timestamps
+  // are sorted by id (uuidv7-prefixed, sorts lex with createdAt).
+  it("paginates stably across rows that share createdAt (id tiebreaker)", async () => {
+    await asViewer();
+    const actor = await seedUser();
+    const sharedTimestamp = new Date("2026-05-01T12:00:00Z");
+    // 10 rows with identical timestamps. Use ids that wouldn't sort
+    // in the same order as insertion to make the tiebreaker visible.
+    const rows = Array.from({ length: 10 }, (_, i) => ({
+      id: `audit_tie_${String(i).padStart(3, "0")}`,
+      actorUserId: actor,
+      action: "registration.approved" as const,
+      createdAt: sharedTimestamp,
+    }));
+    await getDb().insert(schema.auditLog).values(rows);
+
+    const { listAuditEventsAction } =
+      await import("#/server/audit/audit-actions.server");
+    const page1 = await listAuditEventsAction({ page: 1, perPage: 4 });
+    const page2 = await listAuditEventsAction({ page: 2, perPage: 4 });
+    const page3 = await listAuditEventsAction({ page: 3, perPage: 4 });
+
+    expect(page1.totalCount).toBe(10);
+    expect(page1.entries).toHaveLength(4);
+    expect(page2.entries).toHaveLength(4);
+    expect(page3.entries).toHaveLength(2);
+
+    const allIds = [
+      ...page1.entries.map((e) => e.id),
+      ...page2.entries.map((e) => e.id),
+      ...page3.entries.map((e) => e.id),
+    ];
+    // No duplicates and no skipped rows. `[...allIds].sort(...)`
+    // because `.sort()` mutates and we still need allIds in its
+    // original page-traversal order for the next assertion.
+    expect(new Set(allIds).size).toBe(10);
+    expect([...allIds].sort()).toEqual(rows.map((r) => r.id).sort());
+
+    // The order within tied rows is `desc(id)` — verify the page
+    // boundaries sit at the right positions instead of the planner
+    // returning rows in some other arbitrary order.
+    const expectedOrder = [...rows]
+      .map((r) => r.id)
+      .sort()
+      .reverse();
+    expect(allIds).toEqual(expectedOrder);
+  });
+
   it("rejects callers without audit:view", async () => {
     await asViewer([]); // no permissions
 

--- a/apps/web/src/server/audit/audit-actions.server.ts
+++ b/apps/web/src/server/audit/audit-actions.server.ts
@@ -12,20 +12,22 @@ import { getDb, schema } from "#/server/db";
 const PER_PAGE_DEFAULT = 50;
 const PER_PAGE_MAX = 200;
 
+export interface AuditUserRef {
+  userId: string;
+  /** `users.public_id` — the routable token used by `/members/$publicId`.
+   *  Exposed so the viewer can link to a member's profile without an
+   *  extra fetch. */
+  publicId: string;
+  preferredName: string | null;
+  email: string;
+}
+
 export interface AuditEntrySummary {
   id: string;
   action: schema.AuditAction;
   createdAt: number;
-  actor: {
-    userId: string;
-    preferredName: string | null;
-    email: string;
-  } | null;
-  target: {
-    userId: string;
-    preferredName: string | null;
-    email: string;
-  } | null;
+  actor: AuditUserRef | null;
+  target: AuditUserRef | null;
   /** Non-user target (role / landing setting / waiver attestation / etc.) */
   targetType: string | null;
   targetId: string | null;
@@ -113,9 +115,11 @@ export async function listAuditEventsAction(input: {
       action: schema.auditLog.action,
       createdAt: schema.auditLog.createdAt,
       actorUserId: schema.auditLog.actorUserId,
+      actorPublicId: actorUsers.publicId,
       actorEmail: actorUsers.email,
       actorPreferredName: actorProfiles.preferredName,
       targetUserId: schema.auditLog.targetUserId,
+      targetPublicId: targetUsers.publicId,
       targetEmail: targetUsers.email,
       targetPreferredName: targetProfiles.preferredName,
       targetType: schema.auditLog.targetType,
@@ -128,7 +132,14 @@ export async function listAuditEventsAction(input: {
     .leftJoin(targetUsers, eq(targetUsers.id, schema.auditLog.targetUserId))
     .leftJoin(targetProfiles, eq(targetProfiles.userId, targetUsers.id))
     .where(whereClause)
-    .orderBy(desc(schema.auditLog.createdAt))
+    // Tiebreak on `id` so pagination stays stable across requests
+    // even when many rows share the same `createdAt` — `recordAuditEvents`
+    // inserts bulk rows with the same default timestamp, so without
+    // the secondary sort the page boundary could skip or duplicate
+    // entries between requests. `id` is uuidv7-prefixed so newer ids
+    // sort lexicographically after older ones, matching createdAt
+    // direction.
+    .orderBy(desc(schema.auditLog.createdAt), desc(schema.auditLog.id))
     .limit(perPage)
     .offset(offset);
 
@@ -141,6 +152,7 @@ export async function listAuditEventsAction(input: {
       actor: r.actorUserId
         ? {
             userId: r.actorUserId,
+            publicId: r.actorPublicId ?? "",
             email: r.actorEmail ?? "",
             preferredName: r.actorPreferredName ?? null,
           }
@@ -148,6 +160,7 @@ export async function listAuditEventsAction(input: {
       target: r.targetUserId
         ? {
             userId: r.targetUserId,
+            publicId: r.targetPublicId ?? "",
             email: r.targetEmail ?? "",
             preferredName: r.targetPreferredName ?? null,
           }

--- a/apps/web/src/server/audit/audit-actions.server.ts
+++ b/apps/web/src/server/audit/audit-actions.server.ts
@@ -1,0 +1,177 @@
+/**
+ * Read-side actions for the audit log viewer at `/members/audit`. The
+ * viewer is read-only by design; writes go through `recordAuditEvent`
+ * in the various feature server modules. The shell wrapper is in
+ * `./audit-fns.ts`.
+ */
+import { aliasedTable, and, count, desc, eq, gte, lt } from "drizzle-orm";
+
+import { loadCurrentPrincipal } from "#/server/auth/session.server";
+import { getDb, schema } from "#/server/db";
+
+const PER_PAGE_DEFAULT = 50;
+const PER_PAGE_MAX = 200;
+
+export interface AuditEntrySummary {
+  id: string;
+  action: schema.AuditAction;
+  createdAt: number;
+  actor: {
+    userId: string;
+    preferredName: string | null;
+    email: string;
+  } | null;
+  target: {
+    userId: string;
+    preferredName: string | null;
+    email: string;
+  } | null;
+  /** Non-user target (role / landing setting / waiver attestation / etc.) */
+  targetType: string | null;
+  targetId: string | null;
+  /** Parsed metadata. `null` if absent or malformed JSON. The
+   *  serialization-friendly recursive type makes TanStack Start's
+   *  RPC checker happy without losing the "this came from a JSON
+   *  blob" shape. */
+  metadata: JsonObject | null;
+}
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+type JsonObject = { [key: string]: JsonValue };
+
+export interface ListAuditEventsResult {
+  entries: AuditEntrySummary[];
+  totalCount: number;
+}
+
+async function requireAuditViewer() {
+  const principal = await loadCurrentPrincipal();
+  if (!principal) {
+    throw new Error("Not signed in");
+  }
+  if (!principal.permissions.includes("audit:view")) {
+    throw new Error("Forbidden: missing audit:view");
+  }
+  return principal;
+}
+
+export async function listAuditEventsAction(input: {
+  page?: number;
+  perPage?: number;
+  /** Optional filter by action type. */
+  action?: schema.AuditAction;
+  /** Optional filter — start of the date range (inclusive), in ms. */
+  from?: number;
+  /** Optional filter — end of the date range (exclusive), in ms.
+   *  Callers wanting a "through end of day X" should pass the start
+   *  of day X+1. */
+  to?: number;
+}): Promise<ListAuditEventsResult> {
+  await requireAuditViewer();
+
+  const page = Math.max(1, input.page ?? 1);
+  const perPage = Math.min(input.perPage ?? PER_PAGE_DEFAULT, PER_PAGE_MAX);
+  const offset = (page - 1) * perPage;
+
+  const db = getDb();
+  const actorUsers = aliasedTable(schema.users, "actor_users");
+  const actorProfiles = aliasedTable(schema.profiles, "actor_profiles");
+  const targetUsers = aliasedTable(schema.users, "target_users");
+  const targetProfiles = aliasedTable(schema.profiles, "target_profiles");
+
+  const filters = [
+    input.action ? eq(schema.auditLog.action, input.action) : undefined,
+    input.from !== undefined
+      ? gte(schema.auditLog.createdAt, new Date(input.from))
+      : undefined,
+    input.to !== undefined
+      ? lt(schema.auditLog.createdAt, new Date(input.to))
+      : undefined,
+  ].filter((f): f is NonNullable<typeof f> => f !== undefined);
+
+  const whereClause = filters.length > 0 ? and(...filters) : undefined;
+
+  // Total count first so the UI can render correct page numbers even
+  // when the user lands directly on page N. Filtered indexes
+  // (`audit_log_action_idx`, `audit_log_created_at_idx`) keep this
+  // cheap.
+  const [{ totalCount }] = await db
+    .select({ totalCount: count() })
+    .from(schema.auditLog)
+    .where(whereClause);
+
+  const rows = await db
+    .select({
+      id: schema.auditLog.id,
+      action: schema.auditLog.action,
+      createdAt: schema.auditLog.createdAt,
+      actorUserId: schema.auditLog.actorUserId,
+      actorEmail: actorUsers.email,
+      actorPreferredName: actorProfiles.preferredName,
+      targetUserId: schema.auditLog.targetUserId,
+      targetEmail: targetUsers.email,
+      targetPreferredName: targetProfiles.preferredName,
+      targetType: schema.auditLog.targetType,
+      targetId: schema.auditLog.targetId,
+      metadataJson: schema.auditLog.metadataJson,
+    })
+    .from(schema.auditLog)
+    .leftJoin(actorUsers, eq(actorUsers.id, schema.auditLog.actorUserId))
+    .leftJoin(actorProfiles, eq(actorProfiles.userId, actorUsers.id))
+    .leftJoin(targetUsers, eq(targetUsers.id, schema.auditLog.targetUserId))
+    .leftJoin(targetProfiles, eq(targetProfiles.userId, targetUsers.id))
+    .where(whereClause)
+    .orderBy(desc(schema.auditLog.createdAt))
+    .limit(perPage)
+    .offset(offset);
+
+  return {
+    totalCount,
+    entries: rows.map((r) => ({
+      id: r.id,
+      action: r.action,
+      createdAt: r.createdAt.getTime(),
+      actor: r.actorUserId
+        ? {
+            userId: r.actorUserId,
+            email: r.actorEmail ?? "",
+            preferredName: r.actorPreferredName ?? null,
+          }
+        : null,
+      target: r.targetUserId
+        ? {
+            userId: r.targetUserId,
+            email: r.targetEmail ?? "",
+            preferredName: r.targetPreferredName ?? null,
+          }
+        : null,
+      targetType: r.targetType,
+      targetId: r.targetId,
+      metadata: parseMetadata(r.metadataJson),
+    })),
+  };
+}
+
+function parseMetadata(json: string | null): JsonObject | null {
+  if (!json) {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      // Trust the JSON parse output to be a serializable tree; we
+      // wrote it ourselves on the way in.
+      return parsed as JsonObject;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/server/audit/audit-actions.server.ts
+++ b/apps/web/src/server/audit/audit-actions.server.ts
@@ -1,7 +1,7 @@
 /**
- * Read-side actions for the audit log viewer at `/members/audit`. The
- * viewer is read-only by design; writes go through `recordAuditEvent`
- * in the various feature server modules. The shell wrapper is in
+ * Read-side actions for the audit log viewer at `/audit`. The viewer
+ * is read-only by design; writes go through `recordAuditEvent` in
+ * the various feature server modules. The shell wrapper is in
  * `./audit-fns.ts`.
  */
 import { aliasedTable, and, count, desc, eq, gte, lt } from "drizzle-orm";
@@ -100,48 +100,48 @@ export async function listAuditEventsAction(input: {
 
   const whereClause = filters.length > 0 ? and(...filters) : undefined;
 
-  // Total count first so the UI can render correct page numbers even
-  // when the user lands directly on page N. Filtered indexes
-  // (`audit_log_action_idx`, `audit_log_created_at_idx`) keep this
-  // cheap.
-  const [{ totalCount }] = await db
-    .select({ totalCount: count() })
-    .from(schema.auditLog)
-    .where(whereClause);
-
-  const rows = await db
-    .select({
-      id: schema.auditLog.id,
-      action: schema.auditLog.action,
-      createdAt: schema.auditLog.createdAt,
-      actorUserId: schema.auditLog.actorUserId,
-      actorPublicId: actorUsers.publicId,
-      actorEmail: actorUsers.email,
-      actorPreferredName: actorProfiles.preferredName,
-      targetUserId: schema.auditLog.targetUserId,
-      targetPublicId: targetUsers.publicId,
-      targetEmail: targetUsers.email,
-      targetPreferredName: targetProfiles.preferredName,
-      targetType: schema.auditLog.targetType,
-      targetId: schema.auditLog.targetId,
-      metadataJson: schema.auditLog.metadataJson,
-    })
-    .from(schema.auditLog)
-    .leftJoin(actorUsers, eq(actorUsers.id, schema.auditLog.actorUserId))
-    .leftJoin(actorProfiles, eq(actorProfiles.userId, actorUsers.id))
-    .leftJoin(targetUsers, eq(targetUsers.id, schema.auditLog.targetUserId))
-    .leftJoin(targetProfiles, eq(targetProfiles.userId, targetUsers.id))
-    .where(whereClause)
-    // Tiebreak on `id` so pagination stays stable across requests
-    // even when many rows share the same `createdAt` — `recordAuditEvents`
-    // inserts bulk rows with the same default timestamp, so without
-    // the secondary sort the page boundary could skip or duplicate
-    // entries between requests. `id` is uuidv7-prefixed so newer ids
-    // sort lexicographically after older ones, matching createdAt
-    // direction.
-    .orderBy(desc(schema.auditLog.createdAt), desc(schema.auditLog.id))
-    .limit(perPage)
-    .offset(offset);
+  // Count + page query are independent — run them in parallel so
+  // every /audit load saves a D1 round-trip. Filtered indexes
+  // (`audit_log_action_idx`, `audit_log_created_at_idx`) keep the
+  // count cheap. The two queries use the same `whereClause` so
+  // their result sets are consistent for any page the UI shows.
+  const [countResult, rows] = await Promise.all([
+    db.select({ totalCount: count() }).from(schema.auditLog).where(whereClause),
+    db
+      .select({
+        id: schema.auditLog.id,
+        action: schema.auditLog.action,
+        createdAt: schema.auditLog.createdAt,
+        actorUserId: schema.auditLog.actorUserId,
+        actorPublicId: actorUsers.publicId,
+        actorEmail: actorUsers.email,
+        actorPreferredName: actorProfiles.preferredName,
+        targetUserId: schema.auditLog.targetUserId,
+        targetPublicId: targetUsers.publicId,
+        targetEmail: targetUsers.email,
+        targetPreferredName: targetProfiles.preferredName,
+        targetType: schema.auditLog.targetType,
+        targetId: schema.auditLog.targetId,
+        metadataJson: schema.auditLog.metadataJson,
+      })
+      .from(schema.auditLog)
+      .leftJoin(actorUsers, eq(actorUsers.id, schema.auditLog.actorUserId))
+      .leftJoin(actorProfiles, eq(actorProfiles.userId, actorUsers.id))
+      .leftJoin(targetUsers, eq(targetUsers.id, schema.auditLog.targetUserId))
+      .leftJoin(targetProfiles, eq(targetProfiles.userId, targetUsers.id))
+      .where(whereClause)
+      // Tiebreak on `id` so pagination stays stable across requests
+      // even when many rows share the same `createdAt` —
+      // `recordAuditEvents` inserts bulk rows with the same default
+      // timestamp, so without the secondary sort the page boundary
+      // could skip or duplicate entries between requests. `id` is
+      // uuidv7-prefixed so newer ids sort lexicographically after
+      // older ones, matching createdAt direction.
+      .orderBy(desc(schema.auditLog.createdAt), desc(schema.auditLog.id))
+      .limit(perPage)
+      .offset(offset),
+  ]);
+  const totalCount = countResult[0]?.totalCount ?? 0;
 
   return {
     totalCount,

--- a/apps/web/src/server/audit/audit-fns.ts
+++ b/apps/web/src/server/audit/audit-fns.ts
@@ -23,6 +23,7 @@ const auditActionEnum = z.enum([
   "member.deactivated",
   "member.reactivated",
   "member.self_deleted",
+  "member.sessions_revoked",
   "profile.force_edited",
   "role.created",
   "role.deleted",

--- a/apps/web/src/server/audit/audit-fns.ts
+++ b/apps/web/src/server/audit/audit-fns.ts
@@ -22,7 +22,6 @@ const auditActionEnum = z.enum([
   "registration.unrejected",
   "member.deactivated",
   "member.reactivated",
-  "member.hard_deleted",
   "member.self_deleted",
   "profile.force_edited",
   "role.created",
@@ -36,8 +35,6 @@ const auditActionEnum = z.enum([
   "landing.hero_slide_edited",
   "landing.activity_edited",
   "landing.faq_edited",
-  "announcement.published",
-  "announcement.deleted",
 ]);
 
 export const listAuditEventsInputSchema = z.object({

--- a/apps/web/src/server/audit/audit-fns.ts
+++ b/apps/web/src/server/audit/audit-fns.ts
@@ -1,0 +1,58 @@
+/**
+ * Server-fn shells for the audit log viewer. Implementation lives in
+ * `./audit-actions.server.ts`; handler bodies dynamic-import to keep
+ * server-only code off the client module graph.
+ */
+import { createServerFn } from "@tanstack/react-start";
+import { z } from "zod";
+
+import type {
+  AuditEntrySummary,
+  ListAuditEventsResult,
+} from "#/server/audit/audit-actions.server";
+
+export type { AuditEntrySummary, ListAuditEventsResult };
+
+// Mirror of the `auditAction` enum in `drizzle/schema.ts`. Re-declaring
+// the values here keeps the client bundle from pulling in the entire
+// schema file just to validate a string filter.
+const auditActionEnum = z.enum([
+  "registration.approved",
+  "registration.rejected",
+  "registration.unrejected",
+  "member.deactivated",
+  "member.reactivated",
+  "member.hard_deleted",
+  "member.self_deleted",
+  "profile.force_edited",
+  "role.created",
+  "role.deleted",
+  "role.permissions_set",
+  "role.assigned",
+  "role.unassigned",
+  "waiver.attested",
+  "waiver.revoked",
+  "landing.settings_edited",
+  "landing.hero_slide_edited",
+  "landing.activity_edited",
+  "landing.faq_edited",
+  "announcement.published",
+  "announcement.deleted",
+]);
+
+export const listAuditEventsInputSchema = z.object({
+  page: z.number().int().min(1).optional(),
+  perPage: z.number().int().min(1).max(200).optional(),
+  action: auditActionEnum.optional(),
+  /** Inclusive start of date range (ms). */
+  from: z.number().int().nonnegative().optional(),
+  /** Exclusive end of date range (ms). */
+  to: z.number().int().nonnegative().optional(),
+});
+
+export const listAuditEventsFn = createServerFn({ method: "GET" })
+  .inputValidator(listAuditEventsInputSchema)
+  .handler(async ({ data }): Promise<ListAuditEventsResult> => {
+    const { listAuditEventsAction } = await import("./audit-actions.server");
+    return listAuditEventsAction(data);
+  });

--- a/apps/web/src/server/audit/audit-log.server.ts
+++ b/apps/web/src/server/audit/audit-log.server.ts
@@ -1,0 +1,83 @@
+/**
+ * Append-only audit log writes. Called from every officer / admin
+ * action whose effect we want to be reconstructable after the fact —
+ * registration approvals, role changes, waiver attestations, landing
+ * edits, hard deletes.
+ *
+ * **Strict, not best-effort.** A failed audit insert throws and
+ * propagates back to the caller, which means the parent action fails
+ * too. That's deliberate: silently dropping audit events would defeat
+ * the constitutional CSA paper-trail purpose of the table. Better to
+ * surface a transient D1 error to the officer (who can retry) than to
+ * lose the record.
+ *
+ * **PII discipline.** `metadata` is for non-PII context only — role
+ * names, status transitions, decision text, counts. Never email,
+ * phone, full name, or anything reversible to a specific person; that
+ * comes from the FK relationships if the row still exists.
+ *
+ * **One exception:** `member.self_deleted` and `member.hard_deleted`
+ * cascade-NULL both `actorUserId` and `targetUserId` immediately on
+ * the user-row delete, leaving the audit row with no attribution at
+ * all. For those two events specifically, capture `email` (and the
+ * original `userId` as a text value) in `metadata` so the row stays
+ * meaningful — that's the whole point of preserving an audit trail
+ * across deletions. No other event type should follow this pattern.
+ *
+ * The schema doc-comment in `drizzle/schema.ts` is the canonical
+ * statement of this rule.
+ */
+import { uuidv7 } from "uuidv7";
+
+import { getDb, schema } from "#/server/db";
+
+export type AuditAction = schema.AuditAction;
+
+export interface AuditEventInput {
+  /** The officer / admin performing the action. NULL only for
+   *  system-initiated events (none today; reserved for future cron
+   *  actions that mutate state). */
+  actorUserId: string | null;
+  action: AuditAction;
+  /** The user the action targets. Use this for any user-targeted
+   *  event so the audit page can join across users + actions. */
+  targetUserId?: string | null;
+  /** For non-user targets — role IDs, landing setting keys,
+   *  announcement IDs. Pair with `targetId`. */
+  targetType?: string | null;
+  targetId?: string | null;
+  /** Non-PII context. Will be JSON-serialized. See module-level
+   *  doc-comment for what's allowed. */
+  metadata?: Record<string, unknown>;
+}
+
+function buildRow(event: AuditEventInput) {
+  return {
+    id: `audit_${uuidv7()}`,
+    actorUserId: event.actorUserId,
+    action: event.action,
+    targetUserId: event.targetUserId ?? null,
+    targetType: event.targetType ?? null,
+    targetId: event.targetId ?? null,
+    metadataJson: event.metadata ? JSON.stringify(event.metadata) : null,
+  };
+}
+
+export async function recordAuditEvent(event: AuditEventInput): Promise<void> {
+  await getDb().insert(schema.auditLog).values(buildRow(event));
+}
+
+/**
+ * Bulk variant for actions that touch multiple targets in one call
+ * (approve N members, attest a stack of paper waivers, etc.). One
+ * audit row per target so the per-user view stays granular. Empty
+ * input is a no-op.
+ */
+export async function recordAuditEvents(
+  events: AuditEventInput[],
+): Promise<void> {
+  if (events.length === 0) {
+    return;
+  }
+  await getDb().insert(schema.auditLog).values(events.map(buildRow));
+}

--- a/apps/web/src/server/audit/audit-log.server.ts
+++ b/apps/web/src/server/audit/audit-log.server.ts
@@ -16,13 +16,14 @@
  * phone, full name, or anything reversible to a specific person; that
  * comes from the FK relationships if the row still exists.
  *
- * **One exception:** `member.self_deleted` and `member.hard_deleted`
- * cascade-NULL both `actorUserId` and `targetUserId` immediately on
- * the user-row delete, leaving the audit row with no attribution at
- * all. For those two events specifically, capture `email` (and the
- * original `userId` as a text value) in `metadata` so the row stays
- * meaningful — that's the whole point of preserving an audit trail
- * across deletions. No other event type should follow this pattern.
+ * **One exception:** `member.self_deleted` cascade-NULLs both
+ * `actorUserId` and `targetUserId` immediately on the user-row
+ * delete, leaving the audit row with no attribution at all. For that
+ * event specifically, capture `email` (and the original `userId` as
+ * a text value) in `metadata` so the row stays meaningful — that's
+ * the whole point of preserving an audit trail across deletions. No
+ * other event type follows this pattern; if you find yourself adding
+ * one, the audit story for that flow is probably wrong.
  *
  * The schema doc-comment in `drizzle/schema.ts` is the canonical
  * statement of this rule.

--- a/apps/web/src/server/audit/audit-log.server.ts
+++ b/apps/web/src/server/audit/audit-log.server.ts
@@ -1,8 +1,18 @@
 /**
- * Append-only audit log writes. Called from every officer / admin
- * action whose effect we want to be reconstructable after the fact —
- * registration approvals, role changes, waiver attestations, landing
- * edits, hard deletes.
+ * Append-only audit log writes. Called from officer / admin actions
+ * whose effect we want to be reconstructable after the fact — the
+ * lifecycle state transitions on `users`, RBAC mutations, waiver
+ * attestations, landing-page CRUD, member self-delete, and
+ * officer-initiated session revocation. The `auditAction` enum in
+ * `drizzle/schema.ts` is the canonical list.
+ *
+ * **What's deliberately NOT audited.** Cosmetic/no-effect mutations
+ * are skipped to keep the log signal-to-noise high: role description
+ * edits (`updateRoleAction`), and reorder operations across roles,
+ * hero slides, FAQ items, and activities. These don't change *what*
+ * the system says or does, only the order it presents things in.
+ * Reconstructing intent from order changes would also require a
+ * before/after diff that we don't capture today.
  *
  * **Strict, not best-effort.** A failed audit insert throws and
  * propagates back to the caller, which means the parent action fails


### PR DESCRIPTION
## Summary

Closes W-7 from the compliance roadmap. Constitutionally load-bearing now that the retention cron auto-deletes user rows: a member rejected for cause and then auto-purged 30 days later otherwise leaves zero trace anywhere else.

Two commits:

1. **`feat: append-only audit log + writes from every officer/admin action`** — schema + permission + helper + wiring across every officer/admin write path. Tests.
2. **`feat: /audit viewer with action + date-range filters and pagination`** — read path, server-fn shell, viewer route, sidebar link.

## Schema (`audit_log`)

Append-only by discipline — nothing in the app does UPDATE or DELETE here, the retention cron explicitly skips it. `actor_user_id` and `target_user_id` are FKs with `ON DELETE SET NULL` so a hard-deleted user doesn't take their audit history with them. Indexes on `created_at`, `actor`, `target_user`, `action` cover the four common queries.

The action column is a typed enum (19 values in v1, including the new `member.sessions_revoked`) — typos surface at compile time, and adding a new event type is an explicit migration rather than a free-form string. PII discipline is documented in the schema doc-comment: `metadata_json` is for non-PII context only (role names, status transitions, decision text, counts), with one explicit exception for `member.self_deleted` where the FK cascade nulls both actor + target and we capture `email + userId` in metadata to preserve attribution.

## Permission (`audit:view`)

- `system_admin` gets it via the all-perms bypass in `principal.server.ts`
- `advisor` is granted by default (constitutional CSA reporter — should not need a `system_admin` elevation to see incident-relevant events)
- `treasurer` and `president` do **not** get it — their constitutional duties (waiver attestation, financial actions) don't require browsing the log

## Wiring

Every officer/admin write path now records an audit event. Bulk operations write one row per affected user (so "who promoted Alice to system_admin?" is a single index lookup):

- approve / reject / unreject / deactivate / reactivate
- admin profile force-edit
- role create / delete / permissions_set (single + bulk)
- role assignment (one row per added/removed role — the diff, not the post-state)
- waiver attest (single + bulk) / revoke
- landing settings + hero slide + activity + FAQ create/update/delete
- section image (about / meeting) set/remove
- self-delete

`recordAuditEvent` is **strict** — a failed audit insert throws and propagates to the parent action. Silently dropping audit events would defeat the constitutional CSA paper-trail purpose; better to surface a transient D1 error to the officer (who can retry).

## Viewer (`/audit`)

Top-level route, **not** under `/members` — the audit log spans landing edits / role changes / waiver attestations / account deletions and isn't really "member management". Sidebar link is a sibling of "Members".

Filters:
- **Action type** — single select with all 21 actions
- **Date range** — date-range picker (inclusive `from`, exclusive `to` server-side; the route adds 24h to `to` so a user-selected end date includes everything from that day)
- **Pagination** — `DataPagination` with 25 / 50 / 100 / 200 per-page options. Filter + page state lives in URL search params so links and refreshes round-trip.

Each entry renders:
- Action badge (monospace, the literal action name)
- Actor name (preferred name → email → "(deleted user)")
- Timestamp
- Target user link (preferred name → email) OR typed `targetType:targetId` for non-user targets
- JSON metadata preview when present

## Test plan

- [x] `pnpm --filter ucmc-web lint` — 0 errors
- [x] `pnpm --filter ucmc-web typecheck` — clean
- [x] `pnpm --filter ucmc-web test` — 269 tests pass (13 new for audit log)
- [x] `pnpm --filter ucmc-web build` — worker bundles cleanly
- [x] Migrations apply locally
- [ ] Manual: as system_admin, approve a registration → confirm a `registration.approved` row appears at /audit with the right actor/target
- [ ] Manual: hard-delete a user → confirm their audit rows survive with actor/target nulled to "(deleted user)"
- [ ] Manual: as advisor, /audit loads; as treasurer, /audit redirects to / (no audit:view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
