### PR TITLE
perf(ucmc-web): edge-cache anonymous public pages

### DIFF
--- a/apps/web/src/server-entry.ts
+++ b/apps/web/src/server-entry.ts
@@ -3,15 +3,17 @@
  * entry (which provides `fetch`) with:
  *   - a `scheduled` handler so cron triggers declared in
  *     `wrangler.jsonc` reach our retention sweeps; and
- *   - an anonymous home-page cache layer that serves `/` from
- *     `caches.default` for cookie-less GETs (see `./server/edge-cache`).
+ *   - a public-page cache layer that serves cookie-less GETs to a
+ *     known set of public pages (`/`, `/about`, `/membership`, the
+ *     legal/policy routes) from `caches.default` (see
+ *     `./server/edge-cache`).
  *
  * `wrangler.jsonc` `main` points here instead of straight at the
  * TanStack package.
  */
 import startEntry from "@tanstack/react-start/server-entry";
 
-import { withAnonymousHomeCache } from "./server/edge-cache";
+import { withPublicPageCache } from "./server/edge-cache";
 import type { WorkerFetchHandler } from "./server/edge-cache";
 
 // `startEntry.fetch` is typed `(request, opts?)` even though the
@@ -21,7 +23,7 @@ import type { WorkerFetchHandler } from "./server/edge-cache";
 // losing the runtime invocation. (This same gap is why the original
 // `satisfies` line used `typeof startEntry.fetch` rather than
 // `ExportedHandlerFetchHandler` — keeping that to avoid further drift.)
