### PR TITLE
chore(ucmc-web): bundle issue cleanup for #25, #28, #34

### DIFF
--- a/apps/web/src/config/legal.ts
+++ b/apps/web/src/config/legal.ts
@@ -259,7 +259,7 @@ export const PRIVACY_BODY: readonly LegalSection[] = [
       "UC student/staff IDs (M-numbers). The Treasurer maintains the canonical roster — including IDs — on UC's official CampusLINK platform per Bylaw 1.3.",
       "Medical information, insurance information, and signed waivers. These exist only on the paper waiver, which lives off-platform with the Treasurer.",
       "Payment information. UCMC dues are collected off-platform.",
-      "Third-party analytics, ad-tech identifiers, or any tracking beyond essential session cookies and the bot-screening signals collected by Cloudflare Turnstile on the magic-link form (see processors below).",
+      "Third-party analytics, ad-tech identifiers, or any cross-site tracking beyond essential session cookies.",
     ],
   },
   {

--- a/apps/web/src/config/legal.ts
+++ b/apps/web/src/config/legal.ts
@@ -259,7 +259,7 @@ export const PRIVACY_BODY: readonly LegalSection[] = [
       "UC student/staff IDs (M-numbers). The Treasurer maintains the canonical roster — including IDs — on UC's official CampusLINK platform per Bylaw 1.3.",
       "Medical information, insurance information, and signed waivers. These exist only on the paper waiver, which lives off-platform with the Treasurer.",
       "Payment information. UCMC dues are collected off-platform.",
-      "Browser fingerprinting, third-party analytics, ad-tech identifiers, or any tracking beyond essential session cookies.",
+      "Third-party analytics, ad-tech identifiers, or any tracking beyond essential session cookies and the bot-screening signals collected by Cloudflare Turnstile on the magic-link form (see processors below).",
     ],
   },
   {
@@ -279,7 +279,8 @@ export const PRIVACY_BODY: readonly LegalSection[] = [
       "The site runs on Cloudflare Workers; member data lives in Cloudflare's managed services in the United States. We do not sell, rent, or share member data with third parties beyond the technical processors listed below.",
     ],
     bullets: [
-      "Cloudflare — hosting, edge TLS, D1 (database), R2 (avatars), KV (short-lived auth state), Turnstile (anti-bot challenge on the magic-link form), rate limiting, observability logs (~7 day retention).",
+      "Cloudflare — hosting, edge TLS, D1 (database), R2 (avatars), KV (short-lived auth state), rate limiting, observability logs (~7 day retention).",
+      "Cloudflare Turnstile — anti-bot challenge on the magic-link form. Turnstile passively scores bot-likeness from request signals (user-agent, headers, behavioral cues) on that one page; the resulting token is sent to Cloudflare for verification and is not retained server-side.",
       "Resend — outbound email delivery (the magic-link emails). Recipient address and email body are sent to Resend; Resend does not retain message content beyond the sending window.",
     ],
   },

--- a/apps/web/src/features/auth/server/magic-link-actions.server.ts
+++ b/apps/web/src/features/auth/server/magic-link-actions.server.ts
@@ -17,7 +17,7 @@ import {
   consumeMagicLink,
   requestMagicLink,
 } from "#/features/auth/server/magic-link.server";
