### PR TITLE
feat(infra): provision public R2 bucket + CDN custom domain

### DIFF
--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -5,6 +5,8 @@ config:
   ucmc-infra:workerName: ucmc-web-dev
   ucmc-infra:d1DatabaseName: ucmc-web-dev
   ucmc-infra:r2BucketName: ucmc-web-dev-storage
+  ucmc-infra:r2PublicBucketName: ucmc-web-dev-public-storage
+  ucmc-infra:cdnHostname: cdn.dev.ucmc.spencerwill.com
   ucmc-infra:kvNamespaceTitle: ucmc-web-dev-kv
   ucmc-infra:webauthnRpName: UCMC (dev)
   ucmc-infra:resendFromName: UCMC

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -5,6 +5,8 @@ config:
   ucmc-infra:workerName: ucmc-web
   ucmc-infra:d1DatabaseName: ucmc-web
   ucmc-infra:r2BucketName: ucmc-web-storage
+  ucmc-infra:r2PublicBucketName: ucmc-web-public-storage
+  ucmc-infra:cdnHostname: cdn.ucmc.spencerwill.com
   ucmc-infra:kvNamespaceTitle: ucmc-web-kv
   ucmc-infra:webauthnRpName: UCMC
   ucmc-infra:resendFromName: UCMC

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -13,6 +13,8 @@ const hostname = cfg.require("hostname");
 const workerName = cfg.require("workerName");
 const d1DatabaseName = cfg.require("d1DatabaseName");
 const r2BucketName = cfg.require("r2BucketName");
+const r2PublicBucketName = cfg.require("r2PublicBucketName");
+const cdnHostname = cfg.require("cdnHostname");
 const kvNamespaceTitle = cfg.require("kvNamespaceTitle");
 const webauthnRpName = cfg.require("webauthnRpName");
 const resendFromName = cfg.require("resendFromName");
@@ -57,6 +59,44 @@ const bucket = new cloudflare.R2Bucket(
     location: "enam",
   },
   { protect: true },
+);
+
+// Public R2 bucket for content that's safe to serve directly from a
+// Cloudflare CDN custom domain — avatars, landing photos, future public
+// media. URL bytes bypass the worker entirely, so reads don't pay any
+// CPU. Anything held here is implicitly readable by anyone who has the
+// URL; the private bucket above is the default for everything else.
+//
+// `protect: true` — same data-loss reasoning as the private bucket.
+const publicBucket = new cloudflare.R2Bucket(
+  `ucmc-web-${stack}-public-bucket`,
+  {
+    accountId,
+    name: r2PublicBucketName,
+    location: "enam",
+  },
+  { protect: true },
+);
+
+// Binds the CDN hostname to the public bucket. Cloudflare provisions
+// the proxied DNS record + edge cert automatically. Setting `enabled`
+// explicitly even though it's the default — the resource argument is
+// required and Cloudflare's API treats undefined as enabled, so we
+// state intent rather than rely on the default.
+//
+// `minTls: "1.2"` — refuse TLS 1.0/1.1 connections, matching modern
+// Cloudflare zone defaults. Avatars are loaded by every modern browser
+// over HTTPS; there's no legitimate downstream that can't do 1.2+.
+const publicBucketDomain = new cloudflare.R2CustomDomain(
+  `ucmc-web-${stack}-cdn`,
+  {
+    accountId,
+    zoneId,
+    bucketName: publicBucket.name,
+    domain: cdnHostname,
+    enabled: true,
+    minTls: "1.2",
+  },
 );
 
 // Workers KV namespace for the web app. Wrangler binds by namespace UUID
@@ -104,6 +144,16 @@ export const d1DatabaseNameOutput = database.name;
 // already static in `apps/web/wrangler.jsonc`, so this export is for drift
 // detection / reference rather than being consumed by any workflow today.
 export const r2BucketNameOutput = bucket.name;
+
+// Public R2 bucket name — same drift-detection role as the private
+// bucket above. Wrangler will bind to it by name once the public binding
+// lands in `apps/web/wrangler.jsonc`.
+export const r2PublicBucketNameOutput = publicBucket.name;
+
+// CDN hostname for the public bucket. Consumed by `web-deploy.yml` and
+// passed to the worker as `R2_PUBLIC_HOST` so the app can construct
+// `https://${R2_PUBLIC_HOST}/<key>` URLs that bypass the worker.
+export const r2PublicHost = publicBucketDomain.domain;
 
 // KV namespace UUID — wrangler needs this for `kv_namespaces[].id`. The
 // web-deploy workflow injects it into `apps/web/wrangler.jsonc` before


### PR DESCRIPTION
## Summary

Phase 2 PR 2a of the worker-CPU reduction effort. Provisions a second R2 bucket per environment (public, served directly via a Cloudflare R2 custom domain) so future PRs can move avatars + landing photos out of the worker entirely. The existing private bucket is unchanged and stays the default for everything else (waivers and other future private media).

- New: `cloudflare.R2Bucket` `ucmc-web-{dev,}-public-bucket` (`protect: true`, location `enam`)
- New: `cloudflare.R2CustomDomain` `ucmc-web-{dev,}-cdn` (`enabled: true`, `minTls: "1.2"`) bound to the new public bucket on the existing zone
- New stack outputs: `r2PublicBucketNameOutput`, `r2PublicHost` — consumed by `web-deploy.yml` in the follow-up PR
- New config keys per stack: `r2PublicBucketName`, `cdnHostname`

Hostnames:
- prod: `cdn.ucmc.spencerwill.com` → `ucmc-web-public-storage`
- dev: `cdn.dev.ucmc.spencerwill.com` → `ucmc-web-dev-public-storage`

This PR does NOT yet wire the web app to the new bucket. That's `feat/r2-public-binding` (PR 2b) which depends on these stack outputs being live, so deploy ordering is **dev infra → verify → prod infra → verify → app PR**.

`pulumi preview` against the dev stack confirmed: 2 new resources, no replacements, no drift, no edits to the existing private bucket. The custom domain's `bucketName` resolves to the new public bucket — verified to NOT bind to the existing private one.

## Test plan

- [x] `pnpm --filter @ucmc/infra exec tsc --noEmit` clean
- [x] `pnpm --filter @ucmc/infra exec eslint .` clean
- [x] `pulumi preview --stack dev` shows exactly 2 new resources (R2Bucket + R2CustomDomain), no replacements, no deletions
- [ ] After merge + auto-deploy to dev: `dig cdn.dev.ucmc.spencerwill.com` resolves and `curl -I https://cdn.dev.ucmc.spencerwill.com/` returns Cloudflare 404 with valid TLS cert
- [ ] Manual prod deploy via workflow_dispatch + same dig/curl check on `cdn.ucmc.spencerwill.com`
- [ ] After both envs verified, open PR 2b (`feat/r2-public-binding`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)