-const cachedFetch = withAnonymousHomeCache(
+const cachedFetch = withPublicPageCache(
   startEntry.fetch as unknown as WorkerFetchHandler,
 );
 

--- a/apps/web/src/server-entry.ts
+++ b/apps/web/src/server-entry.ts
@@ -1,23 +1,41 @@
 /**
  * Cloudflare Worker entry point. Wraps TanStack Start's default server
- * entry (which provides `fetch`) with a `scheduled` handler so cron
- * triggers declared in `wrangler.jsonc` reach our retention sweeps.
+ * entry (which provides `fetch`) with:
+ *   - a `scheduled` handler so cron triggers declared in
+ *     `wrangler.jsonc` reach our retention sweeps; and
+ *   - an anonymous home-page cache layer that serves `/` from
+ *     `caches.default` for cookie-less GETs (see `./server/edge-cache`).
  *
  * `wrangler.jsonc` `main` points here instead of straight at the
- * TanStack package; the only meaningful difference is the additional
- * scheduled export.
+ * TanStack package.
  */
 import startEntry from "@tanstack/react-start/server-entry";
+
+import { withAnonymousHomeCache } from "./server/edge-cache";
+import type { WorkerFetchHandler } from "./server/edge-cache";
+
+// `startEntry.fetch` is typed `(request, opts?)` even though the
+// Cloudflare runtime always invokes it as `(request, env, ctx)` via
+// the standard ExportedHandler contract. Cast to the runtime shape so
+// the wrapper's `inner.call(request, env, ctx)` typechecks without
+// losing the runtime invocation. (This same gap is why the original
+// `satisfies` line used `typeof startEntry.fetch` rather than
+// `ExportedHandlerFetchHandler` — keeping that to avoid further drift.)
+const cachedFetch = withAnonymousHomeCache(
+  startEntry.fetch as unknown as WorkerFetchHandler,
+);
 
 // `ExportedHandler<WorkerEnv>` from @cloudflare/workers-types declares
 // `fetch` with a Request shape that doesn't match the one TanStack
 // Start's handler expects (the latter omits a few standard Fetch
-// properties). Spreading the Start handler and adding a `scheduled`
-// key gives us the right runtime shape; we annotate `scheduled`
-// individually so the cron contract is type-checked without fighting
-// TypeScript over the fetch signature.
+// properties). Spreading the Start handler and overriding `fetch` +
+// adding `scheduled` gives us the right runtime shape; we annotate
+// `scheduled` individually so the cron contract is type-checked
+// without fighting TypeScript over the fetch signature.
 export default {
   ...startEntry,
+
+  fetch: cachedFetch as unknown as typeof startEntry.fetch,
 
   async scheduled(_event, _env, ctx) {
     // Server-only import. Lazy-loaded so the worker entry's static

--- a/apps/web/src/server/__tests__/edge-cache.test.ts
+++ b/apps/web/src/server/__tests__/edge-cache.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  homePageCacheKey,
+  isAnonymousHomePageRequest,
+} from "#/server/edge-cache";
+
+const ORIGIN = "https://example.com";
+
+function makeRequest(
+  pathAndQuery: string,
+  init?: { method?: string; cookie?: string },
+): Request {
+  const headers = new Headers();
+  if (init?.cookie) {
+    headers.set("cookie", init.cookie);
+  }
+  return new Request(`${ORIGIN}${pathAndQuery}`, {
+    method: init?.method ?? "GET",
+    headers,
+  });
+}
+
+describe("isAnonymousHomePageRequest", () => {
+  it("returns true for GET / with no cookies", () => {
+    expect(isAnonymousHomePageRequest(makeRequest("/"))).toBe(true);
+  });
+
+  it("returns true for GET / with a non-auth cookie", () => {
+    expect(
+      isAnonymousHomePageRequest(makeRequest("/", { cookie: "_ga=GA1.2.x" })),
+    ).toBe(true);
+  });
+
+  it("returns true for GET / with a query string", () => {
+    expect(isAnonymousHomePageRequest(makeRequest("/?utm_source=insta"))).toBe(
+      true,
+    );
+  });
+
+  it.each([
+    ["ucmc_session=abc"],
+    ["__Host-ucmc_session=abc"],
+    ["ucmc_proof=xyz"],
+    ["__Host-ucmc_proof=xyz"],
+    ["ucmc_webauthn=qrs"],
+    ["__Host-ucmc_webauthn=qrs"],
+  ])("returns false for GET / with %s cookie", (cookie) => {
+    expect(isAnonymousHomePageRequest(makeRequest("/", { cookie }))).toBe(
+      false,
+    );
+  });
+
+  it("returns false when an auth cookie is present alongside others", () => {
+    expect(
+      isAnonymousHomePageRequest(
+        makeRequest("/", {
+          cookie: "_ga=GA1.2.x; ucmc_session=abc; theme=dark",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does NOT false-positive on a tracking cookie value containing 'ucmc_session='", () => {
+    // Defensive: a name-based parse should treat 'ucmc_session=abc' as a
+    // *value* (not a name) when it appears after '='. This guards a future
+    // sloppy substring check from regressing.
+    expect(
+      isAnonymousHomePageRequest(
+        makeRequest("/", { cookie: "_evil=ucmc_session=fake" }),
+      ),
+    ).toBe(true);
+  });
+
+  it.each(["POST", "HEAD", "OPTIONS", "DELETE"])(
+    "returns false for %s /",
+    (method) => {
+      expect(isAnonymousHomePageRequest(makeRequest("/", { method }))).toBe(
+        false,
+      );
+    },
+  );
+
+  it.each(["/about", "/sign-in", "/announcements", "/foo"])(
+    "returns false for GET %s with no cookies",
+    (path) => {
+      expect(isAnonymousHomePageRequest(makeRequest(path))).toBe(false);
+    },
+  );
+});
+
+describe("homePageCacheKey", () => {
+  it("strips query strings so utm variants share an entry", () => {
+    const a = homePageCacheKey(makeRequest("/?utm_source=insta"));
+    const b = homePageCacheKey(makeRequest("/?utm_source=fb&ref=email"));
+    expect(a.url).toBe(`${ORIGIN}/`);
+    expect(b.url).toBe(`${ORIGIN}/`);
+    expect(a.method).toBe("GET");
+  });
+
+  it("preserves the request origin", () => {
+    const request = new Request("https://other.example/", { method: "GET" });
+    expect(homePageCacheKey(request).url).toBe("https://other.example/");
+  });
+});

--- a/apps/web/src/server/__tests__/edge-cache.test.ts
+++ b/apps/web/src/server/__tests__/edge-cache.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  homePageCacheKey,
-  isAnonymousHomePageRequest,
+  isCacheablePublicPageRequest,
+  publicPageCacheKey,
 } from "#/server/edge-cache";
 
 const ORIGIN = "https://example.com";
@@ -21,21 +21,36 @@ function makeRequest(
   });
 }
 
-describe("isAnonymousHomePageRequest", () => {
+describe("isCacheablePublicPageRequest", () => {
   it("returns true for GET / with no cookies", () => {
-    expect(isAnonymousHomePageRequest(makeRequest("/"))).toBe(true);
+    expect(isCacheablePublicPageRequest(makeRequest("/"))).toBe(true);
   });
 
   it("returns true for GET / with a non-auth cookie", () => {
     expect(
-      isAnonymousHomePageRequest(makeRequest("/", { cookie: "_ga=GA1.2.x" })),
+      isCacheablePublicPageRequest(makeRequest("/", { cookie: "_ga=GA1.2.x" })),
     ).toBe(true);
   });
 
   it("returns true for GET / with a query string", () => {
-    expect(isAnonymousHomePageRequest(makeRequest("/?utm_source=insta"))).toBe(
-      true,
-    );
+    expect(
+      isCacheablePublicPageRequest(makeRequest("/?utm_source=insta")),
+    ).toBe(true);
+  });
+
+  it.each([
+    "/about",
+    "/membership",
+    "/legal",
+    "/disclaimer",
+    "/anti-hazing",
+    "/nondiscrimination",
+    "/waiver",
+    "/privacy",
+    "/terms",
+    "/open-source",
+  ])("returns true for GET %s with no cookies", (path) => {
+    expect(isCacheablePublicPageRequest(makeRequest(path))).toBe(true);
   });
 
   it.each([
@@ -46,14 +61,25 @@ describe("isAnonymousHomePageRequest", () => {
     ["ucmc_webauthn=qrs"],
     ["__Host-ucmc_webauthn=qrs"],
   ])("returns false for GET / with %s cookie", (cookie) => {
-    expect(isAnonymousHomePageRequest(makeRequest("/", { cookie }))).toBe(
+    expect(isCacheablePublicPageRequest(makeRequest("/", { cookie }))).toBe(
       false,
     );
   });
 
+  it("returns false for any cacheable path when an auth cookie is present", () => {
+    // The auth-cookie gate applies to every path uniformly. Spot-check
+    // one of the legal routes to make sure the bypass is on cookies,
+    // not just `/`.
+    expect(
+      isCacheablePublicPageRequest(
+        makeRequest("/privacy", { cookie: "ucmc_session=abc" }),
+      ),
+    ).toBe(false);
+  });
+
   it("returns false when an auth cookie is present alongside others", () => {
     expect(
-      isAnonymousHomePageRequest(
+      isCacheablePublicPageRequest(
         makeRequest("/", {
           cookie: "_ga=GA1.2.x; ucmc_session=abc; theme=dark",
         }),
@@ -66,7 +92,7 @@ describe("isAnonymousHomePageRequest", () => {
     // *value* (not a name) when it appears after '='. This guards a future
     // sloppy substring check from regressing.
     expect(
-      isAnonymousHomePageRequest(
+      isCacheablePublicPageRequest(
         makeRequest("/", { cookie: "_evil=ucmc_session=fake" }),
       ),
     ).toBe(true);
@@ -75,31 +101,48 @@ describe("isAnonymousHomePageRequest", () => {
   it.each(["POST", "HEAD", "OPTIONS", "DELETE"])(
     "returns false for %s /",
     (method) => {
-      expect(isAnonymousHomePageRequest(makeRequest("/", { method }))).toBe(
+      expect(isCacheablePublicPageRequest(makeRequest("/", { method }))).toBe(
         false,
       );
     },
   );
 
-  it.each(["/about", "/sign-in", "/announcements", "/foo"])(
-    "returns false for GET %s with no cookies",
-    (path) => {
-      expect(isAnonymousHomePageRequest(makeRequest(path))).toBe(false);
-    },
-  );
+  it.each([
+    "/sign-in",
+    "/announcements",
+    "/feedback",
+    "/my/account",
+    "/members",
+    "/foo",
+    "/about/extra",
+  ])("returns false for non-cacheable path %s", (path) => {
+    expect(isCacheablePublicPageRequest(makeRequest(path))).toBe(false);
+  });
 });
 
-describe("homePageCacheKey", () => {
+describe("publicPageCacheKey", () => {
   it("strips query strings so utm variants share an entry", () => {
-    const a = homePageCacheKey(makeRequest("/?utm_source=insta"));
-    const b = homePageCacheKey(makeRequest("/?utm_source=fb&ref=email"));
+    const a = publicPageCacheKey(makeRequest("/?utm_source=insta"));
+    const b = publicPageCacheKey(makeRequest("/?utm_source=fb&ref=email"));
     expect(a.url).toBe(`${ORIGIN}/`);
     expect(b.url).toBe(`${ORIGIN}/`);
     expect(a.method).toBe("GET");
   });
 
+  it("preserves the request path so different cacheable pages get different keys", () => {
+    expect(publicPageCacheKey(makeRequest("/")).url).toBe(`${ORIGIN}/`);
+    expect(publicPageCacheKey(makeRequest("/privacy")).url).toBe(
+      `${ORIGIN}/privacy`,
+    );
+    expect(publicPageCacheKey(makeRequest("/about?ref=x")).url).toBe(
+      `${ORIGIN}/about`,
+    );
+  });
+
   it("preserves the request origin", () => {
-    const request = new Request("https://other.example/", { method: "GET" });
-    expect(homePageCacheKey(request).url).toBe("https://other.example/");
+    const request = new Request("https://other.example/legal", {
+      method: "GET",
+    });
+    expect(publicPageCacheKey(request).url).toBe("https://other.example/legal");
   });
 });

--- a/apps/web/src/server/edge-cache.ts
+++ b/apps/web/src/server/edge-cache.ts
@@ -1,42 +1,45 @@
 /**
- * Worker-level edge cache for the anonymous home-page SSR. Wraps the
+ * Worker-level edge cache for anonymous public-page SSR. Wraps the
  * TanStack Start fetch handler in `apps/web/src/server-entry.ts` so
- * GET `/` requests with no auth cookies are served from
+ * GET requests to a known set of public pages are served from
  * `caches.default` (per-PoP Workers Cache API) instead of paying the
- * ~180 ms React SSR cost on every request.
+ * full React SSR cost on every request.
  *
- * Why only `/` for now: it's the heaviest single path in the worker
- * telemetry tail (P95 ~180 ms CPU). Other public pages
- * (/about, /membership, the legal routes) are even more static and
- * can be folded in once this validates; deferred to a follow-up so
- * the first cut has the smallest blast radius.
+ * Why bypass-by-cookie instead of stub-the-auth-aware-UI: most public
+ * traffic is anonymous (recruitment + legal-policy surfaces), and
+ * anonymous SSR HTML on these pages is fully deterministic — UserMenu
+ * shows "Sign in", AnnouncementsBell hidden, the auth-gated sidebar
+ * branches collapsed, EditAffordance widgets render null. Signed-in
+ * visits bypass the cache and pay full SSR (rare on these surfaces).
  *
- * Why bypass-by-cookie instead of stub-the-auth-aware-UI: most
- * `/` traffic is anonymous (recruitment surface), and anonymous SSR
- * HTML for `/` is already deterministic — UserMenu, AnnouncementsBell,
- * the auth-gated sidebar branches, and EditAffordance widgets all
- * render their public-fallback shape when `useAuth()` is anonymous.
- * Signed-in visits bypass the cache and pay full SSR (rare on `/`).
+ * Why these paths only: every entry in `CACHEABLE_PATHS` either has
+ * no admin CMS surface at all (the legal/policy routes are constants
+ * in `apps/web/src/config/legal.ts`) or has one that's edited
+ * infrequently enough that the 60 s `s-maxage` window is invisible
+ * (`/`, `/about`, `/membership` read landing-CMS data via the
+ * `landingContentQueryOptions` query). Auth-mediated surfaces and
+ * the sign-in form (Turnstile widget, CSRF) are deliberately
+ * excluded.
  *
  * Why not active invalidation on admin write: editor population is
- * small, edits are infrequent, and the 60 s `s-maxage` window plus
- * `stale-while-revalidate=86400` means visitors never see a stalled
- * page — they get the stale copy instantly and the next request
- * triggers a background refresh. Revisit if landing edits become
- * high-frequency.
+ * small, edits are infrequent, and `stale-while-revalidate=86400`
+ * means visitors during the staleness window get an instant
+ * response with a background revalidation. Revisit if landing
+ * edits become high-frequency.
  */
 
 // Every cookie the project sets that signals "this is a user-specific
 // request" — sessions, registration proofs, and in-flight passkey
-// ceremonies. The session cookie is the only one that affects the `/`
-// SSR today; the proof + webauthn names are added defensively so the
-// cache key reads as "no auth state of any kind", which is easier to
-// reason about than "this auth state happens not to affect `/` right now".
+// ceremonies. Only the session cookie meaningfully affects SSR on the
+// cacheable pages today; the proof + webauthn names are added
+// defensively so the cache key reads as "no auth state of any kind",
+// which is easier to reason about than "this auth state happens not
+// to affect these pages right now".
 //
-// Both `__Host-`-prefixed names (HTTPS) and bare names (HTTP local dev)
-// listed because cookie helpers swap based on `APP_BASE_URL` scheme —
-// see `apps/web/src/server/auth/session-cookie.server.ts` and
-// `apps/web/src/features/auth/server/webauthn-ceremony.server.ts`.
+// Both `__Host-`-prefixed names (HTTPS) and bare names (HTTP local
+// dev) listed because cookie helpers swap based on `APP_BASE_URL`
+// scheme — see `apps/web/src/server/auth/session-cookie.server.ts`
+// and `apps/web/src/features/auth/server/webauthn-ceremony.server.ts`.
 const AUTH_COOKIE_NAMES: ReadonlySet<string> = new Set([
   "ucmc_session",
   "__Host-ucmc_session",
@@ -46,17 +49,44 @@ const AUTH_COOKIE_NAMES: ReadonlySet<string> = new Set([
   "__Host-ucmc_webauthn",
 ]);
 
+// Every path that should share the public-page cache. Each must:
+//   1. Render the same HTML for every anonymous visitor (no per-visitor
+//      randomness, locale-detection, A/B testing, etc.).
+//   2. Render no Set-Cookie response header in the anonymous case
+//      (the runtime gate enforces this defensively, but it's the
+//      pre-condition for inclusion).
+//   3. Be tolerant of a 60 s staleness window (admin edits land within
+//      a minute on the 4 routes that have CMS-edited content; the
+//      rest are constants in `apps/web/src/config/legal.ts`).
+//
+// `/sign-in` is intentionally excluded — it renders the Turnstile
+// widget, which polls Cloudflare's CDN and may render differently
+// per visitor, and posts a CSRF-sensitive form.
+const CACHEABLE_PATHS: ReadonlySet<string> = new Set([
+  "/",
+  "/about",
+  "/membership",
+  "/legal",
+  "/disclaimer",
+  "/anti-hazing",
+  "/nondiscrimination",
+  "/waiver",
+  "/privacy",
+  "/terms",
+  "/open-source",
+]);
+
 /**
- * True when the request is eligible to share the anonymous home-page
- * cache entry: GET method, exact path `/`, and no auth cookies set.
- * Pure function — exported for unit tests.
+ * True when the request is eligible to share a public-page cache
+ * entry: GET method, path is in `CACHEABLE_PATHS`, and no auth
+ * cookies set. Pure function — exported for unit tests.
  */
-export function isAnonymousHomePageRequest(request: Request): boolean {
+export function isCacheablePublicPageRequest(request: Request): boolean {
   if (request.method !== "GET") {
     return false;
   }
   const url = new URL(request.url);
-  if (url.pathname !== "/") {
+  if (!CACHEABLE_PATHS.has(url.pathname)) {
     return false;
   }
   return !hasAnyAuthCookie(request.headers.get("cookie"));
@@ -86,14 +116,14 @@ function hasAnyAuthCookie(cookieHeader: string | null): boolean {
 }
 
 /**
- * Cache key that ignores query strings. Without this, `?utm_source=x`,
- * `?utm_source=y`, and `/` would each get their own cache entry — same
- * SSR output, three times the storage. The original request keeps its
- * URL so the underlying handler still sees query params for analytics.
+ * Cache key that strips query strings so `?utm_source=x` and
+ * `?utm_source=y` share an entry — same SSR output, one cache slot.
+ * The original request keeps its URL so the underlying handler still
+ * sees query params for analytics.
  */
-export function homePageCacheKey(request: Request): Request {
+export function publicPageCacheKey(request: Request): Request {
   const url = new URL(request.url);
-  return new Request(`${url.origin}/`, { method: "GET" });
+  return new Request(`${url.origin}${url.pathname}`, { method: "GET" });
 }
 
 /**
@@ -111,15 +141,15 @@ export type WorkerFetchHandler = (
 ) => Response | Promise<Response>;
 
 /**
- * Wraps a Worker fetch handler with the home-page cache layer. All
- * requests that don't satisfy `isAnonymousHomePageRequest` pass
+ * Wraps a Worker fetch handler with the public-page cache layer. All
+ * requests that don't satisfy `isCacheablePublicPageRequest` pass
  * through to `inner` unchanged.
  */
-export function withAnonymousHomeCache(
+export function withPublicPageCache(
   inner: WorkerFetchHandler,
 ): WorkerFetchHandler {
   return async function cachedFetch(request, env, ctx) {
-    if (!isAnonymousHomePageRequest(request)) {
+    if (!isCacheablePublicPageRequest(request)) {
       return inner(request, env, ctx);
     }
 
@@ -128,7 +158,7 @@ export function withAnonymousHomeCache(
     // Cast through the Cloudflare-typed shape so TypeScript accepts
     // the access without losing type-safety on the resulting `Cache`.
     const cache = (caches as unknown as { default: Cache }).default;
-    const cacheKey = homePageCacheKey(request);
+    const cacheKey = publicPageCacheKey(request);
     const cached = await cache.match(cacheKey);
     if (cached) {
       return cached;
@@ -136,11 +166,11 @@ export function withAnonymousHomeCache(
 
     const response = await inner(request, env, ctx);
 
-    // Belt-and-suspenders gate. Today's anonymous `/` SSR satisfies
-    // all three; the checks defend against a future change silently
-    // making the cache leaky (e.g. someone adds a Set-Cookie to the
-    // root loader). On any miss we degrade to no-cache, not to
-    // caching-a-leak.
+    // Belt-and-suspenders gate. Today's anonymous SSR for every entry
+    // in CACHEABLE_PATHS satisfies all three; the checks defend
+    // against a future change silently making the cache leaky (e.g.
+    // someone adds a Set-Cookie to a route's loader). On any miss
+    // we degrade to no-cache, not to caching-a-leak.
     if (
       response.status === 200 &&
       !response.headers.has("Set-Cookie") &&

--- a/apps/web/src/server/edge-cache.ts
+++ b/apps/web/src/server/edge-cache.ts
@@ -1,0 +1,159 @@
+/**
+ * Worker-level edge cache for the anonymous home-page SSR. Wraps the
+ * TanStack Start fetch handler in `apps/web/src/server-entry.ts` so
+ * GET `/` requests with no auth cookies are served from
+ * `caches.default` (per-PoP Workers Cache API) instead of paying the
+ * ~180 ms React SSR cost on every request.
+ *
+ * Why only `/` for now: it's the heaviest single path in the worker
+ * telemetry tail (P95 ~180 ms CPU). Other public pages
+ * (/about, /membership, the legal routes) are even more static and
+ * can be folded in once this validates; deferred to a follow-up so
+ * the first cut has the smallest blast radius.
+ *
+ * Why bypass-by-cookie instead of stub-the-auth-aware-UI: most
+ * `/` traffic is anonymous (recruitment surface), and anonymous SSR
+ * HTML for `/` is already deterministic — UserMenu, AnnouncementsBell,
+ * the auth-gated sidebar branches, and EditAffordance widgets all
+ * render their public-fallback shape when `useAuth()` is anonymous.
+ * Signed-in visits bypass the cache and pay full SSR (rare on `/`).
+ *
+ * Why not active invalidation on admin write: editor population is
+ * small, edits are infrequent, and the 60 s `s-maxage` window plus
+ * `stale-while-revalidate=86400` means visitors never see a stalled
+ * page — they get the stale copy instantly and the next request
+ * triggers a background refresh. Revisit if landing edits become
+ * high-frequency.
+ */
+
+// Every cookie the project sets that signals "this is a user-specific
+// request" — sessions, registration proofs, and in-flight passkey
+// ceremonies. The session cookie is the only one that affects the `/`
+// SSR today; the proof + webauthn names are added defensively so the
+// cache key reads as "no auth state of any kind", which is easier to
+// reason about than "this auth state happens not to affect `/` right now".
+//
+// Both `__Host-`-prefixed names (HTTPS) and bare names (HTTP local dev)
+// listed because cookie helpers swap based on `APP_BASE_URL` scheme —
+// see `apps/web/src/server/auth/session-cookie.server.ts` and
+// `apps/web/src/features/auth/server/webauthn-ceremony.server.ts`.
+const AUTH_COOKIE_NAMES: ReadonlySet<string> = new Set([
+  "ucmc_session",
+  "__Host-ucmc_session",
+  "ucmc_proof",
+  "__Host-ucmc_proof",
+  "ucmc_webauthn",
+  "__Host-ucmc_webauthn",
+]);
+
+/**
+ * True when the request is eligible to share the anonymous home-page
+ * cache entry: GET method, exact path `/`, and no auth cookies set.
+ * Pure function — exported for unit tests.
+ */
+export function isAnonymousHomePageRequest(request: Request): boolean {
+  if (request.method !== "GET") {
+    return false;
+  }
+  const url = new URL(request.url);
+  if (url.pathname !== "/") {
+    return false;
+  }
+  return !hasAnyAuthCookie(request.headers.get("cookie"));
+}
+
+/**
+ * Returns true if the cookie header contains any of the project's
+ * auth cookies. Parses by name to avoid false positives where a
+ * tracking cookie's *value* happens to contain a substring like
+ * `ucmc_session=` — name matching only triggers on actual cookie
+ * names, which appear before the `=` of each `; `-separated pair.
+ */
+function hasAnyAuthCookie(cookieHeader: string | null): boolean {
+  if (!cookieHeader) {
+    return false;
+  }
+  for (const part of cookieHeader.split(/;\s*/)) {
+    const eq = part.indexOf("=");
+    if (eq === -1) {
+      continue;
+    }
+    if (AUTH_COOKIE_NAMES.has(part.slice(0, eq))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Cache key that ignores query strings. Without this, `?utm_source=x`,
+ * `?utm_source=y`, and `/` would each get their own cache entry — same
+ * SSR output, three times the storage. The original request keeps its
+ * URL so the underlying handler still sees query params for analytics.
+ */
+export function homePageCacheKey(request: Request): Request {
+  const url = new URL(request.url);
+  return new Request(`${url.origin}/`, { method: "GET" });
+}
+
+/**
+ * Cloudflare Workers-style fetch handler signature
+ * (`(request, env, ctx) => Response | Promise<Response>`). Mirrors
+ * `ExportedHandlerFetchHandler` from `@cloudflare/workers-types`, but
+ * narrowed so the wrapper composes cleanly with TanStack Start's
+ * `startEntry.fetch` (which is typed `(request, opts?)` even though
+ * the Cloudflare runtime always invokes it as `(request, env, ctx)`).
+ */
+export type WorkerFetchHandler = (
+  request: Request,
+  env: unknown,
+  ctx: ExecutionContext,
+) => Response | Promise<Response>;
+
+/**
+ * Wraps a Worker fetch handler with the home-page cache layer. All
+ * requests that don't satisfy `isAnonymousHomePageRequest` pass
+ * through to `inner` unchanged.
+ */
+export function withAnonymousHomeCache(
+  inner: WorkerFetchHandler,
+): WorkerFetchHandler {
+  return async function cachedFetch(request, env, ctx) {
+    if (!isAnonymousHomePageRequest(request)) {
+      return inner(request, env, ctx);
+    }
+
+    // `caches.default` is a Cloudflare extension to the standard
+    // `CacheStorage` interface that the DOM lib type doesn't declare.
+    // Cast through the Cloudflare-typed shape so TypeScript accepts
+    // the access without losing type-safety on the resulting `Cache`.
+    const cache = (caches as unknown as { default: Cache }).default;
+    const cacheKey = homePageCacheKey(request);
+    const cached = await cache.match(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const response = await inner(request, env, ctx);
+
+    // Belt-and-suspenders gate. Today's anonymous `/` SSR satisfies
+    // all three; the checks defend against a future change silently
+    // making the cache leaky (e.g. someone adds a Set-Cookie to the
+    // root loader). On any miss we degrade to no-cache, not to
+    // caching-a-leak.
+    if (
+      response.status === 200 &&
+      !response.headers.has("Set-Cookie") &&
+      (response.headers.get("Content-Type") ?? "").includes("text/html")
+    ) {
+      const toCache = response.clone();
+      toCache.headers.set(
+        "Cache-Control",
+        "public, s-maxage=60, stale-while-revalidate=86400",
+      );
+      ctx.waitUntil(cache.put(cacheKey, toCache));
+    }
+
+    return response;
+  };
+}

--- a/apps/web/src/server/edge-cache.ts
+++ b/apps/web/src/server/edge-cache.ts
@@ -161,7 +161,13 @@ export function withPublicPageCache(
     const cacheKey = publicPageCacheKey(request);
     const cached = await cache.match(cacheKey);
     if (cached) {
-      return cached;
+      // Cached `Response` headers are immutable; wrap to attach an
+      // observability marker. Cheap (no body read), and gives ops a
+      // single header to grep for in `wrangler tail` to verify the
+      // cache is working as expected.
+      const hit = new Response(cached.body, cached);
+      hit.headers.set("X-Edge-Cache", "HIT");
+      return hit;
     }
 
     const response = await inner(request, env, ctx);
@@ -171,11 +177,12 @@ export function withPublicPageCache(
     // against a future change silently making the cache leaky (e.g.
     // someone adds a Set-Cookie to a route's loader). On any miss
     // we degrade to no-cache, not to caching-a-leak.
-    if (
+    const isCacheable =
       response.status === 200 &&
       !response.headers.has("Set-Cookie") &&
-      (response.headers.get("Content-Type") ?? "").includes("text/html")
-    ) {
+      (response.headers.get("Content-Type") ?? "").includes("text/html");
+
+    if (isCacheable) {
       const toCache = response.clone();
       toCache.headers.set(
         "Cache-Control",
@@ -184,6 +191,13 @@ export function withPublicPageCache(
       ctx.waitUntil(cache.put(cacheKey, toCache));
     }
 
+    // Observability header is set on the user-facing response only;
+    // the cached copy (above) carries no marker, so a future HIT can
+    // be tagged HIT without colliding. `BYPASS` covers the case where
+    // we got here via cache miss but the response failed the cacheable
+    // gate — useful signal that something downstream is poisoning the
+    // cache eligibility.
+    response.headers.set("X-Edge-Cache", isCacheable ? "MISS" : "BYPASS");
     return response;
   };
 }


### PR DESCRIPTION
## Summary

Final fix from the worker-CPU effort. Adds a per-PoP Workers Cache API layer in the worker entrypoint that serves cookie-less GETs to the public landing + legal pages from \`caches.default\`, dropping CPU on those routes to sub-ms on cache hits. Worker telemetry showed \`/\` at P95 ~180 ms CPU (entirely React SSR); the legal pages were lower-CPU but still SSR'd on every visit.

Two commits, reviewable in order:

- **Commit 1 (\`c65be11\`)** — adds the cache layer, narrowed to \`/\`. New module \`apps/web/src/server/edge-cache.ts\` exports \`isAnonymousHomePageRequest\`, \`homePageCacheKey\`, and \`withAnonymousHomeCache\`. Wired into \`server-entry.ts\`. 21 unit tests cover the predicate.
- **Commit 2 (\`2db81a6\`)** — generalizes to a \`Set<string>\` of cacheable paths, adds \`/about\`, \`/membership\`, \`/legal\`, \`/disclaimer\`, \`/anti-hazing\`, \`/nondiscrimination\`, \`/waiver\`, \`/privacy\`, \`/terms\`, \`/open-source\`. Renames symbols to match the broader scope (\`isCacheablePublicPageRequest\`, \`publicPageCacheKey\`, \`withPublicPageCache\`). Tests grow to 36.

## How it works

Eligibility predicate (must satisfy all):
- \`request.method === "GET"\` — drops HEAD, OPTIONS/preflight, POST server-fns.
- \`pathname\` ∈ \`CACHEABLE_PATHS\` (exact match, no nested paths).
- No auth cookies set: \`ucmc_session\`, \`__Host-ucmc_session\`, \`ucmc_proof\`, \`__Host-ucmc_proof\`, \`ucmc_webauthn\`, \`__Host-ucmc_webauthn\`. Parsed by name to avoid false positives where a tracking cookie's *value* contains a substring like \`ucmc_session=\`.

Cache key is normalized to \`origin + pathname\` (drops query strings), so \`?utm_source=insta\`, \`?utm_source=fb\`, and the bare path share a single entry per page. Different pages get different keys.

On hit: return cached \`Response\` directly, sub-ms.

On miss: invoke the underlying TanStack Start handler, then **belt-and-suspenders gate** on the response — only cache when \`status === 200\` AND no \`Set-Cookie\` AND \`Content-Type\` is HTML. If a future change accidentally adds a cookie or 500s, we degrade to no-cache rather than caching a leak. Cached copy gets \`Cache-Control: public, s-maxage=60, stale-while-revalidate=86400\` (60s freshness window, 24h SWR background refresh).

\`/sign-in\` is intentionally excluded — Turnstile widget polls Cloudflare's CDN and may render differently per visitor; CSRF concerns on the form. Auth-mediated surfaces (\`/announcements\`, \`/feedback\`, \`/my/*\`, \`/members\`, \`/audit\`) are excluded by the cookie predicate.

## Why this approach

The plan considered seven alternatives in detail (full doc at \`/home/vscode/.claude/plans/reactive-puzzling-penguin.md\`):

- **Stub auth-aware UI for everyone** — refactor the entire \`AppLayout\` shell + sidebar + EditAffordance widgets so SSR HTML is byte-identical for anonymous and signed-in. Massive refactor with UX risk (flash-of-incorrect-nav). Cookie-bypass captures the same realistic win without touching any React component.
- **Cloudflare zone-level Cache Rules** — true zero CPU on hits but requires Pulumi resource + dashboard verification. Win delta vs Workers Cache API is small (~1–5 ms saved per hit).
- **Build-time prerender** — admin CMS edits wouldn't surface until next deploy. Hostile UX.
- **Streaming SSR / lazy-mount below-the-fold / cache D1 in KV** — partial measures that don't address the actual bottleneck (React SSR cost) or trade SEO for CPU.
- **Migrate to a platform with first-class ISR** — cost-benefit upside-down at our traffic.

## Test plan

- [x] \`pnpm --filter ucmc-web typecheck\` clean
- [x] \`pnpm --filter ucmc-web lint\` clean (0 errors; 15 warnings, all pre-existing)
- [x] \`pnpm --filter ucmc-web test\` — 404/404 across 30 files (15 new for the path-set generalization, 21 from the home-only commit)
- [x] Local smoke: GET \`/\` cold = 2.8 s (full SSR), GET \`/\` warm = 8.7 ms (cache hit). GET \`/\` with \`ucmc_session\` cookie bypasses cache and runs the SSR pipeline as today (~70 ms in dev mode).
- [ ] Post-deploy (dev): pull a fresh telemetry CSV after 24 h. Expected: P95 CPU on \`/\` and the legal pages should drop dramatically. Tail items from the original CSV's per-path table should clear out.
- [ ] Post-deploy (prod): same checks. Cache hit rate >70 % on these routes within 24 h is the target.

## Out of scope (deferred)

- Active cache invalidation on admin write — landing CMS edits propagate within 60 s via \`s-maxage\`, which is invisible.
- Caching auth-mediated routes — would require the auth-aware-UI stub refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)