### PR TITLE
chore(ucmc-web): bundle issue cleanup for #29, #52, #53

### DIFF
--- a/apps/web/src/config/legal.ts
+++ b/apps/web/src/config/legal.ts
@@ -1,3 +1,5 @@
+import type { FileRoutesByTo } from "../routeTree.gen";
+
 /**
  * Legal text + version constants. Single source of truth for:
  *   - The UC-mandated registration disclaimer (Rule 40-03-01) shown
@@ -446,7 +448,7 @@ export const MEMBERSHIP_BODY: readonly LegalSection[] = [
  * useful as a "what's the official line on X" landing pad.
  */
 export const LEGAL_INDEX_LINKS: readonly {
-  href: string;
+  href: keyof FileRoutesByTo;
   label: string;
   description: string;
 }[] = [

--- a/apps/web/src/features/auth/server/magic-link-actions.server.ts
+++ b/apps/web/src/features/auth/server/magic-link-actions.server.ts
@@ -330,55 +330,70 @@ export async function exportMyDataAction(): Promise<{
   const db = getDb();
   const userId = principal.userId;
 
-  const [user, emails, profile, emergencyContacts, userRoles, attestations] =
-    await Promise.all([
-      db.query.users.findFirst({ where: eq(schema.users.id, userId) }),
-      db
-        .select({
-          email: schema.userEmails.email,
-          isPrimary: schema.userEmails.isPrimary,
-          verifiedAt: schema.userEmails.verifiedAt,
-          createdAt: schema.userEmails.createdAt,
-        })
-        .from(schema.userEmails)
-        .where(eq(schema.userEmails.userId, userId)),
-      db.query.profiles.findFirst({
-        where: eq(schema.profiles.userId, userId),
-      }),
-      db
-        .select({
-          name: schema.emergencyContacts.name,
-          phone: schema.emergencyContacts.phone,
-          relationship: schema.emergencyContacts.relationship,
-          createdAt: schema.emergencyContacts.createdAt,
-        })
-        .from(schema.emergencyContacts)
-        .where(eq(schema.emergencyContacts.userId, userId)),
-      db
-        .select({ roleId: schema.userRoles.roleId })
-        .from(schema.userRoles)
-        .where(eq(schema.userRoles.userId, userId)),
-      db
-        .select({
-          cycle: schema.waiverAttestations.cycle,
-          version: schema.waiverAttestations.version,
-          attestedAt: schema.waiverAttestations.attestedAt,
-          attestedBy: schema.waiverAttestations.attestedBy,
-          revokedAt: schema.waiverAttestations.revokedAt,
-          revokedBy: schema.waiverAttestations.revokedBy,
-          revocationReason: schema.waiverAttestations.revocationReason,
-          notes: schema.waiverAttestations.notes,
-        })
-        .from(schema.waiverAttestations)
-        .where(eq(schema.waiverAttestations.userId, userId)),
-    ]);
+  // The six reads all key on `userId` only — no dependency between
+  // them. Bundle them in a `db.batch` so they ride on a single D1
+  // HTTP request (`Promise.all` would still issue six separate
+  // calls) and observe a single point-in-time snapshot of the user's
+  // data. The export endpoint isn't on a hot path, but the
+  // consistency win (the bundle can't see a profile mid-write while
+  // missing the matching emergency-contact row) is free here.
+  const [
+    userRows,
+    emails,
+    profileRows,
+    emergencyContacts,
+    userRoles,
+    attestations,
+  ] = await db.batch([
+    db.select().from(schema.users).where(eq(schema.users.id, userId)).limit(1),
+    db
+      .select({
+        email: schema.userEmails.email,
+        isPrimary: schema.userEmails.isPrimary,
+        verifiedAt: schema.userEmails.verifiedAt,
+        createdAt: schema.userEmails.createdAt,
+      })
+      .from(schema.userEmails)
+      .where(eq(schema.userEmails.userId, userId)),
+    db
+      .select()
+      .from(schema.profiles)
+      .where(eq(schema.profiles.userId, userId))
+      .limit(1),
+    db
+      .select({
+        name: schema.emergencyContacts.name,
+        phone: schema.emergencyContacts.phone,
+        relationship: schema.emergencyContacts.relationship,
+        createdAt: schema.emergencyContacts.createdAt,
+      })
+      .from(schema.emergencyContacts)
+      .where(eq(schema.emergencyContacts.userId, userId)),
+    db
+      .select({ roleId: schema.userRoles.roleId })
+      .from(schema.userRoles)
+      .where(eq(schema.userRoles.userId, userId)),
+    db
+      .select({
+        cycle: schema.waiverAttestations.cycle,
+        version: schema.waiverAttestations.version,
+        attestedAt: schema.waiverAttestations.attestedAt,
+        attestedBy: schema.waiverAttestations.attestedBy,
+        revokedAt: schema.waiverAttestations.revokedAt,
+        revokedBy: schema.waiverAttestations.revokedBy,
+        revocationReason: schema.waiverAttestations.revocationReason,
+        notes: schema.waiverAttestations.notes,
+      })
+      .from(schema.waiverAttestations)
+      .where(eq(schema.waiverAttestations.userId, userId)),
+  ]);
 
   return {
     exportedAt: new Date().toISOString(),
     schemaVersion: 1,
-    user: user ?? null,
+    user: userRows[0] ?? null,
     emails,
-    profile: profile ?? null,
+    profile: profileRows[0] ?? null,
     emergencyContacts,
     roles: userRoles.map((r) => r.roleId),
     waiverAttestations: attestations,

--- a/apps/web/src/server/db/index.ts
+++ b/apps/web/src/server/db/index.ts
@@ -4,6 +4,22 @@ import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { env } from "#/server/cloudflare-env";
 import * as schema from "../../../drizzle/schema.ts";
 
+/**
+ * D1 driver semantics worth knowing when reading callers of this module.
+ *
+ * `drizzle-orm/d1`'s `db.batch([...])` collapses to one
+ * `D1Database#batch` HTTP request — `Promise.all([q1, q2, ...])` would
+ * issue N separate calls. The batched call also runs as a single
+ * SQLite transaction, so writes are atomic and reads observe a single
+ * point-in-time snapshot.
+ *
+ * Both properties are specific to the D1 driver and are NOT part of
+ * drizzle's cross-dialect contract. If this codebase ever swaps D1 for
+ * another backend (libSQL, Turso, raw SQLite, Postgres), the new
+ * `drizzle-orm/<driver>`'s `batch` implementation must be re-verified
+ * to preserve the one-request + atomic-tx contract before the existing
+ * call sites can be considered correct on the new backend.
+ */
 // Lazy singleton so the D1 binding is only touched when a server-fn handler
 // actually runs. Module-level evaluation stays pure — important because this
 // file can end up in the client bundle (TanStack Start's RPC compiler


### PR DESCRIPTION
## Summary

Three mechanical follow-ups bundled into one PR — they share the "tighten / document things made true by #51" theme and touch independent files.

- **#52 (perf)** — Convert `exportMyDataAction`'s six `Promise.all` reads to `db.batch` (one D1 round-trip + snapshot isolation), matching the `loadPrincipal` pattern from #51. Two `db.query.X.findFirst` calls become `db.select().from(...).limit(1)` since `db.batch` only accepts SQL builder ops. Behavior unchanged.
- **#29 (types)** — Tighten `LEGAL_INDEX_LINKS[].href` from `string` to `keyof FileRoutesByTo` so a typo'd legal-index href fails the build instead of rendering a broken `<Link>`. Used `FileRoutesByTo` over `FileRoutesByPath` because the latter includes index-route trailing-slash variants (`/members/`) that `Link.to` rejects.
- **#53 (docs)** — Add a module-level JSDoc to `server/db/index.ts` documenting that the D1 driver's `db.batch` collapses to a single HTTP request and runs as one SQLite transaction, and that those guarantees are driver-specific (relevant for any future port).

Also updated #40's issue body separately (out of band, no code) to drop the obsolete `loadReferencedR2Keys` bullet — that one was already addressed by #51.

Closes #29
Closes #52
Closes #53

## Test plan

- [x] `pnpm --filter ucmc-web typecheck` — passes (the #29 tightening exercises the route-tree type)
- [x] `pnpm --filter ucmc-web test` — 362/362 passing, incl. all 7 `export-my-data` tests
- [x] `pnpm exec eslint` on touched files — clean
- [ ] Smoke `/api/account/export` once on dev to confirm the JSON export shape is unchanged
- [ ] Smoke a `/legal` link click to confirm the typed-href change didn't break navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)