### PR TITLE
refactor(ucmc-web): inline sidebar footer nav into scroll area

### DIFF
--- a/apps/web/src/components/layouts/app-layout.tsx
+++ b/apps/web/src/components/layouts/app-layout.tsx
@@ -62,7 +62,6 @@ import {
 import {
   Sidebar,
   SidebarContent,
-  SidebarFooter,
   SidebarGroup,
   SidebarInset,
   SidebarMenu,
@@ -154,10 +153,8 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
         >
           <SidebarContent>
             <SidebarNav />
+            <SidebarUtilityNav />
           </SidebarContent>
-          <SidebarFooter>
-            <SidebarFooterNav />
-          </SidebarFooter>
           <SidebarRail />
         </Sidebar>
         <SidebarInset>
@@ -562,65 +559,65 @@ function SidebarNav() {
   );
 }
 
-function SidebarFooterNav() {
+function SidebarUtilityNav() {
   const { isApproved, hasPermission } = useAuth();
   const canSubmitFeedback = isApproved && hasPermission("feedback:submit");
   const canViewAudit = hasPermission("audit:view");
-  // Settings is always rendered (disabled placeholder), so the footer is
-  // never empty and the wrapper always renders.
   return (
-    <SidebarMenu>
-      <SidebarMenuItem>
-        <SidebarMenuButton
-          aria-disabled
-          tabIndex={-1}
-          tooltip="Settings (coming soon)"
-        >
-          <Settings />
-          <span>Settings</span>
-        </SidebarMenuButton>
-      </SidebarMenuItem>
-      {canSubmitFeedback ? (
+    <SidebarGroup>
+      <SidebarMenu>
         <SidebarMenuItem>
-          <SidebarMenuButton asChild tooltip="Feedback">
-            <Link to="/feedback">
-              <MessageSquare />
-              <span>Feedback</span>
-            </Link>
+          <SidebarMenuButton
+            aria-disabled
+            tabIndex={-1}
+            tooltip="Settings (coming soon)"
+          >
+            <Settings />
+            <span>Settings</span>
           </SidebarMenuButton>
         </SidebarMenuItem>
-      ) : null}
-      <SidebarMenuItem>
-        <SidebarMenuButton
-          aria-disabled
-          tabIndex={-1}
-          tooltip="Analytics (coming soon)"
-        >
-          <BarChart3 />
-          <span>Analytics</span>
-        </SidebarMenuButton>
-      </SidebarMenuItem>
-      <SidebarMenuItem>
-        <SidebarMenuButton
-          aria-disabled
-          tabIndex={-1}
-          tooltip="Reports (coming soon)"
-        >
-          <FileText />
-          <span>Reports</span>
-        </SidebarMenuButton>
-      </SidebarMenuItem>
-      {canViewAudit ? (
+        {canSubmitFeedback ? (
+          <SidebarMenuItem>
+            <SidebarMenuButton asChild tooltip="Feedback">
+              <Link to="/feedback">
+                <MessageSquare />
+                <span>Feedback</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        ) : null}
         <SidebarMenuItem>
-          <SidebarMenuButton asChild tooltip="Audit log">
-            <Link to="/audit">
-              <History />
-              <span>Audit log</span>
-            </Link>
+          <SidebarMenuButton
+            aria-disabled
+            tabIndex={-1}
+            tooltip="Analytics (coming soon)"
+          >
+            <BarChart3 />
+            <span>Analytics</span>
           </SidebarMenuButton>
         </SidebarMenuItem>
-      ) : null}
-    </SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            aria-disabled
+            tabIndex={-1}
+            tooltip="Reports (coming soon)"
+          >
+            <FileText />
+            <span>Reports</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+        {canViewAudit ? (
+          <SidebarMenuItem>
+            <SidebarMenuButton asChild tooltip="Audit log">
+              <Link to="/audit">
+                <History />
+                <span>Audit log</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        ) : null}
+      </SidebarMenu>
+    </SidebarGroup>
   );
 }
 


### PR DESCRIPTION
## Summary
- Drops the sticky `SidebarFooter` wrapper in `app-layout.tsx`
- Renames `SidebarFooterNav` → `SidebarUtilityNav` and wraps its `SidebarMenu` in a `SidebarGroup` matching the other scroll-area sections
- Renders the utility nav inside `SidebarContent` after `SidebarNav`, so Settings / Feedback / Analytics / Reports / Audit log now scroll with the rest of the navigation instead of staying pinned to the bottom

## Test plan
- [ ] Sidebar scrolls as one continuous list — utility items follow main nav, no sticky footer
- [ ] Icon-collapsed sidebar still shows utility items with tooltips
- [ ] Feedback / Audit log links remain gated by their respective permissions
- [ ] `pnpm --filter ucmc-web typecheck` and ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)