### PR TITLE
perf(ucmc-web): cut worker CPU on avatar fetches and hero carousel

### DIFF
--- a/apps/web/public/landing/trip-1.svg
+++ b/apps/web/public/landing/trip-1.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" preserveAspectRatio="none"><rect width="800" height="600" fill="#1e293b"/></svg>

--- a/apps/web/public/landing/trip-2.svg
+++ b/apps/web/public/landing/trip-2.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" preserveAspectRatio="none"><rect width="800" height="600" fill="#166534"/></svg>

--- a/apps/web/public/landing/trip-3.svg
+++ b/apps/web/public/landing/trip-3.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" preserveAspectRatio="none"><rect width="800" height="600" fill="#78716c"/></svg>

--- a/apps/web/public/landing/trip-4.svg
+++ b/apps/web/public/landing/trip-4.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" preserveAspectRatio="none"><rect width="800" height="600" fill="#b45309"/></svg>

--- a/apps/web/public/landing/trip-5.svg
+++ b/apps/web/public/landing/trip-5.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" preserveAspectRatio="none"><rect width="800" height="600" fill="#0c4a6e"/></svg>

--- a/apps/web/public/landing/trip-6.svg
+++ b/apps/web/public/landing/trip-6.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" preserveAspectRatio="none"><rect width="800" height="600" fill="#44403c"/></svg>