-import { UnauthorizedError } from "#/server/auth/principal.server";
+import { UnauthorizedError } from "#/server/auth/errors.server";
 import type { Principal } from "#/server/auth/principal.server";
 import {
   clearProofCookie,

--- a/apps/web/src/features/auth/server/magic-link-actions.server.ts
+++ b/apps/web/src/features/auth/server/magic-link-actions.server.ts
@@ -17,6 +17,7 @@ import {
   consumeMagicLink,
   requestMagicLink,
 } from "#/features/auth/server/magic-link.server";
+import { UnauthorizedError } from "#/server/auth/principal.server";
 import type { Principal } from "#/server/auth/principal.server";
 import {
   clearProofCookie,
@@ -324,7 +325,7 @@ export async function exportMyDataAction(): Promise<{
 }> {
   const principal = await loadCurrentPrincipal();
   if (!principal) {
-    throw new Error("Not signed in");
+    throw new UnauthorizedError();
   }
 
   const db = getDb();

--- a/apps/web/src/features/auth/server/magic-link-actions.server.ts
+++ b/apps/web/src/features/auth/server/magic-link-actions.server.ts
@@ -286,9 +286,11 @@ export async function signOutAction(): Promise<{ ok: true }> {
  *     stolen-account scenario, not a recovery aid),
  *   - magic-link token hashes (one-shot auth state, never user-facing).
  *
- * Caller-auth is the responsibility of the route handler — it knows
- * how to return a 401 Response. Throwing here would force the
- * handler to translate, which adds a layer for no reason.
+ * Throws `UnauthorizedError` when no principal is present. The
+ * `/api/account/export` route handler `instanceof`-checks the
+ * sentinel and translates it to a 401 Response — string-matching
+ * the message would couple the route's correctness to specific
+ * error wording, which is what #25 set out to fix.
  */
 export async function exportMyDataAction(): Promise<{
   exportedAt: string;

--- a/apps/web/src/lib/sanitize-filename.ts
+++ b/apps/web/src/lib/sanitize-filename.ts
@@ -9,6 +9,13 @@
  *
  * Replaces every non-allowed character with `_`. Allowed:
  * `A-Z a-z 0-9 . _ -`.
+ *
+ * NOTE: `.` is in the whitelist, so `..` round-trips unchanged
+ * (`../../etc/passwd` becomes `.._.._etc_passwd`, not `___etc_passwd`).
+ * That's safe in a `Content-Disposition` header — `..` is inert there
+ * — but it's NOT safe if the result is used to construct a filesystem
+ * path. Do NOT reuse this helper for filesystem path construction;
+ * scope it to header / similar contexts where dots are inert.
  */
 export function sanitizeFilenameSegment(input: string): string {
   return input.replace(/[^A-Za-z0-9._-]/g, "_");

--- a/apps/web/src/routes/api/account.export.ts
+++ b/apps/web/src/routes/api/account.export.ts
@@ -11,6 +11,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import { sanitizeFilenameSegment } from "#/lib/sanitize-filename";
+import { UnauthorizedError } from "#/server/auth/principal.server";
 
 export const Route = createFileRoute("/api/account/export")({
   server: {
@@ -23,7 +24,7 @@ export const Route = createFileRoute("/api/account/export")({
         try {
           payload = await exportMyDataAction();
         } catch (err) {
-          if (err instanceof Error && err.message === "Not signed in") {
+          if (err instanceof UnauthorizedError) {
             return new Response("Unauthorized", { status: 401 });
           }
           throw err;

--- a/apps/web/src/routes/api/account.export.ts
+++ b/apps/web/src/routes/api/account.export.ts
@@ -11,7 +11,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import { sanitizeFilenameSegment } from "#/lib/sanitize-filename";
-import { UnauthorizedError } from "#/server/auth/principal.server";
+import { UnauthorizedError } from "#/server/auth/errors.server";
 
 export const Route = createFileRoute("/api/account/export")({
   server: {

--- a/apps/web/src/server/auth/errors.server.ts
+++ b/apps/web/src/server/auth/errors.server.ts
@@ -1,0 +1,19 @@
+/**
+ * Lightweight server-side auth errors. Kept in its own module (with
+ * no DB/KV imports) so route handlers and other consumers can pull
+ * the sentinel without dragging in `principal.server.ts`'s heavier
+ * Drizzle + KV dependencies at module scope.
+ */
+
+/**
+ * Thrown by server actions and route handlers when the caller is not
+ * signed in. Routes should `instanceof`-check this and translate to a
+ * 401 — string-matching the message couples the route's correctness
+ * to specific error wording.
+ */
+export class UnauthorizedError extends Error {
+  constructor(message = "Not signed in") {
+    super(message);
+    this.name = "UnauthorizedError";
+  }
+}

--- a/apps/web/src/server/auth/principal.server.ts
+++ b/apps/web/src/server/auth/principal.server.ts
@@ -9,6 +9,19 @@ import { asc, desc, eq, inArray } from "drizzle-orm";
 import { getDb, schema } from "#/server/db";
 import { getKv } from "#/server/kv";
 
+/**
+ * Thrown by server actions and route handlers when the caller is not
+ * signed in. Routes should `instanceof`-check this and translate to a
+ * 401 — string-matching the message couples the route's correctness
+ * to specific error wording.
+ */
+export class UnauthorizedError extends Error {
+  constructor(message = "Not signed in") {
+    super(message);
+    this.name = "UnauthorizedError";
+  }
+}
+
 export interface Principal {
   userId: string;
   /**

--- a/apps/web/src/server/auth/principal.server.ts
+++ b/apps/web/src/server/auth/principal.server.ts
@@ -9,19 +9,6 @@ import { asc, desc, eq, inArray } from "drizzle-orm";
 import { getDb, schema } from "#/server/db";
 import { getKv } from "#/server/kv";
 
-/**
- * Thrown by server actions and route handlers when the caller is not
- * signed in. Routes should `instanceof`-check this and translate to a
- * 401 — string-matching the message couples the route's correctness
- * to specific error wording.
- */
-export class UnauthorizedError extends Error {
-  constructor(message = "Not signed in") {
-    super(message);
-    this.name = "UnauthorizedError";
-  }
-}
-
 export interface Principal {
   userId: string;
   /**


### PR DESCRIPTION
## Summary

Three small follow-ups bundled into one PR — all touching different files, all surfaced in PR #23 / #33 review threads.

- **#25 (types)** — Introduce `UnauthorizedError` in `server/auth/principal.server.ts` and have `exportMyDataAction` throw it instead of a bare `Error("Not signed in")`. The `/api/account/export` route now `instanceof`-checks the typed sentinel rather than string-matching the message, so a future wording change on the action can't silently turn a 401 into a 500. Other actions still throw the bare-string error — out of scope for this issue, can be migrated incrementally.
- **#28 (docs)** — Rephrase the privacy "what we don't collect" bullet to drop the bare "fingerprinting" claim, and call out Cloudflare Turnstile explicitly in the processors section as collecting passive bot-screening signals on the magic-link form. Keeps the privacy text internally consistent with what the magic-link flow actually runs.
- **#34 (docs)** — Add a JSDoc warning to `sanitizeFilenameSegment` that it's safe ONLY for `Content-Disposition` / similar header contexts. `.` is in the whitelist, so `..` round-trips unchanged — using the helper for filesystem path construction would be one underscore-collapse away from a path traversal vulnerability.

Also closing **#27** out of band: the privacy retention text already uses definitive language (`legal.ts:290-291`: "Rejected registrations **are deleted** 30 days…" / "Deactivated accounts **are deleted** 12 months…"). The "may → will" pivot called for in that issue has happened in the natural course of work.

Closes #25
Closes #28
Closes #34

## Test plan

- [x] `pnpm --filter ucmc-web typecheck` — passes
- [x] `pnpm --filter ucmc-web test` — 362/362 passing (existing `export-my-data` test asserting `.toThrow("Not signed in")` still passes because `UnauthorizedError`'s default message is preserved)
- [x] `pnpm exec eslint` on touched files — clean
- [ ] Smoke an unauthenticated GET on `/api/account/export` to confirm 401 still returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)