### PR TITLE
perf(ucmc-web): SQL optimization pass — fewer round-trips and one correctness fix

### DIFF
--- a/apps/web/src/features/announcements/server/repo.server.ts
+++ b/apps/web/src/features/announcements/server/repo.server.ts
@@ -133,12 +133,14 @@ export async function deleteAnnouncement(id: string): Promise<void> {
  * unread. A subquery keeps this to one D1 round-trip instead of two
  * (user lookup + count).
  *
- * If the userId doesn't exist, the COALESCE makes the marker `0`, so
- * every announcement counts as unread. That matches the prior contract
- * for never-seen-before users; the only behavior change is the missing-
- * user case (previously returned 0), which isn't reachable from caller
- * code today (only signed-in users hit this, and a missing row would
- * already have failed at the principal layer).
+ * COALESCE falls back to `-1` (not `0`) for the null marker / missing-
+ * user case so that a hypothetical `published_at = 0` row still
+ * satisfies the strict `>` comparison and counts as unread. The
+ * timestamp column stores `unixepoch() * 1000` and never legitimately
+ * lands on 0, but the `-1` sentinel keeps the "every announcement is
+ * unread" semantics literal regardless of stored values. The missing-
+ * user case isn't reachable from caller code today (only signed-in
+ * users hit this), but the sentinel makes the contract explicit.
  */
 export async function getUnreadCount(userId: string): Promise<number> {
   const db = getDb();
@@ -148,7 +150,7 @@ export async function getUnreadCount(userId: string): Promise<number> {
     .where(
       gt(
         schema.announcements.publishedAt,
-        sql`COALESCE((SELECT ${schema.users.lastReadAnnouncementsAt} FROM ${schema.users} WHERE ${schema.users.id} = ${userId}), 0)`,
+        sql`COALESCE((SELECT ${schema.users.lastReadAnnouncementsAt} FROM ${schema.users} WHERE ${schema.users.id} = ${userId}), -1)`,
       ),
     );
   return rows[0]?.value ?? 0;

--- a/apps/web/src/features/announcements/server/repo.server.ts
+++ b/apps/web/src/features/announcements/server/repo.server.ts
@@ -3,7 +3,7 @@
  * actions layer is responsible for authorization. Joins users + profiles
  * to project the author's display name and avatar key alongside each row.
  */
-import { and, count, desc, eq, gt } from "drizzle-orm";
+import { and, count, desc, eq, gt, sql } from "drizzle-orm";
 
 import { getDb, schema } from "#/server/db";
 
@@ -130,22 +130,27 @@ export async function deleteAnnouncement(id: string): Promise<void> {
 /**
  * Count announcements published after the user's last-read marker. A null
  * marker means they have never opened the page, so every announcement is
- * unread.
+ * unread. A subquery keeps this to one D1 round-trip instead of two
+ * (user lookup + count).
+ *
+ * If the userId doesn't exist, the COALESCE makes the marker `0`, so
+ * every announcement counts as unread. That matches the prior contract
+ * for never-seen-before users; the only behavior change is the missing-
+ * user case (previously returned 0), which isn't reachable from caller
+ * code today (only signed-in users hit this, and a missing row would
+ * already have failed at the principal layer).
  */
 export async function getUnreadCount(userId: string): Promise<number> {
   const db = getDb();
-  const user = await db.query.users.findFirst({
-    where: eq(schema.users.id, userId),
-    columns: { lastReadAnnouncementsAt: true },
-  });
-  if (!user) {
-    return 0;
-  }
-  const marker = user.lastReadAnnouncementsAt;
-  const query = db.select({ value: count() }).from(schema.announcements);
-  const rows = marker
-    ? await query.where(gt(schema.announcements.publishedAt, marker))
-    : await query;
+  const rows = await db
+    .select({ value: count() })
+    .from(schema.announcements)
+    .where(
+      gt(
+        schema.announcements.publishedAt,
+        sql`COALESCE((SELECT ${schema.users.lastReadAnnouncementsAt} FROM ${schema.users} WHERE ${schema.users.id} = ${userId}), 0)`,
+      ),
+    );
   return rows[0]?.value ?? 0;
 }
 

--- a/apps/web/src/features/auth/server/__tests__/auth-flows.test.ts
+++ b/apps/web/src/features/auth/server/__tests__/auth-flows.test.ts
@@ -7,7 +7,11 @@
  * Same mock strategy as server-fns.test.ts: cookie jar for session/proof
  * cookies, rate-limit stubs always-allow, turnstile stub always-pass.
  */
-import { eq as drizzleEq } from "drizzle-orm";
+import {
+  and as drizzleAnd,
+  eq as drizzleEq,
+  ne as drizzleNe,
+} from "drizzle-orm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type * as Resend from "#/server/email/resend";
@@ -534,13 +538,16 @@ describe("list pending registrations", () => {
   });
 });
 
-describe("submit-profile status race", () => {
-  it("does not clobber an approved status when a returning approved user re-submits without a profile", async () => {
-    // Returning user: signed in via session (principal-based call site),
-    // approved by an officer, but somehow has no profiles row — this is
-    // the path that re-runs `submitProfileAction` with the principal
-    // path. The status reset's WHERE clause must not flip them back to
-    // pending.
+describe("submit-profile status reset", () => {
+  // Sanity-level contract test: a returning approved user re-submitting
+  // their profile keeps `approved` status. JavaScript is single-threaded
+  // and the action loads the principal at the top, so there's no clean
+  // way to interleave an approver's UPDATE between principal-load and
+  // batch-commit from inside one test. The actual race-fix coverage is
+  // the SQL-primitive test below — together they show:
+  //   (a) end-to-end: approved + resubmit = still approved
+  //   (b) primitive: the WHERE-guarded UPDATE no-ops on an approved row
+  it("approved user re-submitting without a profile keeps approved status", async () => {
     const userId = await seedUser({
       email: TEST_EMAIL,
       status: "approved",
@@ -555,10 +562,7 @@ describe("submit-profile status race", () => {
     expect(after!.status).toBe("approved");
   });
 
-  it("still resets a pending user back to pending after profile re-submit", async () => {
-    // Sanity check that the WHERE-guarded UPDATE still fires when the
-    // user is genuinely not-approved. Status stays pending (already its
-    // value), but the path is the one that mattered before the race fix.
+  it("pending user re-submitting profile stays pending", async () => {
     const userId = await seedUser({
       email: TEST_EMAIL,
       status: "pending",
@@ -571,6 +575,38 @@ describe("submit-profile status race", () => {
       where: (u, { eq }) => eq(u.id, userId),
     });
     expect(after!.status).toBe("pending");
+  });
+
+  it("WHERE-guarded UPDATE no-ops on an approved row (race-fix primitive)", async () => {
+    // Direct exercise of the SQL guard `submitProfileAction` relies on.
+    // Models the production race: an approver flips `users.status` to
+    // "approved" between the action's `loadCurrentPrincipal` and its
+    // batch commit. Without the WHERE clause, the unconditional
+    // `SET status = 'pending'` would revert the approver's decision;
+    // with it, the UPDATE matches zero rows and the approval survives.
+    const userId = await seedUser({
+      email: TEST_EMAIL,
+      status: "approved",
+    });
+
+    const updated = await getDb()
+      .update(schema.users)
+      .set({ status: "pending" })
+      .where(
+        drizzleAnd(
+          drizzleEq(schema.users.id, userId),
+          drizzleNe(schema.users.status, "approved"),
+        ),
+      )
+      .returning({ id: schema.users.id });
+
+    // Guard fired — zero rows touched.
+    expect(updated).toHaveLength(0);
+
+    const after = await getDb().query.users.findFirst({
+      where: (u, { eq }) => eq(u.id, userId),
+    });
+    expect(after!.status).toBe("approved");
   });
 });
 

--- a/apps/web/src/features/auth/server/__tests__/auth-flows.test.ts
+++ b/apps/web/src/features/auth/server/__tests__/auth-flows.test.ts
@@ -534,6 +534,46 @@ describe("list pending registrations", () => {
   });
 });
 
+describe("submit-profile status race", () => {
+  it("does not clobber an approved status when a returning approved user re-submits without a profile", async () => {
+    // Returning user: signed in via session (principal-based call site),
+    // approved by an officer, but somehow has no profiles row — this is
+    // the path that re-runs `submitProfileAction` with the principal
+    // path. The status reset's WHERE clause must not flip them back to
+    // pending.
+    const userId = await seedUser({
+      email: TEST_EMAIL,
+      status: "approved",
+    });
+    await signInAs(userId);
+
+    await submitProfileAction(validProfile);
+
+    const after = await getDb().query.users.findFirst({
+      where: (u, { eq }) => eq(u.id, userId),
+    });
+    expect(after!.status).toBe("approved");
+  });
+
+  it("still resets a pending user back to pending after profile re-submit", async () => {
+    // Sanity check that the WHERE-guarded UPDATE still fires when the
+    // user is genuinely not-approved. Status stays pending (already its
+    // value), but the path is the one that mattered before the race fix.
+    const userId = await seedUser({
+      email: TEST_EMAIL,
+      status: "pending",
+    });
+    await signInAs(userId);
+
+    await submitProfileAction(validProfile);
+
+    const after = await getDb().query.users.findFirst({
+      where: (u, { eq }) => eq(u.id, userId),
+    });
+    expect(after!.status).toBe("pending");
+  });
+});
+
 describe("pre-seeded user registration", () => {
   it("reuses a pre-seeded email-only row instead of creating a duplicate", async () => {
     // Pre-seed a user with just an email (no profile).

--- a/apps/web/src/features/auth/server/email-actions.server.ts
+++ b/apps/web/src/features/auth/server/email-actions.server.ts
@@ -21,10 +21,13 @@
  * The shell in `./email-fns.ts` dynamic-imports each action so server-
  * only code never reaches the client bundle.
  */
-import { and, asc, count, desc, eq, sql } from "drizzle-orm";
+import { and, asc, desc, eq, sql } from "drizzle-orm";
 import { uuidv7 } from "uuidv7";
 
-import { recordAuditEvent } from "#/server/audit/audit-log.server";
+import {
+  buildAuditEventStatement,
+  recordAuditEvent,
+} from "#/server/audit/audit-log.server";
 import { normalizeEmail } from "#/server/auth/email-normalize";
 import {
   consumeMagicLink,
@@ -197,29 +200,35 @@ export async function consumeAddEmailAction(
   const email = normalizeEmail(proof.email);
   const db = getDb();
   try {
-    await db.insert(schema.userEmails).values({
-      id: `uem_${uuidv7()}`,
-      userId: principal.userId,
-      email,
-      isPrimary: false,
-      verifiedAt: new Date(),
-    });
+    // Insert + audit in one batch — the email is known up front, so
+    // the audit metadata doesn't need to be derived from `.returning()`.
+    // D1 commits both atomically.
+    await db.batch([
+      db.insert(schema.userEmails).values({
+        id: `uem_${uuidv7()}`,
+        userId: principal.userId,
+        email,
+        isPrimary: false,
+        verifiedAt: new Date(),
+      }),
+      buildAuditEventStatement({
+        actorUserId: principal.userId,
+        action: "email.added",
+        targetUserId: principal.userId,
+        metadata: { email },
+      }),
+    ]);
   } catch (err) {
     if (isUniqueViolation(err, "user_emails.email")) {
       // The address was claimed by another account between the
       // request and the consume. The pre-check at request time would
       // have caught the common case; this branch covers the race.
+      // The whole batch rolls back, so no orphan audit row.
       return { ok: false, reason: "email_taken" };
     }
     throw err;
   }
 
-  await recordAuditEvent({
-    actorUserId: principal.userId,
-    action: "email.added",
-    targetUserId: principal.userId,
-    metadata: { email },
-  });
   return { ok: true, email };
 }
 
@@ -237,12 +246,18 @@ export async function removeEmailAction(args: {
   }
 
   const db = getDb();
-  const row = await db.query.userEmails.findFirst({
-    where: and(
-      eq(schema.userEmails.id, args.emailId),
-      eq(schema.userEmails.userId, principal.userId),
-    ),
-  });
+  // One read fetches both the target row and the count of all rows
+  // for this user. The belt-and-suspenders row-count guard documented
+  // below stays active without a second round-trip.
+  const userRows = await db
+    .select({
+      id: schema.userEmails.id,
+      email: schema.userEmails.email,
+      isPrimary: schema.userEmails.isPrimary,
+    })
+    .from(schema.userEmails)
+    .where(eq(schema.userEmails.userId, principal.userId));
+  const row = userRows.find((r) => r.id === args.emailId);
   if (!row) {
     return { ok: false, reason: "not_found" };
   }
@@ -268,24 +283,21 @@ export async function removeEmailAction(args: {
   // first place; the action-level guard is purely defense-in-depth
   // for direct API callers (tests, future scripts) and the invariant-
   // breaking edge case described above.
-  const [{ count: total } = { count: 0 }] = await db
-    .select({ count: count() })
-    .from(schema.userEmails)
-    .where(eq(schema.userEmails.userId, principal.userId));
-  if (total <= 1) {
+  if (userRows.length <= 1) {
     return { ok: false, reason: "is_last" };
   }
 
-  await db
-    .delete(schema.userEmails)
-    .where(eq(schema.userEmails.id, args.emailId));
-
-  await recordAuditEvent({
-    actorUserId: principal.userId,
-    action: "email.removed",
-    targetUserId: principal.userId,
-    metadata: { email: row.email },
-  });
+  // Delete + audit in one batch so the audit row can't survive a
+  // delete that ultimately fails (or vice versa).
+  await db.batch([
+    db.delete(schema.userEmails).where(eq(schema.userEmails.id, args.emailId)),
+    buildAuditEventStatement({
+      actorUserId: principal.userId,
+      action: "email.removed",
+      targetUserId: principal.userId,
+      metadata: { email: row.email },
+    }),
+  ]);
   return { ok: true };
 }
 
@@ -328,6 +340,11 @@ export async function setPrimaryEmailAction(args: {
   // we surface `not_found` below. Without the gate, the demote would
   // succeed unconditionally and the promote's WHERE would match
   // nothing.
+  //
+  // Audit stays sequential (out of the batch) because the audit log
+  // is append-only — bundling here would either require a phantom
+  // row when the gated demote no-ops, or a compensating delete that
+  // violates the append-only invariant.
   const [, promoted] = await db.batch([
     db
       .update(schema.userEmails)

--- a/apps/web/src/features/auth/server/email-actions.server.ts
+++ b/apps/web/src/features/auth/server/email-actions.server.ts
@@ -246,21 +246,29 @@ export async function removeEmailAction(args: {
   }
 
   const db = getDb();
-  // One read fetches both the target row and the count of all rows
-  // for this user. The belt-and-suspenders row-count guard documented
-  // below stays active without a second round-trip.
-  const userRows = await db
+  // One read fetches the target row plus the total count for the user
+  // via a correlated subquery. The result is bounded to one row even
+  // when the user has many addresses — `select all rows for user` was
+  // unbounded and could spike memory on a pathological email list.
+  const rows = await db
     .select({
       id: schema.userEmails.id,
       email: schema.userEmails.email,
       isPrimary: schema.userEmails.isPrimary,
+      totalForUser: sql<number>`(SELECT COUNT(*) FROM ${schema.userEmails} WHERE ${schema.userEmails.userId} = ${principal.userId})`,
     })
     .from(schema.userEmails)
-    .where(eq(schema.userEmails.userId, principal.userId));
-  const row = userRows.find((r) => r.id === args.emailId);
-  if (!row) {
+    .where(
+      and(
+        eq(schema.userEmails.id, args.emailId),
+        eq(schema.userEmails.userId, principal.userId),
+      ),
+    )
+    .limit(1);
+  if (rows.length === 0) {
     return { ok: false, reason: "not_found" };
   }
+  const row = rows[0];
   if (row.isPrimary) {
     // Two-step UX: promote another row to primary first, then remove
     // the old primary. Allowing direct removal would leave the user
@@ -283,7 +291,7 @@ export async function removeEmailAction(args: {
   // first place; the action-level guard is purely defense-in-depth
   // for direct API callers (tests, future scripts) and the invariant-
   // breaking edge case described above.
-  if (userRows.length <= 1) {
+  if (row.totalForUser <= 1) {
     return { ok: false, reason: "is_last" };
   }
 

--- a/apps/web/src/features/auth/server/magic-link-actions.server.ts
+++ b/apps/web/src/features/auth/server/magic-link-actions.server.ts
@@ -8,7 +8,7 @@
  * Each function has a matching `*Fn` wrapper in `server-fns.ts`; tests
  * exercise the actions here directly.
  */
-import { eq } from "drizzle-orm";
+import { and, eq, ne } from "drizzle-orm";
 import { uuidv7 } from "uuidv7";
 
 import { normalizeEmail } from "#/server/auth/email-normalize";
@@ -58,21 +58,37 @@ async function findUserIdByEmail(email: string): Promise<string | null> {
   return row?.userId ?? null;
 }
 
+/** Sentinel returned by `resolveUserByEmail` when `user_emails`
+ *  references a `userId` that no longer exists in `users`. Only
+ *  reachable mid-cascade or with manual SQL inconsistencies; callers
+ *  should treat this as "invalid" rather than registering a new user. */
+const BROKEN_USER_FK = Symbol("broken_user_fk");
+
 /**
  * Consume-time lookup: given a verified email, return the owning user
  * along with whether they have a profile. One join replaces the prior
  * three-query sequence (userEmails → users → profiles).
  *
- * Returns `null` if the address has no row in `user_emails`. Returns
- * `{ userId: null }` shape when `user_emails` references a userId that
- * no longer exists — only possible mid-cascade or with manual SQL — so
- * callers can distinguish "fresh registrant" from "broken FK".
+ * Returns:
+ *   - `null` if the address has no row in `user_emails` (fresh
+ *     registration click).
+ *   - `BROKEN_USER_FK` when `user_emails` references a userId that
+ *     no longer exists in `users` — only possible mid-cascade or with
+ *     manual-SQL inconsistency. Caller treats this as invalid rather
+ *     than as a fresh registrant, matching the prior explicit guard.
+ *   - The resolved `{ userId, status, hasProfile }` otherwise.
+ *
+ * The LEFT JOIN against `users` is what makes the broken-FK case
+ * distinguishable from "no row in user_emails": the outer row exists,
+ * but its joined `users.id` comes back NULL.
  */
-async function resolveUserByEmail(email: string): Promise<{
-  userId: string;
-  status: schema.UserStatus;
-  hasProfile: boolean;
-} | null> {
+async function resolveUserByEmail(
+  email: string,
+): Promise<
+  | { userId: string; status: schema.UserStatus; hasProfile: boolean }
+  | typeof BROKEN_USER_FK
+  | null
+> {
   const row = await getDb()
     .select({
       userId: schema.users.id,
@@ -80,12 +96,15 @@ async function resolveUserByEmail(email: string): Promise<{
       profileUserId: schema.profiles.userId,
     })
     .from(schema.userEmails)
-    .innerJoin(schema.users, eq(schema.users.id, schema.userEmails.userId))
+    .leftJoin(schema.users, eq(schema.users.id, schema.userEmails.userId))
     .leftJoin(schema.profiles, eq(schema.profiles.userId, schema.users.id))
     .where(eq(schema.userEmails.email, normalizeEmail(email)))
     .get();
   if (!row) {
     return null;
+  }
+  if (row.userId === null || row.status === null) {
+    return BROKEN_USER_FK;
   }
   return {
     userId: row.userId,
@@ -168,10 +187,17 @@ export async function consumeMagicLinkAction(
   // and can route by status + hasProfile instead of bouncing through
   // /register/profile.
   //
+  // If `user_emails` references a userId that no longer exists,
+  // surface as invalid rather than registering a new account — same
+  // outcome as the prior explicit guard.
+  //
   // If no user owns this email yet, this is a first-time registration
   // click — write the short-lived proof cookie that /register/profile
   // gates on, and return `mode: "proof"` so the caller redirects there.
   const existing = await resolveUserByEmail(proof.email);
+  if (existing === BROKEN_USER_FK) {
+    return { ok: false, reason: "invalid" };
+  }
   if (existing) {
     // rotateSession (not openSession) so any stale session cookie on the
     // device gets replaced — same privilege-boundary discipline the
@@ -533,14 +559,12 @@ export async function submitProfileAction(
   // Status reset to "pending" only matters for the existing-user path:
   // a returning user who lost their profile must re-enter the approval
   // queue. Brand-new users were already inserted with status="pending"
-  // above, so the UPDATE is a no-op for them; skip it. For session-
-  // based callers, the principal's status drives the decision without
-  // an extra read.
-  const needsStatusReset = !isNewUser && principal?.status !== "approved";
-
-  // Profile upsert + emergency-contact replace + (optional) status
-  // reset, committed as one D1 batch so all the writes for a single
-  // profile submission either land together or roll back together.
+  // above, so we skip the UPDATE for them entirely. For everyone else
+  // we let SQL decide whether the row needs touching by guarding the
+  // UPDATE with `WHERE status != 'approved'` — the principal's status
+  // can be stale by the time the batch commits (an approver flipping
+  // the row mid-flight), and the WHERE keeps an unconditional revert
+  // from racing with that approval.
   const now = new Date();
   const stmts: Parameters<typeof db.batch>[0][number][] = [
     db
@@ -567,12 +591,14 @@ export async function submitProfileAction(
       ),
     );
   }
-  if (needsStatusReset) {
+  if (!isNewUser) {
     stmts.push(
       db
         .update(schema.users)
         .set({ status: "pending" })
-        .where(eq(schema.users.id, userId)),
+        .where(
+          and(eq(schema.users.id, userId), ne(schema.users.status, "approved")),
+        ),
     );
   }
   await db.batch(stmts as [(typeof stmts)[number], ...typeof stmts]);

--- a/apps/web/src/features/auth/server/magic-link-actions.server.ts
+++ b/apps/web/src/features/auth/server/magic-link-actions.server.ts
@@ -58,6 +58,42 @@ async function findUserIdByEmail(email: string): Promise<string | null> {
   return row?.userId ?? null;
 }
 
+/**
+ * Consume-time lookup: given a verified email, return the owning user
+ * along with whether they have a profile. One join replaces the prior
+ * three-query sequence (userEmails → users → profiles).
+ *
+ * Returns `null` if the address has no row in `user_emails`. Returns
+ * `{ userId: null }` shape when `user_emails` references a userId that
+ * no longer exists — only possible mid-cascade or with manual SQL — so
+ * callers can distinguish "fresh registrant" from "broken FK".
+ */
+async function resolveUserByEmail(email: string): Promise<{
+  userId: string;
+  status: schema.UserStatus;
+  hasProfile: boolean;
+} | null> {
+  const row = await getDb()
+    .select({
+      userId: schema.users.id,
+      status: schema.users.status,
+      profileUserId: schema.profiles.userId,
+    })
+    .from(schema.userEmails)
+    .innerJoin(schema.users, eq(schema.users.id, schema.userEmails.userId))
+    .leftJoin(schema.profiles, eq(schema.profiles.userId, schema.users.id))
+    .where(eq(schema.userEmails.email, normalizeEmail(email)))
+    .get();
+  if (!row) {
+    return null;
+  }
+  return {
+    userId: row.userId,
+    status: row.status,
+    hasProfile: row.profileUserId !== null,
+  };
+}
+
 // ── timing jitter ────────────────────────────────────────────────────────
 // All paths through requestMagicLinkAction must take roughly the same
 // wall-clock time so an attacker can't distinguish "known email" (DB hit +
@@ -135,31 +171,17 @@ export async function consumeMagicLinkAction(
   // If no user owns this email yet, this is a first-time registration
   // click — write the short-lived proof cookie that /register/profile
   // gates on, and return `mode: "proof"` so the caller redirects there.
-  const existingUserId = await findUserIdByEmail(proof.email);
-  if (existingUserId) {
-    const existing = await getDb().query.users.findFirst({
-      where: eq(schema.users.id, existingUserId),
-      columns: { id: true, status: true },
-    });
-    if (!existing) {
-      // user_emails references a userId that no longer exists — only
-      // possible mid-cascade or with a manual-SQL inconsistency. Treat
-      // as invalid rather than crash.
-      return { ok: false, reason: "invalid" };
-    }
-    const profile = await getDb().query.profiles.findFirst({
-      where: eq(schema.profiles.userId, existing.id),
-      columns: { userId: true },
-    });
+  const existing = await resolveUserByEmail(proof.email);
+  if (existing) {
     // rotateSession (not openSession) so any stale session cookie on the
     // device gets replaced — same privilege-boundary discipline the
     // other auth transitions follow.
-    await rotateSession(existing.id);
+    await rotateSession(existing.userId);
     return {
       ok: true,
       mode: "session",
       status: existing.status,
-      hasProfile: Boolean(profile),
+      hasProfile: existing.hasProfile,
     };
   }
 
@@ -463,6 +485,7 @@ export async function submitProfileAction(
   // users row on the loser of the race.
   const db = getDb();
   let userId: string;
+  let isNewUser = false;
   if (principal) {
     userId = principal.userId;
   } else {
@@ -487,6 +510,7 @@ export async function submitProfileAction(
           }),
         ]);
         userId = newUserId;
+        isNewUser = true;
       } catch (err) {
         if (isUniqueViolation(err, "user_emails.email")) {
           // Lost the race; the email belongs to a user that another
@@ -505,17 +529,11 @@ export async function submitProfileAction(
       }
     }
   }
-  const userRow = await db.query.users.findFirst({
-    where: eq(schema.users.id, userId),
-  });
-  if (!userRow) {
-    throw new Error("User row not found after upsert (unexpected)");
-  }
 
   const now = new Date();
   await db
     .insert(schema.profiles)
-    .values({ userId: userRow.id, ...profileData, updatedAt: now })
+    .values({ userId, ...profileData, updatedAt: now })
     .onConflictDoUpdate({
       target: schema.profiles.userId,
       set: { ...profileData, updatedAt: now },
@@ -524,13 +542,13 @@ export async function submitProfileAction(
   // Replace emergency contacts: delete existing, then insert new set.
   await db
     .delete(schema.emergencyContacts)
-    .where(eq(schema.emergencyContacts.userId, userRow.id));
+    .where(eq(schema.emergencyContacts.userId, userId));
 
   if (emergencyContacts.length > 0) {
     await db.insert(schema.emergencyContacts).values(
       emergencyContacts.map((ec) => ({
         id: `ec_${uuidv7()}`,
-        userId: userRow.id,
+        userId,
         name: ec.name,
         phone: ec.phone,
         relationship: ec.relationship,
@@ -538,15 +556,24 @@ export async function submitProfileAction(
     );
   }
 
-  if (userRow.status !== "approved") {
-    await db
-      .update(schema.users)
-      .set({ status: "pending" })
-      .where(eq(schema.users.id, userRow.id));
+  // Status reset to "pending" only matters for the existing-user path:
+  // a returning user who lost their profile must re-enter the approval
+  // queue. Brand-new users were already inserted with status="pending"
+  // above, so the UPDATE is a no-op for them; skip it. For session-
+  // based callers, the principal's status drives the decision without
+  // an extra read.
+  if (!isNewUser) {
+    const currentStatus = principal?.status;
+    if (currentStatus !== "approved") {
+      await db
+        .update(schema.users)
+        .set({ status: "pending" })
+        .where(eq(schema.users.id, userId));
+    }
   }
 
   if (!principal) {
-    await openSession(userRow.id);
+    await openSession(userId);
     clearProofCookie();
   }
 

--- a/apps/web/src/features/auth/server/magic-link-actions.server.ts
+++ b/apps/web/src/features/auth/server/magic-link-actions.server.ts
@@ -530,47 +530,52 @@ export async function submitProfileAction(
     }
   }
 
-  const now = new Date();
-  await db
-    .insert(schema.profiles)
-    .values({ userId, ...profileData, updatedAt: now })
-    .onConflictDoUpdate({
-      target: schema.profiles.userId,
-      set: { ...profileData, updatedAt: now },
-    });
-
-  // Replace emergency contacts: delete existing, then insert new set.
-  await db
-    .delete(schema.emergencyContacts)
-    .where(eq(schema.emergencyContacts.userId, userId));
-
-  if (emergencyContacts.length > 0) {
-    await db.insert(schema.emergencyContacts).values(
-      emergencyContacts.map((ec) => ({
-        id: `ec_${uuidv7()}`,
-        userId,
-        name: ec.name,
-        phone: ec.phone,
-        relationship: ec.relationship,
-      })),
-    );
-  }
-
   // Status reset to "pending" only matters for the existing-user path:
   // a returning user who lost their profile must re-enter the approval
   // queue. Brand-new users were already inserted with status="pending"
   // above, so the UPDATE is a no-op for them; skip it. For session-
   // based callers, the principal's status drives the decision without
   // an extra read.
-  if (!isNewUser) {
-    const currentStatus = principal?.status;
-    if (currentStatus !== "approved") {
-      await db
+  const needsStatusReset = !isNewUser && principal?.status !== "approved";
+
+  // Profile upsert + emergency-contact replace + (optional) status
+  // reset, committed as one D1 batch so all the writes for a single
+  // profile submission either land together or roll back together.
+  const now = new Date();
+  const stmts: Parameters<typeof db.batch>[0][number][] = [
+    db
+      .insert(schema.profiles)
+      .values({ userId, ...profileData, updatedAt: now })
+      .onConflictDoUpdate({
+        target: schema.profiles.userId,
+        set: { ...profileData, updatedAt: now },
+      }),
+    db
+      .delete(schema.emergencyContacts)
+      .where(eq(schema.emergencyContacts.userId, userId)),
+  ];
+  if (emergencyContacts.length > 0) {
+    stmts.push(
+      db.insert(schema.emergencyContacts).values(
+        emergencyContacts.map((ec) => ({
+          id: `ec_${uuidv7()}`,
+          userId,
+          name: ec.name,
+          phone: ec.phone,
+          relationship: ec.relationship,
+        })),
+      ),
+    );
+  }
+  if (needsStatusReset) {
+    stmts.push(
+      db
         .update(schema.users)
         .set({ status: "pending" })
-        .where(eq(schema.users.id, userId));
-    }
+        .where(eq(schema.users.id, userId)),
+    );
   }
+  await db.batch(stmts as [(typeof stmts)[number], ...typeof stmts]);
 
   if (!principal) {
     await openSession(userId);
@@ -624,26 +629,33 @@ export async function submitDetailsAction(
   const { emergencyContacts, ...profileData } = data;
   const db = getDb();
 
-  await db
-    .update(schema.profiles)
-    .set({ ...profileData, updatedAt: new Date() })
-    .where(eq(schema.profiles.userId, principal.userId));
-
-  await db
-    .delete(schema.emergencyContacts)
-    .where(eq(schema.emergencyContacts.userId, principal.userId));
-
+  // Profile update + emergency-contact replace as one batch. Same
+  // shape as `submitProfileAction` and `adminUpdateProfileAction`:
+  // delete-then-insert + audit (no audit needed for self-edit) all
+  // committed together.
+  const stmts: Parameters<typeof db.batch>[0][number][] = [
+    db
+      .update(schema.profiles)
+      .set({ ...profileData, updatedAt: new Date() })
+      .where(eq(schema.profiles.userId, principal.userId)),
+    db
+      .delete(schema.emergencyContacts)
+      .where(eq(schema.emergencyContacts.userId, principal.userId)),
+  ];
   if (emergencyContacts.length > 0) {
-    await db.insert(schema.emergencyContacts).values(
-      emergencyContacts.map((ec) => ({
-        id: `ec_${uuidv7()}`,
-        userId: principal.userId,
-        name: ec.name,
-        phone: ec.phone,
-        relationship: ec.relationship,
-      })),
+    stmts.push(
+      db.insert(schema.emergencyContacts).values(
+        emergencyContacts.map((ec) => ({
+          id: `ec_${uuidv7()}`,
+          userId: principal.userId,
+          name: ec.name,
+          phone: ec.phone,
+          relationship: ec.relationship,
+        })),
+      ),
     );
   }
+  await db.batch(stmts as [(typeof stmts)[number], ...typeof stmts]);
 
   return { ok: true };
 }

--- a/apps/web/src/features/landing/server/landing-actions.server.ts
+++ b/apps/web/src/features/landing/server/landing-actions.server.ts
@@ -26,9 +26,6 @@ import {
   listFaqItems,
   listHeroSlides,
   listSettings,
-  nextActivitySortOrder,
-  nextFaqSortOrder,
-  nextHeroSlideSortOrder,
   reorderActivities,
   reorderFaqItems,
   reorderHeroSlides,
@@ -197,8 +194,7 @@ export async function createHeroSlideAction(
   await putLandingImage(imageKey, bytes, contentType);
 
   const id = `hslide_${uuidv7()}`;
-  const sortOrder = await nextHeroSlideSortOrder();
-  await insertHeroSlide({ id, imageKey, alt: input.alt, sortOrder });
+  await insertHeroSlide({ id, imageKey, alt: input.alt });
 
   await recordAuditEvent({
     actorUserId: principal.userId,
@@ -296,12 +292,10 @@ export async function createFaqItemAction(
     );
   }
   const id = `faq_${uuidv7()}`;
-  const sortOrder = await nextFaqSortOrder();
   await insertFaqItem({
     id,
     question: input.question,
     answer: input.answer,
-    sortOrder,
   });
   await recordAuditEvent({
     actorUserId: principal.userId,
@@ -392,14 +386,12 @@ export async function createActivityAction(
     ? await uploadActivityImage(input.dataUrl)
     : null;
   const id = `act_${uuidv7()}`;
-  const sortOrder = await nextActivitySortOrder();
   await insertActivity({
     id,
     icon: input.icon,
     title: input.title,
     blurb: input.blurb,
     imageKey,
-    sortOrder,
   });
   await recordAuditEvent({
     actorUserId: principal.userId,

--- a/apps/web/src/features/landing/server/landing-repo.server.ts
+++ b/apps/web/src/features/landing/server/landing-repo.server.ts
@@ -75,11 +75,14 @@ export async function getHeroSlide(
   return rows.length > 0 ? rows[0] : null;
 }
 
+// Computes `sort_order = COALESCE(MAX(sort_order), -1) + 1` inside
+// the INSERT statement so the read+insert is one round-trip and the
+// MAX→INSERT TOCTOU window goes away (concurrent inserts no longer
+// collide on the same sort_order).
 export async function insertHeroSlide(input: {
   id: string;
   imageKey: string;
   alt: string;
-  sortOrder: number;
 }): Promise<void> {
   const db = getDb();
   const now = new Date();
@@ -87,7 +90,7 @@ export async function insertHeroSlide(input: {
     id: input.id,
     imageKey: input.imageKey,
     alt: input.alt,
-    sortOrder: input.sortOrder,
+    sortOrder: sql<number>`COALESCE((SELECT MAX(${schema.landingHeroSlides.sortOrder}) FROM ${schema.landingHeroSlides}), -1) + 1`,
     createdAt: now,
     updatedAt: now,
   });
@@ -117,16 +120,6 @@ export async function deleteHeroSlide(id: string): Promise<void> {
   await db
     .delete(schema.landingHeroSlides)
     .where(eq(schema.landingHeroSlides.id, id));
-}
-
-export async function nextHeroSlideSortOrder(): Promise<number> {
-  const db = getDb();
-  const rows = await db
-    .select({
-      max: sql<number>`COALESCE(MAX(${schema.landingHeroSlides.sortOrder}), -1)`,
-    })
-    .from(schema.landingHeroSlides);
-  return (rows[0]?.max ?? -1) + 1;
 }
 
 // Atomically reorder a contiguous batch of rows. Caller passes the new
@@ -177,7 +170,6 @@ export async function insertFaqItem(input: {
   id: string;
   question: string;
   answer: string;
-  sortOrder: number;
 }): Promise<void> {
   const db = getDb();
   const now = new Date();
@@ -185,7 +177,7 @@ export async function insertFaqItem(input: {
     id: input.id,
     question: input.question,
     answer: input.answer,
-    sortOrder: input.sortOrder,
+    sortOrder: sql<number>`COALESCE((SELECT MAX(${schema.landingFaqItems.sortOrder}) FROM ${schema.landingFaqItems}), -1) + 1`,
     createdAt: now,
     updatedAt: now,
   });
@@ -212,16 +204,6 @@ export async function deleteFaqItem(id: string): Promise<void> {
   await db
     .delete(schema.landingFaqItems)
     .where(eq(schema.landingFaqItems.id, id));
-}
-
-export async function nextFaqSortOrder(): Promise<number> {
-  const db = getDb();
-  const rows = await db
-    .select({
-      max: sql<number>`COALESCE(MAX(${schema.landingFaqItems.sortOrder}), -1)`,
-    })
-    .from(schema.landingFaqItems);
-  return (rows[0]?.max ?? -1) + 1;
 }
 
 export async function countFaqItems(): Promise<number> {
@@ -278,7 +260,6 @@ export async function insertActivity(input: {
   title: string;
   blurb: string;
   imageKey: string | null;
-  sortOrder: number;
 }): Promise<void> {
   const db = getDb();
   const now = new Date();
@@ -288,7 +269,7 @@ export async function insertActivity(input: {
     title: input.title,
     blurb: input.blurb,
     imageKey: input.imageKey,
-    sortOrder: input.sortOrder,
+    sortOrder: sql<number>`COALESCE((SELECT MAX(${schema.landingActivities.sortOrder}) FROM ${schema.landingActivities}), -1) + 1`,
     createdAt: now,
     updatedAt: now,
   });
@@ -341,16 +322,6 @@ export async function deleteActivity(id: string): Promise<void> {
   await db
     .delete(schema.landingActivities)
     .where(eq(schema.landingActivities.id, id));
-}
-
-export async function nextActivitySortOrder(): Promise<number> {
-  const db = getDb();
-  const rows = await db
-    .select({
-      max: sql<number>`COALESCE(MAX(${schema.landingActivities.sortOrder}), -1)`,
-    })
-    .from(schema.landingActivities);
-  return (rows[0]?.max ?? -1) + 1;
 }
 
 export async function reorderActivities(idsInOrder: string[]): Promise<void> {

--- a/apps/web/src/features/landing/server/landing-repo.server.ts
+++ b/apps/web/src/features/landing/server/landing-repo.server.ts
@@ -79,6 +79,15 @@ export async function getHeroSlide(
 // the INSERT statement so the read+insert is one round-trip and the
 // MAX→INSERT TOCTOU window goes away (concurrent inserts no longer
 // collide on the same sort_order).
+//
+// Race-safety here assumes Cloudflare D1's single-primary write model:
+// SQLite serializes writes, so two parallel inserts can't see the
+// same MAX. If D1 ever moves to a multi-primary / active-active
+// topology, this subquery could see a stale local MAX and two regions
+// could pick the same next value — at that point sort_order needs a
+// different generator (e.g. a counter row in `landing_settings` or a
+// monotonic uuidv7-derived ordinal). All three landing tables
+// (hero slides / FAQ items / activities) share this assumption.
 export async function insertHeroSlide(input: {
   id: string;
   imageKey: string;

--- a/apps/web/src/features/members/server/__tests__/member-actions.test.ts
+++ b/apps/web/src/features/members/server/__tests__/member-actions.test.ts
@@ -647,6 +647,48 @@ describe("listMembersAction status filtering", () => {
   });
 });
 
+// ── role filtering in listMembersAction ────────────────────────────────
+
+describe("listMembersAction role filter", () => {
+  it("returns only members holding any of the requested roles, with a matching total", async () => {
+    await signInWithPermission("manager@example.com", "members:manage");
+
+    const officerId = await seedUser("officer@example.com");
+    await assignRole(officerId, "role_member");
+    await assignRole(officerId, "role_president");
+
+    const plainId = await seedUser("plain@example.com");
+    await assignRole(plainId, "role_member");
+
+    const filtered = await listMembersAction({ roles: "president" });
+    const emails = filtered.rows.map((r) => r.email);
+    expect(emails).toContain("officer@example.com");
+    expect(emails).not.toContain("plain@example.com");
+    // total must reflect the filtered set, not the unfiltered page count.
+    expect(filtered.total).toBe(filtered.rows.length);
+  });
+
+  it("paginates correctly under a role filter", async () => {
+    await signInWithPermission("manager@example.com", "members:manage");
+
+    for (let i = 0; i < 3; i++) {
+      const id = await seedUser(`officer${i}@example.com`);
+      await assignRole(id, "role_member");
+      await assignRole(id, "role_president");
+    }
+    // Decoy that should not appear in the role-filtered total.
+    const decoy = await seedUser("decoy@example.com");
+    await assignRole(decoy, "role_member");
+
+    const page = await listMembersAction({ roles: "president", limit: 2 });
+    expect(page.rows.length).toBe(2);
+    expect(page.total).toBe(3);
+    for (const row of page.rows) {
+      expect(row.roles).toContain("president");
+    }
+  });
+});
+
 // ── getMemberDetailAction ───────────────────────────────────────────────
 
 describe("getMemberDetailAction", () => {

--- a/apps/web/src/features/members/server/member-actions.server.ts
+++ b/apps/web/src/features/members/server/member-actions.server.ts
@@ -229,7 +229,7 @@ export async function listMembersAction(opts: {
     const roleNames = roleList as [string, ...string[]];
     conditions.push(
       exists(
-        getDb()
+        db
           .select({ one: schema.userRoles.userId })
           .from(schema.userRoles)
           .innerJoin(schema.roles, eq(schema.roles.id, schema.userRoles.roleId))
@@ -423,10 +423,14 @@ export async function getMemberDetailAction(
 
   const userId = row.userId;
 
-  // Roles, emergency contacts, and the active-session count all key on
-  // `userId` only — run them in parallel. Permission gates above
-  // already decided whether to fetch private contacts and the session
-  // count; the parallel block just collapses the remaining round-trips.
+  // Roles, emergency contacts, and the active-session count all key
+  // on `userId` only — issue them in parallel via `Promise.all` so
+  // their wall-clock latencies overlap (D1 still receives one HTTP
+  // request per query — `db.batch` would collapse to one request but
+  // would also force us to run the privileged contacts + sessions
+  // queries unconditionally, which is wasted work for the common
+  // regular-member caller). Permission gates above decide whether to
+  // fetch private contacts and the session count.
   const [roleRows, contacts, sessionCountRows] = await Promise.all([
     db
       .select({ roleName: schema.roles.name })

--- a/apps/web/src/features/members/server/member-actions.server.ts
+++ b/apps/web/src/features/members/server/member-actions.server.ts
@@ -5,7 +5,17 @@
  * shell in `./member-fns.ts` loads this via a dynamic import inside its
  * createServerFn handlers.
  */
-import { and, asc, count, desc, eq, gte, inArray, lte } from "drizzle-orm";
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  exists,
+  gte,
+  inArray,
+  lte,
+} from "drizzle-orm";
 import { uuidv7 } from "uuidv7";
 
 import {
@@ -210,16 +220,31 @@ export async function listMembersAction(opts: {
     );
   }
 
-  // Role filter (comma-separated list). Requires a subquery-style
-  // approach — we join userRoles and filter by role name.
+  // Role filter (comma-separated list). Pushed into SQL via an EXISTS
+  // subquery so the count + page query agree on the same filtered set.
+  // A direct join to userRoles+roles would multiply page rows for users
+  // with multiple roles; EXISTS keeps the row count to one per user.
   const roleList = opts.roles?.split(",").filter(Boolean) ?? [];
+  if (roleList.length > 0) {
+    const roleNames = roleList as [string, ...string[]];
+    conditions.push(
+      exists(
+        getDb()
+          .select({ one: schema.userRoles.userId })
+          .from(schema.userRoles)
+          .innerJoin(schema.roles, eq(schema.roles.id, schema.userRoles.roleId))
+          .where(
+            and(
+              eq(schema.userRoles.userId, schema.users.id),
+              inArray(schema.roles.name, roleNames),
+            ),
+          ),
+      ),
+    );
+  }
 
   // TODO: wire opts.search to LIKE on name/email.
 
-  // Build the base query with the profile join (needed for affiliation
-  // filter and display columns). Role filtering is done post-query
-  // because a join to userRoles+roles would multiply rows for users
-  // with multiple roles; for a small dataset this is fine.
   const where = and(...conditions);
 
   // Sort order.
@@ -314,7 +339,7 @@ export async function listMembersAction(opts: {
     contactsByUser.set(c.userId, list);
   }
 
-  let mappedRows: MemberSummary[] = rows.map((r) => ({
+  const mappedRows: MemberSummary[] = rows.map((r) => ({
     userId: r.userId,
     publicId: r.publicId,
     email: r.email,
@@ -330,18 +355,7 @@ export async function listMembersAction(opts: {
       : [],
   }));
 
-  let total = countResult[0]?.value ?? 0;
-
-  // Role filter — applied in JS after the batch role fetch. For a small
-  // dataset this is simpler than a correlated subquery.
-  if (roleList.length > 0) {
-    mappedRows = mappedRows.filter((m) =>
-      roleList.some((r) => m.roles.includes(r)),
-    );
-    total = mappedRows.length;
-  }
-
-  return { total, rows: mappedRows };
+  return { total: countResult[0]?.value ?? 0, rows: mappedRows };
 }
 
 // ── get member detail ───────────────────────────────────────────────────

--- a/apps/web/src/features/members/server/member-actions.server.ts
+++ b/apps/web/src/features/members/server/member-actions.server.ts
@@ -423,34 +423,37 @@ export async function getMemberDetailAction(
 
   const userId = row.userId;
 
-  // Fetch roles.
-  const roleRows = await db
-    .select({ roleName: schema.roles.name })
-    .from(schema.userRoles)
-    .innerJoin(schema.roles, eq(schema.roles.id, schema.userRoles.roleId))
-    .where(eq(schema.userRoles.userId, userId));
+  // Roles, emergency contacts, and the active-session count all key on
+  // `userId` only — run them in parallel. Permission gates above
+  // already decided whether to fetch private contacts and the session
+  // count; the parallel block just collapses the remaining round-trips.
+  const [roleRows, contacts, sessionCountRows] = await Promise.all([
+    db
+      .select({ roleName: schema.roles.name })
+      .from(schema.userRoles)
+      .innerJoin(schema.roles, eq(schema.roles.id, schema.userRoles.roleId))
+      .where(eq(schema.userRoles.userId, userId)),
+    canViewPrivate
+      ? db
+          .select({
+            name: schema.emergencyContacts.name,
+            phone: schema.emergencyContacts.phone,
+            relationship: schema.emergencyContacts.relationship,
+          })
+          .from(schema.emergencyContacts)
+          .where(eq(schema.emergencyContacts.userId, userId))
+      : Promise.resolve<EmergencyContactSummary[]>([]),
+    canRevokeSessions
+      ? db
+          .select({ value: count() })
+          .from(schema.sessions)
+          .where(eq(schema.sessions.userId, userId))
+      : Promise.resolve<{ value: number }[]>([]),
+  ]);
 
-  // Fetch emergency contacts (private data).
-  const contacts: EmergencyContactSummary[] = canViewPrivate
-    ? await db
-        .select({
-          name: schema.emergencyContacts.name,
-          phone: schema.emergencyContacts.phone,
-          relationship: schema.emergencyContacts.relationship,
-        })
-        .from(schema.emergencyContacts)
-        .where(eq(schema.emergencyContacts.userId, userId))
-    : [];
-
-  // Optionally count active sessions.
-  let activeSessions: number | null = null;
-  if (canRevokeSessions) {
-    const sessionCount = await db
-      .select({ value: count() })
-      .from(schema.sessions)
-      .where(eq(schema.sessions.userId, userId));
-    activeSessions = sessionCount[0]?.value ?? 0;
-  }
+  const activeSessions = canRevokeSessions
+    ? (sessionCountRows[0]?.value ?? 0)
+    : null;
 
   return {
     userId: row.userId,

--- a/apps/web/src/features/members/server/rbac-actions.server.ts
+++ b/apps/web/src/features/members/server/rbac-actions.server.ts
@@ -89,17 +89,27 @@ export async function listRolesDetailedAction(): Promise<
   await requireRolesManager();
   const db = getDb();
 
-  const roles = await db.query.roles.findMany({
-    orderBy: (roles, { asc }) => [asc(roles.position), asc(roles.name)],
-  });
-
-  // Batch-fetch permission grants for all roles.
-  const permGrants = await db
-    .select({
-      roleId: schema.rolePermissions.roleId,
-      permissionId: schema.rolePermissions.permissionId,
-    })
-    .from(schema.rolePermissions);
+  // Roles, all role-permission grants, and the per-role member count
+  // are independent — `Promise.all` collapses three serial reads into
+  // one D1 round-trip.
+  const [roles, permGrants, memberCounts] = await Promise.all([
+    db.query.roles.findMany({
+      orderBy: (roles, { asc }) => [asc(roles.position), asc(roles.name)],
+    }),
+    db
+      .select({
+        roleId: schema.rolePermissions.roleId,
+        permissionId: schema.rolePermissions.permissionId,
+      })
+      .from(schema.rolePermissions),
+    db
+      .select({
+        roleId: schema.userRoles.roleId,
+        count: count(),
+      })
+      .from(schema.userRoles)
+      .groupBy(schema.userRoles.roleId),
+  ]);
 
   const permsByRole = new Map<string, string[]>();
   for (const g of permGrants) {
@@ -107,15 +117,6 @@ export async function listRolesDetailedAction(): Promise<
     list.push(g.permissionId);
     permsByRole.set(g.roleId, list);
   }
-
-  // Batch count members per role.
-  const memberCounts = await db
-    .select({
-      roleId: schema.userRoles.roleId,
-      count: count(),
-    })
-    .from(schema.userRoles)
-    .groupBy(schema.userRoles.roleId);
 
   const countByRole = new Map<string, number>();
   for (const mc of memberCounts) {
@@ -137,36 +138,38 @@ export async function getRoleAction(roleId: string): Promise<RoleDetail> {
   await requireRolesManager();
   const db = getDb();
 
-  const role = await db.query.roles.findFirst({
-    where: eq(schema.roles.id, roleId),
-  });
+  // Role row, permission grants, and member list all key on `roleId`
+  // alone. Run them under one `Promise.all`; we still validate role
+  // existence below before returning.
+  const [role, permGrants, memberRows] = await Promise.all([
+    db.query.roles.findFirst({
+      where: eq(schema.roles.id, roleId),
+    }),
+    db
+      .select({ permissionId: schema.rolePermissions.permissionId })
+      .from(schema.rolePermissions)
+      .where(eq(schema.rolePermissions.roleId, roleId)),
+    db
+      .select({
+        userId: schema.users.id,
+        email: schema.userEmails.email,
+        preferredName: schema.profiles.preferredName,
+      })
+      .from(schema.userRoles)
+      .innerJoin(schema.users, eq(schema.users.id, schema.userRoles.userId))
+      .innerJoin(
+        schema.userEmails,
+        and(
+          eq(schema.userEmails.userId, schema.users.id),
+          eq(schema.userEmails.isPrimary, true),
+        ),
+      )
+      .leftJoin(schema.profiles, eq(schema.profiles.userId, schema.users.id))
+      .where(eq(schema.userRoles.roleId, roleId)),
+  ]);
   if (!role) {
     throw new Error("Role not found");
   }
-
-  const permGrants = await db
-    .select({ permissionId: schema.rolePermissions.permissionId })
-    .from(schema.rolePermissions)
-    .where(eq(schema.rolePermissions.roleId, roleId));
-
-  // Load members with this role (join through user_roles → users → profiles).
-  const memberRows = await db
-    .select({
-      userId: schema.users.id,
-      email: schema.userEmails.email,
-      preferredName: schema.profiles.preferredName,
-    })
-    .from(schema.userRoles)
-    .innerJoin(schema.users, eq(schema.users.id, schema.userRoles.userId))
-    .innerJoin(
-      schema.userEmails,
-      and(
-        eq(schema.userEmails.userId, schema.users.id),
-        eq(schema.userEmails.isPrimary, true),
-      ),
-    )
-    .leftJoin(schema.profiles, eq(schema.profiles.userId, schema.users.id))
-    .where(eq(schema.userRoles.roleId, roleId));
 
   return {
     id: role.id,

--- a/apps/web/src/features/members/server/rbac-actions.server.ts
+++ b/apps/web/src/features/members/server/rbac-actions.server.ts
@@ -3,7 +3,7 @@
  * the shell + .server.ts split — the shell in `./rbac-fns.ts` loads
  * this via dynamic imports inside its createServerFn handlers.
  */
-import { and, count, eq, inArray, max } from "drizzle-orm";
+import { and, asc, count, eq, inArray, max } from "drizzle-orm";
 
 import {
   buildAuditEventStatement,
@@ -90,12 +90,13 @@ export async function listRolesDetailedAction(): Promise<
   const db = getDb();
 
   // Roles, all role-permission grants, and the per-role member count
-  // are independent — `Promise.all` collapses three serial reads into
-  // one D1 round-trip.
-  const [roles, permGrants, memberCounts] = await Promise.all([
-    db.query.roles.findMany({
-      orderBy: (r, { asc }) => [asc(r.position), asc(r.name)],
-    }),
+  // are independent — bundle into one `db.batch` so all three reads
+  // ride on a single D1 HTTP request.
+  const [roles, permGrants, memberCounts] = await db.batch([
+    db
+      .select()
+      .from(schema.roles)
+      .orderBy(asc(schema.roles.position), asc(schema.roles.name)),
     db
       .select({
         roleId: schema.rolePermissions.roleId,
@@ -139,12 +140,11 @@ export async function getRoleAction(roleId: string): Promise<RoleDetail> {
   const db = getDb();
 
   // Role row, permission grants, and member list all key on `roleId`
-  // alone. Run them under one `Promise.all`; we still validate role
-  // existence below before returning.
-  const [role, permGrants, memberRows] = await Promise.all([
-    db.query.roles.findFirst({
-      where: eq(schema.roles.id, roleId),
-    }),
+  // alone. Bundle into one `db.batch` so all three reads ride on a
+  // single D1 HTTP request; existence is validated below before
+  // returning.
+  const [roleRows, permGrants, memberRows] = await db.batch([
+    db.select().from(schema.roles).where(eq(schema.roles.id, roleId)).limit(1),
     db
       .select({ permissionId: schema.rolePermissions.permissionId })
       .from(schema.rolePermissions)
@@ -167,9 +167,10 @@ export async function getRoleAction(roleId: string): Promise<RoleDetail> {
       .leftJoin(schema.profiles, eq(schema.profiles.userId, schema.users.id))
       .where(eq(schema.userRoles.roleId, roleId)),
   ]);
-  if (!role) {
+  if (roleRows.length === 0) {
     throw new Error("Role not found");
   }
+  const role = roleRows[0];
 
   return {
     id: role.id,
@@ -299,7 +300,7 @@ export async function listPermissionsAction(): Promise<PermissionSummary[]> {
   const db = getDb();
 
   const rows = await db.query.permissions.findMany({
-    orderBy: (permissions, { asc }) => [asc(permissions.name)],
+    orderBy: (p, { asc: a }) => [a(p.name)],
   });
 
   return rows.map((r) => ({

--- a/apps/web/src/features/members/server/rbac-actions.server.ts
+++ b/apps/web/src/features/members/server/rbac-actions.server.ts
@@ -12,7 +12,7 @@ import {
 import { invalidateAnonymousPermissionsCache } from "#/server/auth/principal.server";
 import type { Principal } from "#/server/auth/principal.server";
 import { loadCurrentPrincipal } from "#/server/auth/session.server";
-import { getDb, schema } from "#/server/db";
+import { getDb, isUniqueViolation, schema } from "#/server/db";
 
 // ── constants ──────────────────────────────────────────────────────────
 
@@ -94,7 +94,7 @@ export async function listRolesDetailedAction(): Promise<
   // one D1 round-trip.
   const [roles, permGrants, memberCounts] = await Promise.all([
     db.query.roles.findMany({
-      orderBy: (roles, { asc }) => [asc(roles.position), asc(roles.name)],
+      orderBy: (r, { asc }) => [asc(r.position), asc(r.name)],
     }),
     db
       .select({
@@ -198,37 +198,41 @@ export async function createRoleAction(input: {
 
   const roleId = `role_${input.name}`;
 
-  // Check for duplicate name.
-  const existing = await db.query.roles.findFirst({
-    where: eq(schema.roles.name, input.name),
-    columns: { id: true },
-  });
-  if (existing) {
-    throw new Error(`Role "${input.name}" already exists`);
-  }
-
-  // New roles go after all existing ones.
+  // No pre-check on the name — `roles_name_unique` is the actual race
+  // boundary, so the pre-check was theatre (TOCTOU between the read
+  // and the insert). Compute `nextPos` and try the insert; translate
+  // the unique violation back to the user-facing error.
   const [{ maxPos }] = await db
     .select({ maxPos: max(schema.roles.position) })
     .from(schema.roles);
   const nextPos = (maxPos ?? -1) + 1;
 
-  // Atomic with the audit row.
-  await db.batch([
-    db.insert(schema.roles).values({
-      id: roleId,
-      name: input.name,
-      description: input.description ?? null,
-      position: nextPos,
-    }),
-    buildAuditEventStatement({
-      actorUserId: principal.userId,
-      action: "role.created",
-      targetType: "role",
-      targetId: roleId,
-      metadata: { name: input.name },
-    }),
-  ]);
+  try {
+    // Atomic with the audit row.
+    await db.batch([
+      db.insert(schema.roles).values({
+        id: roleId,
+        name: input.name,
+        description: input.description ?? null,
+        position: nextPos,
+      }),
+      buildAuditEventStatement({
+        actorUserId: principal.userId,
+        action: "role.created",
+        targetType: "role",
+        targetId: roleId,
+        metadata: { name: input.name },
+      }),
+    ]);
+  } catch (err) {
+    if (
+      isUniqueViolation(err, "roles.name") ||
+      isUniqueViolation(err, "roles.id")
+    ) {
+      throw new Error(`Role "${input.name}" already exists`, { cause: err });
+    }
+    throw err;
+  }
 
   return { roleId };
 }

--- a/apps/web/src/server/auth/principal.server.ts
+++ b/apps/web/src/server/auth/principal.server.ts
@@ -37,36 +37,42 @@ export interface Principal {
 export async function loadPrincipal(userId: string): Promise<Principal | null> {
   const db = getDb();
 
-  const user = await db.query.users.findFirst({
-    where: eq(schema.users.id, userId),
-  });
+  // The user row, profile, email list, and role list all key on
+  // `userId` only — no dependency between them. Run them in parallel
+  // so the principal load is one D1 round-trip instead of four.
+  // Primary first, then non-primary in insertion order, on the email
+  // ordering at the DB layer keeps the resulting `emails` array
+  // stable across requests so consumers can rely on the shape. `id`
+  // is the final tiebreaker — `created_at` is millisecond-resolution
+  // and can collide on `db.batch`-inserted rows or fast back-to-back
+  // inserts; the PK gives a deterministic total order.
+  const [user, profile, emailRows, userRoleRows] = await Promise.all([
+    db.query.users.findFirst({ where: eq(schema.users.id, userId) }),
+    db.query.profiles.findFirst({
+      where: eq(schema.profiles.userId, userId),
+      columns: { userId: true, avatarKey: true },
+    }),
+    db
+      .select({
+        email: schema.userEmails.email,
+        isPrimary: schema.userEmails.isPrimary,
+      })
+      .from(schema.userEmails)
+      .where(eq(schema.userEmails.userId, userId))
+      .orderBy(
+        desc(schema.userEmails.isPrimary),
+        asc(schema.userEmails.createdAt),
+        asc(schema.userEmails.id),
+      ),
+    db
+      .select({ roleId: schema.userRoles.roleId, name: schema.roles.name })
+      .from(schema.userRoles)
+      .innerJoin(schema.roles, eq(schema.roles.id, schema.userRoles.roleId))
+      .where(eq(schema.userRoles.userId, userId)),
+  ]);
   if (!user) {
     return null;
   }
-
-  const profile = await db.query.profiles.findFirst({
-    where: eq(schema.profiles.userId, userId),
-    columns: { userId: true, avatarKey: true },
-  });
-
-  // Primary first, then non-primary in insertion order. Ordering at
-  // the DB layer (rather than in JS) keeps the resulting `emails`
-  // array stable across requests so consumers can rely on the shape.
-  // `id` is the final tiebreaker — `created_at` is millisecond-
-  // resolution and can collide on `db.batch`-inserted rows or fast
-  // back-to-back inserts; the PK gives a deterministic total order.
-  const emailRows = await db
-    .select({
-      email: schema.userEmails.email,
-      isPrimary: schema.userEmails.isPrimary,
-    })
-    .from(schema.userEmails)
-    .where(eq(schema.userEmails.userId, userId))
-    .orderBy(
-      desc(schema.userEmails.isPrimary),
-      asc(schema.userEmails.createdAt),
-      asc(schema.userEmails.id),
-    );
 
   const primaryRow = emailRows[0]?.isPrimary ? emailRows[0] : undefined;
   if (!primaryRow) {
@@ -76,12 +82,6 @@ export async function loadPrincipal(userId: string): Promise<Principal | null> {
     throw new Error(`User ${userId} has no primary email row`);
   }
   const emails = emailRows.map((r) => r.email);
-
-  const userRoleRows = await db
-    .select({ roleId: schema.userRoles.roleId, name: schema.roles.name })
-    .from(schema.userRoles)
-    .innerJoin(schema.roles, eq(schema.roles.id, schema.userRoles.roleId))
-    .where(eq(schema.userRoles.userId, userId));
 
   const roleIds = userRoleRows.map((r) => r.roleId);
   const isSystemAdmin = userRoleRows.some((r) => r.name === "system_admin");

--- a/apps/web/src/server/auth/principal.server.ts
+++ b/apps/web/src/server/auth/principal.server.ts
@@ -43,10 +43,15 @@ export async function loadPrincipal(userId: string): Promise<Principal | null> {
   // (`Promise.all` would still issue four separate calls).
   //
   // Free correctness bonus: `db.batch` runs the four reads in one
-  // D1 transaction, so they see a consistent point-in-time snapshot.
-  // `Promise.all` would let a concurrent write (e.g. an admin
-  // assigning a role) split rows between the userRoles and
-  // rolePermissions reads.
+  // D1 transaction, so users / profiles / user_emails / user_roles
+  // are all observed at a single point-in-time. `Promise.all` could
+  // otherwise see a row mid-write — e.g. an admin assigning a role
+  // could land between the users and user_roles reads. The downstream
+  // `rolePermissions` read happens *after* this batch (it depends on
+  // `roleIds` from the userRoles result), so it isn't covered by the
+  // snapshot — a role's permission grants could shift between this
+  // batch and that follow-up read. That window is small and
+  // permissions changes are rare, so we accept it.
   //
   // Primary first, then non-primary in insertion order, on the email
   // ordering at the DB layer keeps the resulting `emails` array

--- a/apps/web/src/server/auth/principal.server.ts
+++ b/apps/web/src/server/auth/principal.server.ts
@@ -38,20 +38,26 @@ export async function loadPrincipal(userId: string): Promise<Principal | null> {
   const db = getDb();
 
   // The user row, profile, email list, and role list all key on
-  // `userId` only — no dependency between them. Run them in parallel
-  // so the principal load is one D1 round-trip instead of four.
-  // Primary first, then non-primary in insertion order, on the email
+  // `userId` only — no dependency between them. Bundle them in a
+  // `db.batch` so all four reads ride on a single D1 HTTP request
+  // (`Promise.all` would still issue four separate calls). Primary
+  // first, then non-primary in insertion order, on the email
   // ordering at the DB layer keeps the resulting `emails` array
   // stable across requests so consumers can rely on the shape. `id`
   // is the final tiebreaker — `created_at` is millisecond-resolution
   // and can collide on `db.batch`-inserted rows or fast back-to-back
   // inserts; the PK gives a deterministic total order.
-  const [user, profile, emailRows, userRoleRows] = await Promise.all([
-    db.query.users.findFirst({ where: eq(schema.users.id, userId) }),
-    db.query.profiles.findFirst({
-      where: eq(schema.profiles.userId, userId),
-      columns: { userId: true, avatarKey: true },
-    }),
+  const [userRows, profileRows, emailRows, userRoleRows] = await db.batch([
+    db
+      .select({ id: schema.users.id, status: schema.users.status })
+      .from(schema.users)
+      .where(eq(schema.users.id, userId))
+      .limit(1),
+    db
+      .select({ avatarKey: schema.profiles.avatarKey })
+      .from(schema.profiles)
+      .where(eq(schema.profiles.userId, userId))
+      .limit(1),
     db
       .select({
         email: schema.userEmails.email,
@@ -70,9 +76,11 @@ export async function loadPrincipal(userId: string): Promise<Principal | null> {
       .innerJoin(schema.roles, eq(schema.roles.id, schema.userRoles.roleId))
       .where(eq(schema.userRoles.userId, userId)),
   ]);
-  if (!user) {
+  if (userRows.length === 0) {
     return null;
   }
+  const user = userRows[0];
+  const profile = profileRows[0] as (typeof profileRows)[number] | undefined;
 
   const primaryRow = emailRows[0]?.isPrimary ? emailRows[0] : undefined;
   if (!primaryRow) {

--- a/apps/web/src/server/auth/principal.server.ts
+++ b/apps/web/src/server/auth/principal.server.ts
@@ -40,8 +40,15 @@ export async function loadPrincipal(userId: string): Promise<Principal | null> {
   // The user row, profile, email list, and role list all key on
   // `userId` only — no dependency between them. Bundle them in a
   // `db.batch` so all four reads ride on a single D1 HTTP request
-  // (`Promise.all` would still issue four separate calls). Primary
-  // first, then non-primary in insertion order, on the email
+  // (`Promise.all` would still issue four separate calls).
+  //
+  // Free correctness bonus: `db.batch` runs the four reads in one
+  // D1 transaction, so they see a consistent point-in-time snapshot.
+  // `Promise.all` would let a concurrent write (e.g. an admin
+  // assigning a role) split rows between the userRoles and
+  // rolePermissions reads.
+  //
+  // Primary first, then non-primary in insertion order, on the email
   // ordering at the DB layer keeps the resulting `emails` array
   // stable across requests so consumers can rely on the shape. `id`
   // is the final tiebreaker — `created_at` is millisecond-resolution

--- a/apps/web/src/server/cron/retention.server.ts
+++ b/apps/web/src/server/cron/retention.server.ts
@@ -189,40 +189,43 @@ async function loadReferencedR2Keys(): Promise<Set<string>> {
   const db = getDb();
   const live = new Set<string>();
 
-  const avatars = await db
-    .select({ key: schema.profiles.avatarKey })
-    .from(schema.profiles)
-    .where(isNotNull(schema.profiles.avatarKey));
+  // Four independent reads against four separate tables — issue them
+  // in parallel so the cron's D1 wait is one round-trip instead of
+  // four. Order doesn't matter; everything funnels into the same Set.
+  const [avatars, heroes, activities, settings] = await Promise.all([
+    db
+      .select({ key: schema.profiles.avatarKey })
+      .from(schema.profiles)
+      .where(isNotNull(schema.profiles.avatarKey)),
+    db
+      .select({ key: schema.landingHeroSlides.imageKey })
+      .from(schema.landingHeroSlides),
+    db
+      .select({ key: schema.landingActivities.imageKey })
+      .from(schema.landingActivities)
+      .where(isNotNull(schema.landingActivities.imageKey)),
+    db
+      .select({
+        key: schema.landingSettings.key,
+        valueJson: schema.landingSettings.valueJson,
+      })
+      .from(schema.landingSettings)
+      .where(inArray(schema.landingSettings.key, SETTINGS_IMAGE_KEYS)),
+  ]);
+
   for (const row of avatars) {
     if (row.key) {
       live.add(row.key);
     }
   }
-
-  const heroes = await db
-    .select({ key: schema.landingHeroSlides.imageKey })
-    .from(schema.landingHeroSlides);
   for (const row of heroes) {
     live.add(row.key);
   }
-
-  const activities = await db
-    .select({ key: schema.landingActivities.imageKey })
-    .from(schema.landingActivities)
-    .where(isNotNull(schema.landingActivities.imageKey));
   for (const row of activities) {
     if (row.key) {
       live.add(row.key);
     }
   }
-
-  const settings = await db
-    .select({
-      key: schema.landingSettings.key,
-      valueJson: schema.landingSettings.valueJson,
-    })
-    .from(schema.landingSettings)
-    .where(inArray(schema.landingSettings.key, SETTINGS_IMAGE_KEYS));
   for (const row of settings) {
     // valueJson is the JSON-encoded image key (`"landing/about/abc.webp"`)
     // or the JSON-encoded null for "no image set". Tolerate both shapes

--- a/apps/web/src/server/cron/retention.server.ts
+++ b/apps/web/src/server/cron/retention.server.ts
@@ -189,10 +189,10 @@ async function loadReferencedR2Keys(): Promise<Set<string>> {
   const db = getDb();
   const live = new Set<string>();
 
-  // Four independent reads against four separate tables — issue them
-  // in parallel so the cron's D1 wait is one round-trip instead of
-  // four. Order doesn't matter; everything funnels into the same Set.
-  const [avatars, heroes, activities, settings] = await Promise.all([
+  // Four independent reads against four separate tables — bundle into
+  // one `db.batch` so the cron's D1 wait is a single HTTP request.
+  // Order doesn't matter; everything funnels into the same Set.
+  const [avatars, heroes, activities, settings] = await db.batch([
     db
       .select({ key: schema.profiles.avatarKey })
       .from(schema.profiles)


### PR DESCRIPTION
## Summary

Audit + fix pass over every server-side SQL caller in `apps/web`. One correctness bug, several hot-path latency wins, and a handful of mutation flows tightened.

- **Correctness**: `listMembersAction`'s role filter ran in JS after the page query, then overwrote `total` with the filtered length — `total` was a lie and pages could come back empty under the filter. Pushed into SQL via an `EXISTS` subquery so count + page agree.
- **Hot path**: `loadPrincipal` (every authenticated request) now bundles its 4 independent reads in `db.batch` (single D1 HTTP request + snapshot isolation across the batched tables) instead of 4 sequential awaits. Magic-link returning-user sign-in collapses 3 reads into 1 join. Retention cron, `listRolesDetailedAction`, and `getRoleAction` are likewise on `db.batch`. `getMemberDetail` stays on `Promise.all` because two of its three reads are gated on permissions and unconditional batching would be wasted work for the common caller.
- **Reads**: Announcements unread count is one query instead of two. `removeEmailAction` folds findFirst + count into a single LIMIT-1 read with a correlated COUNT subquery (bounded — earlier round-1 refactor was unbounded).
- **Mutations**: profile + emergency-contact writes are now `db.batch`ed in `submitProfile` / `submitDetails` (atomicity improvement, not just latency). `createRole` drops the pre-flight findFirst on `roles.name` and relies on the unique index, closing the TOCTOU window. Landing-page `sort_order` is computed inside the INSERT via subquery, removing the parallel-add race (assumes D1's single-primary write topology). Email-add audit is bundled with the parent insert.

**Skipped from the original audit**: `slideSessionRow → waitUntil`. TanStack Start's request handler doesn't expose the Worker `ExecutionContext` to server fns; without `ctx.waitUntil`, fire-and-forget I/O gets cancelled when the response is sent. Documenting rather than wedging in a fragile workaround.

## Round-trip impact (rough)

| Code path | Before | After |
| --- | --- | --- |
| `loadPrincipal` (every auth'd request) | 4–5 sequential | 1 batched + 1 follow-up |
| Magic-link returning-user consume | 3 sequential | 1 join |
| `submitProfile` final stage | 1 dead read + 3 mutations | 1 batched mutation |
| `getMemberDetail` | 4 sequential | 1 row + parallelized 2–3 |
| `listRolesDetailed` / `getRole` | 3 sequential each | 1 batched each |
| Retention cron R2 live-set | 4 sequential | 1 batched |
| Announcements unread count | 2 sequential | 1 query |
| `removeEmail` | 4 sequential | 2 round-trips (1-row read + batched delete+audit) |
| `consumeAddEmail` | 1 insert + 1 audit | 1 batch |
| `createRole` | 1 findFirst + 1 max + 1 batch | 1 max + 1 batch |
| `submitDetails` | 3 sequential mutations | 1 batched mutation |
| Landing add (hero/FAQ/activity) | 1 max + 1 insert | 1 insert with subquery |

## Security review

- `listMembers` role filter: pushed into SQL, no behavior change for callers that don't pass `roles=`. Status filter still gated on `members:manage` — non-managers locked to `approved` regardless of `statuses` param.
- `loadPrincipal` parallelization: identical inputs and outputs; missing-user still short-circuits, missing-primary still throws, sysadmin bypass + per-role permission map derived from the same data.
- Magic-link consume join: switched from INNER → LEFT JOIN with an explicit `BROKEN_USER_FK` sentinel. When `user_emails` references a userId that no longer exists in `users` (only reachable mid-cascade or with manual SQL), the consume returns `{ ok: false, reason: "invalid" }` — matches the prior explicit guard.
- `submitProfileAction` status reset: pushed the "skip if approved" condition into SQL via `WHERE status != 'approved'` so an approver flipping a row mid-flight isn't reverted by a stale-principal-driven UPDATE.
- `setPrimaryEmail`: kept audit OUT of the batch on purpose — bundling would either require a phantom audit row when the gated demote no-ops, or a compensating delete that violates the append-only audit invariant.
- `createRole` unique-index reliance: race-safety **improves** — the prior pre-check was theatre.
- Profile/contact `db.batch`: atomicity **improves** — the prior sequential delete-then-insert had a partial-failure window.
- Landing `sort_order` subquery: removes the parallel-add TOCTOU under D1's single-primary write topology (documented in code).
- `removeEmail`: read is now bounded by LIMIT 1 (was unbounded `select all rows for user`).

## Test plan

- [x] `pnpm --filter ucmc-web typecheck` — clean
- [x] `pnpm --filter ucmc-web test` — 362/362 pass (added: role-filter pagination, status-race primitive test)
- [x] `pnpm exec eslint apps/web/src` — no new warnings
- [ ] Smoke-test sign-in + register + role-filter on members page in dev (post-merge or local)

## Follow-up issues

- #52 — convert `exportMyDataAction` `Promise.all` → `db.batch` for consistency
- #53 — document D1-specific `db.batch` semantics for future driver portability

🤖 Generated with [Claude Code](https://claude.com/claude-code)