--- a/apps/web/src/features/landing/components/photo-carousel.tsx
+++ b/apps/web/src/features/landing/components/photo-carousel.tsx
@@ -12,12 +12,12 @@ import {
 // trip photos at apps/web/public/landing/trip-{1..6}.{jpg,webp} and
 // update the src + alt for each entry.
 const photos = [
-  { src: "/landing/trip-1.svg", alt: "Placeholder image" },
-  { src: "/landing/trip-2.svg", alt: "Placeholder image" },
-  { src: "/landing/trip-3.svg", alt: "Placeholder image" },
-  { src: "/landing/trip-4.svg", alt: "Placeholder image" },
-  { src: "/landing/trip-5.svg", alt: "Placeholder image" },
-  { src: "/landing/trip-6.svg", alt: "Placeholder image" },
+  { src: "/landing/trip-1.svg", alt: "" },
+  { src: "/landing/trip-2.svg", alt: "" },
+  { src: "/landing/trip-3.svg", alt: "" },
+  { src: "/landing/trip-4.svg", alt: "" },
+  { src: "/landing/trip-5.svg", alt: "" },
+  { src: "/landing/trip-6.svg", alt: "" },
 ];
 
 // embla-carousel-react's internal hooks crash under TanStack Start's SSR

--- a/apps/web/src/features/landing/components/photo-carousel.tsx
+++ b/apps/web/src/features/landing/components/photo-carousel.tsx
@@ -8,16 +8,16 @@ import {
   CarouselPrevious,
 } from "#/components/ui/carousel";
 
-// TODO(content): drop trip photos into apps/web/public/landing/ and update
-// the src + alt for each entry. The carousel will render placeholders until
-// real images exist at these paths.
+// TODO(content): replace these solid-color SVG placeholders with real
+// trip photos at apps/web/public/landing/trip-{1..6}.{jpg,webp} and
+// update the src + alt for each entry.
 const photos = [
-  { src: "/landing/trip-1.jpg", alt: "TODO(content): describe photo 1" },
-  { src: "/landing/trip-2.jpg", alt: "TODO(content): describe photo 2" },
-  { src: "/landing/trip-3.jpg", alt: "TODO(content): describe photo 3" },
-  { src: "/landing/trip-4.jpg", alt: "TODO(content): describe photo 4" },
-  { src: "/landing/trip-5.jpg", alt: "TODO(content): describe photo 5" },
-  { src: "/landing/trip-6.jpg", alt: "TODO(content): describe photo 6" },
+  { src: "/landing/trip-1.svg", alt: "Placeholder image" },
+  { src: "/landing/trip-2.svg", alt: "Placeholder image" },
+  { src: "/landing/trip-3.svg", alt: "Placeholder image" },
+  { src: "/landing/trip-4.svg", alt: "Placeholder image" },
+  { src: "/landing/trip-5.svg", alt: "Placeholder image" },
+  { src: "/landing/trip-6.svg", alt: "Placeholder image" },
 ];
 
 // embla-carousel-react's internal hooks crash under TanStack Start's SSR

--- a/apps/web/src/routes/api/avatars.$.ts
+++ b/apps/web/src/routes/api/avatars.$.ts
@@ -33,14 +33,15 @@ export const Route = createFileRoute("/api/avatars/$")({
   server: {
     handlers: {
       GET: async ({ params }: { params: { _splat?: string } }) => {
-        const { requireSession } = await import("#/server/auth/session.server");
+        const { loadCurrentSession } =
+          await import("#/server/auth/session.server");
         const { getAvatar } = await import("#/server/r2/avatars.server");
 
         // Lightweight session check only — avatar bytes don't need the
         // full principal, so we skip the RBAC/profile/email joins +
         // sliding-refresh write that loadCurrentPrincipal pays for.
-        // See requireSession() in session.server.ts.
-        const session = await requireSession();
+        // See loadCurrentSession() in session.server.ts.
+        const session = await loadCurrentSession();
         if (!session) {
           return new Response("Unauthorized", { status: 401 });
         }

--- a/apps/web/src/routes/api/avatars.$.ts
+++ b/apps/web/src/routes/api/avatars.$.ts
@@ -33,12 +33,15 @@ export const Route = createFileRoute("/api/avatars/$")({
   server: {
     handlers: {
       GET: async ({ params }: { params: { _splat?: string } }) => {
-        const { loadCurrentPrincipal } =
-          await import("#/server/auth/session.server");
+        const { requireSession } = await import("#/server/auth/session.server");
         const { getAvatar } = await import("#/server/r2/avatars.server");
 
-        const principal = await loadCurrentPrincipal();
-        if (!principal) {
+        // Lightweight session check only — avatar bytes don't need the
+        // full principal, so we skip the RBAC/profile/email joins +
+        // sliding-refresh write that loadCurrentPrincipal pays for.
+        // See requireSession() in session.server.ts.
+        const session = await requireSession();
+        if (!session) {
           return new Response("Unauthorized", { status: 401 });
         }
 

--- a/apps/web/src/server/auth/__tests__/session.test.ts
+++ b/apps/web/src/server/auth/__tests__/session.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getDb, schema } from "#/server/db";
+import type * as PrincipalModule from "#/server/auth/principal.server";
+
+let cookieValue: string | undefined;
+let cookieCleared = false;
+
+vi.mock("@tanstack/react-start/server", () => ({
+  getCookie: () => cookieValue,
+  setCookie: () => {},
+  deleteCookie: () => {
+    cookieCleared = true;
+  },
+  getRequestHeader: () => undefined,
+}));
+
+const loadPrincipalSpy = vi.fn(async () => null);
+vi.mock("#/server/auth/principal.server", async () => {
+  const actual = await vi.importActual<typeof PrincipalModule>(
+    "#/server/auth/principal.server",
+  );
+  return {
+    ...actual,
+    loadPrincipal: loadPrincipalSpy,
+  };
+});
+
+const { requireSession } = await import("#/server/auth/session.server");
+
+async function seedSession(
+  opts: {
+    expiresAt?: Date;
+  } = {},
+): Promise<{ sid: string; userId: string }> {
+  const userId = `user_${crypto.randomUUID()}`;
+  await getDb()
+    .insert(schema.users)
+    .values({
+      id: userId,
+      publicId: crypto.randomUUID().replace(/-/g, "").slice(0, 12),
+      status: "approved",
+    });
+  const sid = crypto.randomUUID();
+  const now = new Date();
+  await getDb()
+    .insert(schema.sessions)
+    .values({
+      id: sid,
+      userId,
+      createdAt: now,
+      lastSeenAt: now,
+      expiresAt: opts.expiresAt ?? new Date(now.getTime() + 60_000),
+    });
+  return { sid, userId };
+}
+
+beforeEach(async () => {
+  const db = getDb();
+  await db.delete(schema.sessions);
+  await db.delete(schema.users);
+  cookieValue = undefined;
+  cookieCleared = false;
+  loadPrincipalSpy.mockClear();
+});
+
+describe("requireSession", () => {
+  it("returns null when no session cookie is set", async () => {
+    expect(await requireSession()).toBeNull();
+  });
+
+  it("returns null when the cookie points at no session row", async () => {
+    cookieValue = "00000000-0000-0000-0000-000000000000";
+    expect(await requireSession()).toBeNull();
+    expect(cookieCleared).toBe(true);
+  });
+
+  it("returns null and clears the cookie when the session is expired", async () => {
+    const { sid } = await seedSession({
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    cookieValue = sid;
+    expect(await requireSession()).toBeNull();
+    expect(cookieCleared).toBe(true);
+  });
+
+  it("returns { userId } for a valid session", async () => {
+    const { sid, userId } = await seedSession();
+    cookieValue = sid;
+    expect(await requireSession()).toEqual({ userId });
+  });
+
+  it("does not call loadPrincipal", async () => {
+    const { sid } = await seedSession();
+    cookieValue = sid;
+    await requireSession();
+    expect(loadPrincipalSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/server/auth/__tests__/session.test.ts
+++ b/apps/web/src/server/auth/__tests__/session.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getDb, schema } from "#/server/db";
+import type { UserStatus } from "#/../drizzle/schema";
 import type * as PrincipalModule from "#/server/auth/principal.server";
 
 let cookieValue: string | undefined;
@@ -26,11 +27,12 @@ vi.mock("#/server/auth/principal.server", async () => {
   };
 });
 
-const { requireSession } = await import("#/server/auth/session.server");
+const { loadCurrentSession } = await import("#/server/auth/session.server");
 
 async function seedSession(
   opts: {
     expiresAt?: Date;
+    status?: UserStatus;
   } = {},
 ): Promise<{ sid: string; userId: string }> {
   const userId = `user_${crypto.randomUUID()}`;
@@ -39,7 +41,7 @@ async function seedSession(
     .values({
       id: userId,
       publicId: crypto.randomUUID().replace(/-/g, "").slice(0, 12),
-      status: "approved",
+      status: opts.status ?? "approved",
     });
   const sid = crypto.randomUUID();
   const now = new Date();
@@ -64,14 +66,14 @@ beforeEach(async () => {
   loadPrincipalSpy.mockClear();
 });
 
-describe("requireSession", () => {
+describe("loadCurrentSession", () => {
   it("returns null when no session cookie is set", async () => {
-    expect(await requireSession()).toBeNull();
+    expect(await loadCurrentSession()).toBeNull();
   });
 
   it("returns null when the cookie points at no session row", async () => {
     cookieValue = "00000000-0000-0000-0000-000000000000";
-    expect(await requireSession()).toBeNull();
+    expect(await loadCurrentSession()).toBeNull();
     expect(cookieCleared).toBe(true);
   });
 
@@ -80,20 +82,28 @@ describe("requireSession", () => {
       expiresAt: new Date(Date.now() - 1000),
     });
     cookieValue = sid;
-    expect(await requireSession()).toBeNull();
+    expect(await loadCurrentSession()).toBeNull();
     expect(cookieCleared).toBe(true);
   });
 
   it("returns { userId } for a valid session", async () => {
     const { sid, userId } = await seedSession();
     cookieValue = sid;
-    expect(await requireSession()).toEqual({ userId });
+    expect(await loadCurrentSession()).toEqual({ userId });
   });
 
   it("does not call loadPrincipal", async () => {
     const { sid } = await seedSession();
     cookieValue = sid;
-    await requireSession();
+    await loadCurrentSession();
     expect(loadPrincipalSpy).not.toHaveBeenCalled();
+  });
+
+  // Locks in the documented behavior that deactivation is intentionally
+  // NOT checked here — callers that care must reach for loadCurrentPrincipal.
+  it("returns { userId } even when the user is deactivated", async () => {
+    const { sid, userId } = await seedSession({ status: "deactivated" });
+    cookieValue = sid;
+    expect(await loadCurrentSession()).toEqual({ userId });
   });
 });

--- a/apps/web/src/server/auth/session.server.ts
+++ b/apps/web/src/server/auth/session.server.ts
@@ -158,3 +158,34 @@ export async function loadCurrentPrincipal(): Promise<Principal | null> {
 
   return principal;
 }
+
+/**
+ * Lightweight "is there a valid session?" check for hot paths that don't
+ * need the full principal — e.g. asset routes serving R2-backed bytes.
+ * Returns `{ userId } | null` after a single D1 round trip.
+ *
+ * Skipped vs. {@link loadCurrentPrincipal}:
+ *   - principal load (users + profiles + emails + roles + permissions joins)
+ *   - deactivated-user check
+ *   - sliding-window refresh write
+ *
+ * Each of those would force more D1 RTTs, and per-page asset bursts can hit
+ * this 10+ times in a single request fan-out. Use ONLY when the caller
+ * genuinely doesn't need anything past `userId`. If you need permissions,
+ * roles, profile, deactivation status, or sliding refresh, use
+ * {@link loadCurrentPrincipal} and pay the cost.
+ */
+export async function requireSession(): Promise<{ userId: string } | null> {
+  const sid = readSessionCookie();
+  if (!sid) {
+    return null;
+  }
+
+  const session = await getSessionRow(sid);
+  if (!session) {
+    clearSessionCookie();
+    return null;
+  }
+
+  return { userId: session.userId };
+}

--- a/apps/web/src/server/auth/session.server.ts
+++ b/apps/web/src/server/auth/session.server.ts
@@ -162,7 +162,12 @@ export async function loadCurrentPrincipal(): Promise<Principal | null> {
 /**
  * Lightweight "is there a valid session?" check for hot paths that don't
  * need the full principal — e.g. asset routes serving R2-backed bytes.
- * Returns `{ userId } | null` after a single D1 round trip.
+ * Returns `{ userId } | null` after at most two D1 statements: one SELECT
+ * on the happy path, plus a DELETE if the cookie points at an expired row.
+ *
+ * Naming mirrors {@link loadCurrentPrincipal}: both return `null` for
+ * anonymous/invalid; neither throws. This is NOT a `require*` guard — the
+ * `require*` helpers in `features/auth/guards.ts` throw `redirect()`.
  *
  * Skipped vs. {@link loadCurrentPrincipal}:
  *   - principal load (users + profiles + emails + roles + permissions joins)
@@ -175,7 +180,9 @@ export async function loadCurrentPrincipal(): Promise<Principal | null> {
  * roles, profile, deactivation status, or sliding refresh, use
  * {@link loadCurrentPrincipal} and pay the cost.
  */
-export async function requireSession(): Promise<{ userId: string } | null> {
+export async function loadCurrentSession(): Promise<{
+  userId: string;
+} | null> {
   const sid = readSessionCookie();
   if (!sid) {
     return null;


### PR DESCRIPTION
## Summary

Phase 1 of the worker-CPU reduction effort. 7-day Workers Logs telemetry on `ucmc-web` (free plan, 10 ms documented CPU limit) showed P50 12 / P90 64 / P95 90 / P99 153 ms — 60% of requests over budget, no 1102 errors yet (running on grace). Two regressions own most of the tail; this PR fixes both.

- **`/api/avatars/*` was loading the full principal** for every byte served — RBAC + profile + email joins, deactivated-user check, sliding-window session refresh write. Add a lean `requireSession()` helper that does one D1 round trip and returns `{ userId } | null`. Swap the avatar route to it. Expected: P95 ~32 ms → ~12–18 ms.
- **The landing hero carousel pointed at `/landing/trip-{1..6}.jpg`** — orphaned URLs that 404'd through TanStack Start's not-found render (P95 76–153 ms CPU) AND showed users broken images. Re-point to `/landing/trip-{1..6}.svg` and ship 143-byte solid-color placeholder SVGs so `@cloudflare/vite-plugin` serves them as static assets — the worker never sees the request. Real photos to follow (TODO in carousel).

Sitemap (`/sitemap.xml`, P95 59 ms × 37 reqs/week) intentionally left for a future branch — the right fix is build-time pre-render to `public/sitemap.xml`, not in scope here.

A two-bucket public/private R2 split is the Phase 2 follow-up — see `infra/r2-public-bucket` (already open).

## Test plan

- [x] `pnpm --filter ucmc-web typecheck` clean
- [x] `pnpm --filter ucmc-web lint` clean (0 errors; 14 pre-existing warnings unrelated)
- [x] `pnpm --filter ucmc-web test` — 367/367 passing, including 5 new `requireSession` tests covering: null on no cookie, null + cookie clear on missing session row, null + cookie clear on expired session, `{ userId }` on valid session, `loadPrincipal` is never called.
- [x] Local dev: each placeholder SVG returns HTTP 200 / `image/svg+xml` / 143 bytes; orphan `.jpg` URLs no longer referenced anywhere on `/`.
- [ ] Post-merge dev validation: `wrangler tail --env dev` for ~24h to confirm `/landing/trip-*.jpg` 404s vanish from worker logs and `/api/avatars/*` P95 drops in subsequent telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)