### PR TITLE
refactor(ucmc-web): regroup /my/account sections by sensitivity

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -68,7 +68,7 @@ The footer also shows the registration disclaimer text **on every page** (not ju
 
 ### Auth-gated routes
 
-- `/my/account` + `/my/account/details` + `/my/account/security` — member's own profile, sessions, passkeys, data export, hard delete
+- `/my/account` (public profile), `/my/account/details` (private PII + emergency contacts), `/my/account/security` (Sign-in tab: emails + passkeys), `/my/account/preferences` (theme + data export + hard delete) — the member's own account surface
 - `/my/account/waiver` — read-only view of the member's paper-waiver attestation status
 - `/members` — directory (auth-gated, robots-disallowed)
 - `/members/management` — member lifecycle admin: approve pending registrations, pre-add unclaimed members, un-reject rejected, reactivate deactivated (`members:manage`)

--- a/apps/web/src/config/legal.ts
+++ b/apps/web/src/config/legal.ts
@@ -308,13 +308,13 @@ export const PRIVACY_BODY: readonly LegalSection[] = [
       RETENTION_DEACTIVATED_COPY,
       "Waiver attestation records (metadata only — not the paper waiver) are retained while still in effect; revoked attestations are deleted 90 days after revocation.",
       "Avatar images and landing-page images stored in object storage are reconciled against the database daily; any object no longer referenced by an active row is deleted.",
-      "You can delete your account immediately at any time via the controls on /my/account; this also removes your avatar from R2 and signs you out everywhere.",
+      "You can delete your account immediately at any time via the controls on /my/account/preferences; this also removes your avatar from R2 and signs you out everywhere.",
     ],
   },
   {
     heading: "Your rights",
     paragraphs: [
-      "You can download a JSON copy of everything we have on you from your /my/account page. You can hard-delete your account from the same page; the deletion is immediate and irreversible. To correct or update individual fields, edit them on /my/account or /my/account/details.",
+      "You can download a JSON copy of everything we have on you from /my/account/preferences. You can hard-delete your account from the same page; the deletion is immediate and irreversible. To correct or update individual fields, edit them on /my/account (public profile) or /my/account/details (private details and emergency contacts). To add, remove, or change the primary address for your sign-in emails, use /my/account/security.",
     ],
   },
   {

--- a/apps/web/src/features/auth/api/use-consume-add-email.ts
+++ b/apps/web/src/features/auth/api/use-consume-add-email.ts
@@ -15,7 +15,7 @@ import { consumeAddEmailFn } from "#/features/auth/server/email-fns";
  *
  * Cache invalidation is gated on the success branch — there's no
  * server-side state change to reflect when the consume fails.
- * Invalidates the email list (so `/my/account/details` shows the new
+ * Invalidates the email list (so `/my/account/security` shows the new
  * row) and the session (so `principal.emails` reflects the addition
  * without waiting for the next navigation).
  */

--- a/apps/web/src/features/auth/api/use-remove-email.ts
+++ b/apps/web/src/features/auth/api/use-remove-email.ts
@@ -8,7 +8,7 @@ import { removeEmailFn } from "#/features/auth/server/email-fns";
 
 /**
  * Remove an email from the user's account. Invalidates both the email
- * list (so the row disappears from `/my/account/details`) and the
+ * list (so the row disappears from `/my/account/security`) and the
  * session (so `principal.emails` reflects the removal — the cached
  * principal would otherwise still list the deleted address until the
  * next navigation forced a refetch).

--- a/apps/web/src/features/auth/components/email-addresses-section.tsx
+++ b/apps/web/src/features/auth/components/email-addresses-section.tsx
@@ -60,10 +60,12 @@ export function EmailAddressesSection({
         </header>
         <ItemGroup className="gap-2">
           <Item variant="outline" size="sm">
-            <ItemContent>
-              <ItemTitle>
-                <span className="truncate">{primaryEmail}</span>
-                <Badge variant="secondary">Primary</Badge>
+            <ItemContent className="min-w-0">
+              <ItemTitle className="w-full min-w-0">
+                <span className="min-w-0 flex-1 truncate">{primaryEmail}</span>
+                <Badge variant="secondary" className="shrink-0">
+                  Primary
+                </Badge>
               </ItemTitle>
               <ItemDescription>Verified at registration</ItemDescription>
             </ItemContent>
@@ -98,11 +100,23 @@ function ApprovedEmailAddressesSection() {
         <ItemGroup className="gap-2">
           {emails.map((row) => (
             <Item key={row.id} variant="outline" size="sm">
-              <ItemContent>
-                <ItemTitle>
-                  <span className="truncate">{row.email}</span>
+              {/*
+               * `min-w-0` on ItemContent + `w-full min-w-0` on ItemTitle
+               * are needed for the inner `truncate` span to actually
+               * ellipsis on long addresses. ItemContent is `flex-1` but
+               * its default `min-width: auto` lets children overflow,
+               * and ItemTitle ships with `w-fit` (shrink-to-content)
+               * which similarly prevents truncation. Without these,
+               * a 60-char email would widen the row instead of
+               * ellipsizing.
+               */}
+              <ItemContent className="min-w-0">
+                <ItemTitle className="w-full min-w-0">
+                  <span className="min-w-0 flex-1 truncate">{row.email}</span>
                   {row.isPrimary ? (
-                    <Badge variant="secondary">Primary</Badge>
+                    <Badge variant="secondary" className="shrink-0">
+                      Primary
+                    </Badge>
                   ) : null}
                 </ItemTitle>
                 <ItemDescription>

--- a/apps/web/src/features/auth/components/email-addresses-section.tsx
+++ b/apps/web/src/features/auth/components/email-addresses-section.tsx
@@ -5,6 +5,14 @@ import { z } from "zod";
 
 import { Badge } from "#/components/ui/badge";
 import { Button } from "#/components/ui/button";
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemTitle,
+} from "#/components/ui/item";
 import { myEmailsQueryOptions } from "#/features/auth/api/queries";
 import { useAddEmail } from "#/features/auth/api/use-add-email";
 import { useRemoveEmail } from "#/features/auth/api/use-remove-email";
@@ -49,19 +57,17 @@ export function EmailAddressesSection({
             approved.
           </p>
         </header>
-        <ul className="flex flex-col gap-2">
-          <li className="flex flex-wrap items-center justify-between gap-3 rounded-md border p-3">
-            <div className="min-w-0 flex-1">
-              <p className="flex items-center gap-2 truncate text-sm font-medium">
+        <ItemGroup className="gap-2">
+          <Item variant="outline" size="sm">
+            <ItemContent>
+              <ItemTitle>
                 <span className="truncate">{primaryEmail}</span>
                 <Badge variant="secondary">Primary</Badge>
-              </p>
-              <p className="text-xs text-muted-foreground">
-                Verified at registration
-              </p>
-            </div>
-          </li>
-        </ul>
+              </ItemTitle>
+              <ItemDescription>Verified at registration</ItemDescription>
+            </ItemContent>
+          </Item>
+        </ItemGroup>
       </section>
     );
   }
@@ -88,29 +94,26 @@ function ApprovedEmailAddressesSection() {
       {query.isLoading ? (
         <p className="text-sm text-muted-foreground">Loading…</p>
       ) : (
-        <ul className="flex flex-col gap-2">
+        <ItemGroup className="gap-2">
           {emails.map((row) => (
-            <li
-              key={row.id}
-              className="flex flex-wrap items-center justify-between gap-3 rounded-md border p-3"
-            >
-              <div className="min-w-0 flex-1">
-                <p className="flex items-center gap-2 truncate text-sm font-medium">
+            <Item key={row.id} variant="outline" size="sm">
+              <ItemContent>
+                <ItemTitle>
                   <span className="truncate">{row.email}</span>
                   {row.isPrimary ? (
                     <Badge variant="secondary">Primary</Badge>
                   ) : null}
-                </p>
-                <p className="text-xs text-muted-foreground">
+                </ItemTitle>
+                <ItemDescription>
                   {row.verifiedAt
                     ? `Verified ${new Date(row.verifiedAt).toLocaleDateString(
                         undefined,
                         { year: "numeric", month: "short", day: "numeric" },
                       )}`
                     : "Pending verification"}
-                </p>
-              </div>
-              <div className="flex shrink-0 gap-2">
+                </ItemDescription>
+              </ItemContent>
+              <ItemActions>
                 {row.isPrimary ? null : (
                   <Button
                     type="button"
@@ -158,10 +161,10 @@ function ApprovedEmailAddressesSection() {
                 >
                   Remove
                 </Button>
-              </div>
-            </li>
+              </ItemActions>
+            </Item>
           ))}
-        </ul>
+        </ItemGroup>
       )}
 
       <AddEmailForm />

--- a/apps/web/src/features/auth/components/email-addresses-section.tsx
+++ b/apps/web/src/features/auth/components/email-addresses-section.tsx
@@ -24,7 +24,8 @@ const addEmailSchema = z.object({
 });
 
 /**
- * "Email addresses" section on `/my/account/details`. Lists every
+ * "Email addresses" section on the Sign-in tab
+ * (`/my/account/security`). Lists every
  * verified address attached to the user, with a Primary badge, a
  * "Make primary" button on non-primary rows, and a "Remove" button
  * (disabled on the primary row and when only one row exists). Below

--- a/apps/web/src/features/auth/server/email-actions.server.ts
+++ b/apps/web/src/features/auth/server/email-actions.server.ts
@@ -48,8 +48,8 @@ export interface EmailRow {
   // claimed"). This action is only callable by an authenticated user;
   // approved users always have non-null `verifiedAt` on every row,
   // because the only path that inserts NULL is officer pre-add and
-  // those users can't reach the /my/account/details page that consumes
-  // this. The type widening keeps the contract honest.
+  // those users can't reach the Sign-in tab (/my/account/security)
+  // that consumes this. The type widening keeps the contract honest.
   verifiedAt: Date | null;
   createdAt: Date;
 }

--- a/apps/web/src/routes/my.account.details.tsx
+++ b/apps/web/src/routes/my.account.details.tsx
@@ -1,17 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import { toast } from "sonner";
 
 import { EmergencyContactFields } from "#/components/profile/emergency-contact-fields";
 import { PrivateDetailFields } from "#/components/profile/private-detail-fields";
 import { EMPTY_PROFILE_FORM_VALUES } from "#/components/profile/profile-form-shape";
 import type { ProfileFormShape } from "#/components/profile/profile-form-shape";
-import {
-  myEmailsQueryOptions,
-  profileQueryOptions,
-} from "#/features/auth/api/queries";
+import { profileQueryOptions } from "#/features/auth/api/queries";
 import { useAuth } from "#/features/auth/api/use-auth";
-import { EmailAddressesSection } from "#/features/auth/components/email-addresses-section";
 import { useSubmitDetails } from "#/features/auth/api/use-submit-details";
 import { useAppForm } from "#/lib/form/form";
 import { useUnsavedChangesGuard } from "#/lib/form/use-unsaved-changes-guard";
@@ -19,18 +15,16 @@ import { profileInputSchema } from "#/server/profile/profile-schemas";
 import type { DetailsInput } from "#/server/profile/profile-schemas";
 
 /**
- * `/my/account/details` — private profile fields (legal name, M-number,
- * phone) plus emergency contacts. Mirrors the server-side
+ * `/my/account/details` — private profile fields (legal name, phone)
+ * plus emergency contacts. Mirrors the server-side
  * `members:view_private` projection: only the user themselves and
  * admins ever see these values.
+ *
+ * Email addresses moved to the Sign-in tab because they're an
+ * authentication identifier (magic-link target) rather than personal
+ * contact info. Account deletion / data export moved to Preferences.
  */
 export const Route = createFileRoute("/my/account/details")({
-  loader: async ({ context }) => {
-    // Pre-warm the email-addresses list so the section paints with
-    // data on first render. Other tabs in this layout follow the same
-    // ensureQueryData pattern.
-    await context.queryClient.ensureQueryData(myEmailsQueryOptions());
-  },
   component: AccountDetailsPage,
 });
 
@@ -51,11 +45,6 @@ function AccountDetailsPage() {
           immediately.
         </p>
       </header>
-
-      <EmailAddressesSection
-        approved={principal.status === "approved"}
-        primaryEmail={principal.primaryEmail}
-      />
 
       {isLoading ? (
         <p className="text-sm text-muted-foreground">Loading…</p>
@@ -80,6 +69,14 @@ function AccountDetailsPage() {
           }
         />
       )}
+
+      <p className="text-xs text-muted-foreground">
+        Looking to manage your email addresses? Those live on the{" "}
+        <Link to="/my/account/security" className="underline">
+          Sign-in
+        </Link>{" "}
+        tab.
+      </p>
     </div>
   );
 }

--- a/apps/web/src/routes/my.account.preferences.tsx
+++ b/apps/web/src/routes/my.account.preferences.tsx
@@ -1,13 +1,34 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
+import { toast } from "sonner";
 
 import { useTheme } from "#/components/theme-provider";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "#/components/ui/alert-dialog";
 import { Button } from "#/components/ui/button";
+import { Input } from "#/components/ui/input";
+import { Label } from "#/components/ui/label";
+import { useAuth } from "#/features/auth/api/use-auth";
+import { useDeleteMyAccount } from "#/features/auth/api/use-delete-my-account";
 
 /**
- * Preferences tab. Currently just a theme toggle — per-device settings
- * that aren't tied to a user record. Future preferences (email
- * notifications, default trip visibility, etc.) will persist to D1 and
- * slot in under new section headers below.
+ * Preferences tab. Theme toggle plus the privacy controls (data export
+ * and account deletion) that used to live under Security. They moved
+ * here because downloading your data and deleting your account are
+ * account-management concerns, not authentication surface.
+ *
+ * Future per-user preferences (email notifications, default trip
+ * visibility, etc.) will persist to D1 and slot in under new section
+ * headers above the danger zone.
  */
 export const Route = createFileRoute("/my/account/preferences")({
   component: PreferencesPage,
@@ -18,14 +39,15 @@ const THEME_OPTIONS = ["light", "dark", "system"] as const;
 function PreferencesPage() {
   const { theme, setTheme } = useTheme();
   return (
-    <div className="space-y-4">
+    <div className="flex flex-col gap-8">
       <header>
         <h2 className="text-lg font-medium">Preferences</h2>
         <p className="text-sm text-muted-foreground">
-          Personalize how the site looks for you on this device.
+          Personalize how the site looks for you and manage your account data.
         </p>
       </header>
-      <div className="space-y-2">
+
+      <section className="space-y-2">
         <p className="text-sm font-medium">Theme</p>
         <div className="flex gap-2">
           {THEME_OPTIONS.map((mode) => (
@@ -39,7 +61,121 @@ function PreferencesPage() {
             </Button>
           ))}
         </div>
-      </div>
+      </section>
+
+      <DataAndDeletionSection />
     </div>
+  );
+}
+
+/**
+ * Data export + account deletion. Both honor the promises on /privacy:
+ * download a JSON copy of everything we have on you, and hard-delete
+ * the account immediately. Deletion is gated by typing the email on
+ * file — defends against accidental clicks more than it does against
+ * deliberate misuse (a hostile actor with the session can already type
+ * the email).
+ */
+function DataAndDeletionSection() {
+  const { principal } = useAuth();
+  const navigate = useNavigate();
+  const deletion = useDeleteMyAccount();
+  const [open, setOpen] = useState(false);
+  const [confirmEmail, setConfirmEmail] = useState("");
+
+  const expectedEmail = principal?.primaryEmail ?? "";
+  const matches = confirmEmail.trim().toLowerCase() === expectedEmail;
+
+  const onConfirm = () => {
+    deletion.mutate(undefined, {
+      onSuccess: async () => {
+        toast.success("Account deleted");
+        setOpen(false);
+        await navigate({ to: "/" });
+      },
+      onError: (err) => {
+        toast.error(
+          err instanceof Error ? err.message : "Couldn't delete the account",
+        );
+      },
+    });
+  };
+
+  return (
+    <>
+      <section className="space-y-3">
+        <h3 className="text-base font-medium">Your data</h3>
+        <p className="text-sm text-muted-foreground">
+          Download a JSON copy of everything this site stores about you — your
+          profile, emergency contacts, role memberships, and waiver attestation
+          history. The export does not include passkey credentials or magic-link
+          tokens.
+        </p>
+        <Button asChild variant="outline">
+          <a href="/api/account/export" download>
+            Download my data
+          </a>
+        </Button>
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-base font-medium text-destructive">
+          Delete account
+        </h3>
+        <p className="text-sm text-muted-foreground">
+          Permanently delete your account, profile, emergency contacts,
+          passkeys, sessions, and waiver attestation history. This is immediate
+          and irreversible — there is no recovery on the other side. Authored
+          announcements stay (anonymized) so the timeline for other members
+          remains intact.
+        </p>
+        <AlertDialog open={open} onOpenChange={setOpen}>
+          <AlertDialogTrigger asChild>
+            <Button variant="destructive">Delete my account</Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete your account?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This is permanent. Type{" "}
+                <strong className="font-mono">{expectedEmail}</strong> to
+                confirm.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <div className="space-y-2 py-2">
+              <Label htmlFor="confirm-delete-email" className="text-sm">
+                Email
+              </Label>
+              <Input
+                id="confirm-delete-email"
+                type="email"
+                autoComplete="off"
+                value={confirmEmail}
+                onChange={(e) => setConfirmEmail(e.target.value)}
+                placeholder={expectedEmail}
+              />
+            </div>
+            <AlertDialogFooter>
+              <AlertDialogCancel
+                onClick={() => setConfirmEmail("")}
+                disabled={deletion.isPending}
+              >
+                Cancel
+              </AlertDialogCancel>
+              <AlertDialogAction
+                onClick={(e) => {
+                  e.preventDefault();
+                  onConfirm();
+                }}
+                disabled={!matches || deletion.isPending}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                {deletion.isPending ? "Deleting…" : "Delete forever"}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </section>
+    </>
   );
 }

--- a/apps/web/src/routes/my.account.security.tsx
+++ b/apps/web/src/routes/my.account.security.tsx
@@ -1,31 +1,24 @@
 import { useQuery } from "@tanstack/react-query";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useState } from "react";
-import { toast } from "sonner";
+import { createFileRoute, Link } from "@tanstack/react-router";
 
-import { passkeyListQueryOptions } from "#/features/auth/api/queries";
-import { useDeleteMyAccount } from "#/features/auth/api/use-delete-my-account";
+import {
+  myEmailsQueryOptions,
+  passkeyListQueryOptions,
+} from "#/features/auth/api/queries";
 import { useRemovePasskey } from "#/features/auth/api/use-remove-passkey";
 import { useAuth } from "#/features/auth/api/use-auth";
+import { EmailAddressesSection } from "#/features/auth/components/email-addresses-section";
 import { AddPasskeyButton } from "#/features/auth/components/passkey-button";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "#/components/ui/alert-dialog";
 import { Button } from "#/components/ui/button";
-import { Input } from "#/components/ui/input";
-import { Label } from "#/components/ui/label";
 
 /**
- * Account → Security. Lists the user's registered passkeys with an
- * "Add this device" affordance and a per-row "Remove" button.
+ * Account → Sign-in. Surfaces the two ways a member authenticates:
+ * verified email addresses (magic-link targets) and registered
+ * passkeys. The tab URL is still `/my/account/security` — only the
+ * label changed — so existing bookmarks keep working.
+ *
+ * Data export and account deletion moved to the Preferences tab; those
+ * are privacy/account-management concerns rather than sign-in surface.
  *
  * Auth-gating is inherited from the parent `/my` layout (`my.tsx`),
  * which runs `requireApproved` for the entire `/my/*` namespace —
@@ -33,29 +26,42 @@ import { Label } from "#/components/ui/label";
  */
 export const Route = createFileRoute("/my/account/security")({
   loader: async ({ context }) => {
-    await context.queryClient.ensureQueryData(passkeyListQueryOptions());
+    await Promise.all([
+      context.queryClient.ensureQueryData(passkeyListQueryOptions()),
+      context.queryClient.ensureQueryData(myEmailsQueryOptions()),
+    ]);
   },
-  component: SecurityPage,
+  component: SignInPage,
 });
 
-function SecurityPage() {
+function SignInPage() {
+  const { principal } = useAuth();
   const query = useQuery(passkeyListQueryOptions());
   const removal = useRemovePasskey();
 
   const passkeys = query.data ?? [];
 
+  if (!principal) {
+    return null;
+  }
+
   return (
     <div className="flex flex-col gap-8">
-      <header className="space-y-2">
-        <p className="text-sm text-muted-foreground">
-          Passkeys let you sign in with Face ID, Touch ID, a Windows Hello PIN,
-          or a hardware security key. Register one on every device you use and
-          you&rsquo;ll never need the emailed sign-in link again.
-        </p>
-      </header>
+      <EmailAddressesSection
+        approved={principal.status === "approved"}
+        primaryEmail={principal.primaryEmail}
+      />
 
       <section className="space-y-3">
-        <h2 className="text-lg font-semibold">Your passkeys</h2>
+        <header>
+          <h3 className="text-base font-medium">Passkeys</h3>
+          <p className="text-sm text-muted-foreground">
+            Passkeys let you sign in with Face ID, Touch ID, a Windows Hello
+            PIN, or a hardware security key. Register one on every device you
+            use and you&rsquo;ll never need the emailed sign-in link again.
+          </p>
+        </header>
+
         {query.isLoading ? (
           <p className="text-sm text-muted-foreground">Loading…</p>
         ) : passkeys.length === 0 ? (
@@ -104,126 +110,17 @@ function SecurityPage() {
             ))}
           </ul>
         )}
-      </section>
 
-      <section className="space-y-3">
-        <h2 className="text-lg font-semibold">Add a passkey</h2>
         <AddPasskeyButton />
       </section>
 
-      <DataAndDeletionSection />
+      <p className="text-xs text-muted-foreground">
+        Looking to download your data or delete your account? Those live on the{" "}
+        <Link to="/my/account/preferences" className="underline">
+          Preferences
+        </Link>{" "}
+        tab.
+      </p>
     </div>
-  );
-}
-
-/**
- * Data export + account deletion. Both honor the promises on /privacy:
- * download a JSON copy of everything we have on you, and hard-delete
- * the account immediately. Deletion is gated by typing the email on
- * file — defends against accidental clicks more than it does against
- * deliberate misuse (a hostile actor with the session can already type
- * the email).
- */
-function DataAndDeletionSection() {
-  const { principal } = useAuth();
-  const navigate = useNavigate();
-  const deletion = useDeleteMyAccount();
-  const [open, setOpen] = useState(false);
-  const [confirmEmail, setConfirmEmail] = useState("");
-
-  const expectedEmail = principal?.primaryEmail ?? "";
-  const matches = confirmEmail.trim().toLowerCase() === expectedEmail;
-
-  const onConfirm = () => {
-    deletion.mutate(undefined, {
-      onSuccess: async () => {
-        toast.success("Account deleted");
-        setOpen(false);
-        await navigate({ to: "/" });
-      },
-      onError: (err) => {
-        toast.error(
-          err instanceof Error ? err.message : "Couldn't delete the account",
-        );
-      },
-    });
-  };
-
-  return (
-    <>
-      <section className="space-y-3">
-        <h2 className="text-lg font-semibold">Your data</h2>
-        <p className="text-sm text-muted-foreground">
-          Download a JSON copy of everything this site stores about you — your
-          profile, emergency contacts, role memberships, and waiver attestation
-          history. The export does not include passkey credentials or magic-link
-          tokens.
-        </p>
-        <Button asChild variant="outline">
-          <a href="/api/account/export" download>
-            Download my data
-          </a>
-        </Button>
-      </section>
-
-      <section className="space-y-3">
-        <h2 className="text-lg font-semibold text-destructive">
-          Delete account
-        </h2>
-        <p className="text-sm text-muted-foreground">
-          Permanently delete your account, profile, emergency contacts,
-          passkeys, sessions, and waiver attestation history. This is immediate
-          and irreversible — there is no recovery on the other side. Authored
-          announcements stay (anonymized) so the timeline for other members
-          remains intact.
-        </p>
-        <AlertDialog open={open} onOpenChange={setOpen}>
-          <AlertDialogTrigger asChild>
-            <Button variant="destructive">Delete my account</Button>
-          </AlertDialogTrigger>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>Delete your account?</AlertDialogTitle>
-              <AlertDialogDescription>
-                This is permanent. Type{" "}
-                <strong className="font-mono">{expectedEmail}</strong> to
-                confirm.
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <div className="space-y-2 py-2">
-              <Label htmlFor="confirm-delete-email" className="text-sm">
-                Email
-              </Label>
-              <Input
-                id="confirm-delete-email"
-                type="email"
-                autoComplete="off"
-                value={confirmEmail}
-                onChange={(e) => setConfirmEmail(e.target.value)}
-                placeholder={expectedEmail}
-              />
-            </div>
-            <AlertDialogFooter>
-              <AlertDialogCancel
-                onClick={() => setConfirmEmail("")}
-                disabled={deletion.isPending}
-              >
-                Cancel
-              </AlertDialogCancel>
-              <AlertDialogAction
-                onClick={(e) => {
-                  e.preventDefault();
-                  onConfirm();
-                }}
-                disabled={!matches || deletion.isPending}
-                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              >
-                {deletion.isPending ? "Deleting…" : "Delete forever"}
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
-      </section>
-    </>
   );
 }

--- a/apps/web/src/routes/my.account.tsx
+++ b/apps/web/src/routes/my.account.tsx
@@ -23,7 +23,7 @@ const TABS = [
   { to: "/my/account", label: "Profile" },
   { to: "/my/account/details", label: "Details" },
   { to: "/my/account/waiver", label: "Waiver" },
-  { to: "/my/account/security", label: "Security" },
+  { to: "/my/account/security", label: "Sign-in" },
   { to: "/my/account/preferences", label: "Preferences" },
 ] as const;
 
@@ -31,26 +31,35 @@ function AccountLayout() {
   return (
     <div className="mx-auto w-full max-w-4xl p-6">
       <h1 className="mb-4 text-2xl font-semibold">Account</h1>
-      <nav className="mb-6 flex gap-1 border-b border-border">
-        {TABS.map((tab) => (
-          <Link
-            key={tab.to}
-            to={tab.to}
-            // Only the Profile tab uses exact matching — sibling tabs
-            // should stay active when their own tab is selected, and
-            // /my/account should NOT stay active when one of the
-            // siblings is.
-            activeOptions={{ exact: tab.to === "/my/account" }}
-            className="border-b-2 border-transparent px-3 py-2 text-sm text-muted-foreground hover:text-foreground"
-            activeProps={{
-              className:
-                "border-b-2 border-primary px-3 py-2 text-sm text-foreground",
-            }}
-          >
-            {tab.label}
-          </Link>
-        ))}
-      </nav>
+      {/*
+       * The tab bar is allowed to overflow horizontally on narrow viewports
+       * rather than wrapping — five labels at body-text size will line-wrap
+       * on a phone, which looked broken. `border-b` lives on the container
+       * so the underline runs the full visual width even after the row
+       * scrolls. Per-link `whitespace-nowrap` keeps individual labels intact.
+       */}
+      <div className="mb-6 -mx-6 border-b border-border">
+        <nav className="flex gap-1 overflow-x-auto px-6 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          {TABS.map((tab) => (
+            <Link
+              key={tab.to}
+              to={tab.to}
+              // Only the Profile tab uses exact matching — sibling tabs
+              // should stay active when their own tab is selected, and
+              // /my/account should NOT stay active when one of the
+              // siblings is.
+              activeOptions={{ exact: tab.to === "/my/account" }}
+              className="-mb-px shrink-0 border-b-2 border-transparent px-3 py-2 text-sm whitespace-nowrap text-muted-foreground hover:text-foreground"
+              activeProps={{
+                className:
+                  "-mb-px shrink-0 border-b-2 border-primary px-3 py-2 text-sm whitespace-nowrap text-foreground",
+              }}
+            >
+              {tab.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
       <Outlet />
     </div>
   );

--- a/apps/web/src/routes/my.account.tsx
+++ b/apps/web/src/routes/my.account.tsx
@@ -4,8 +4,11 @@ import { RouteErrorFallback } from "#/components/error-page";
 
 /**
  * Account hub layout: a page-level container with a horizontal tab bar
- * over the sub-routes (Profile / Details / Waiver / Security /
- * Preferences) and an `<Outlet />` that renders the active child. Each
+ * over the sub-routes (Profile / Details / Waiver / Sign-in /
+ * Preferences) and an `<Outlet />` that renders the active child. The
+ * Sign-in tab still routes to `/my/account/security` — only the label
+ * was renamed, so existing bookmarks and the passkey E2E keep working.
+ * Each
  * tab is a real URL (not state), so direct navigation, shareable links,
  * and the browser back button all work correctly.
  *

--- a/apps/web/src/routes/my.account.tsx
+++ b/apps/web/src/routes/my.account.tsx
@@ -5,12 +5,11 @@ import { RouteErrorFallback } from "#/components/error-page";
 /**
  * Account hub layout: a page-level container with a horizontal tab bar
  * over the sub-routes (Profile / Details / Waiver / Sign-in /
- * Preferences) and an `<Outlet />` that renders the active child. The
- * Sign-in tab still routes to `/my/account/security` — only the label
- * was renamed, so existing bookmarks and the passkey E2E keep working.
- * Each
+ * Preferences) and an `<Outlet />` that renders the active child. Each
  * tab is a real URL (not state), so direct navigation, shareable links,
- * and the browser back button all work correctly.
+ * and the browser back button all work correctly. The Sign-in tab
+ * still routes to `/my/account/security` — only the label was renamed,
+ * so existing bookmarks and the passkey E2E keep working.
  *
  * The approved-only guard is hoisted to the parent `/my` route, so
  * pending/rejected users get shunted before they reach this layout

--- a/apps/web/src/routes/verify-email.tsx
+++ b/apps/web/src/routes/verify-email.tsx
@@ -12,7 +12,7 @@ const verifyEmailSearchSchema = z.object({
 
 /**
  * Landing page for the verification link emailed by the
- * "Add an email" form on /my/account/details. Confirms the recipient is
+ * "Add an email" form on /my/account/security. Confirms the recipient is
  * signed in to the same account that requested the link
  * (`session.userId === magicLink.targetUserId`), then attaches the
  * email to the account.
@@ -91,7 +91,7 @@ function VerifyEmailPage() {
         </header>
         <Button
           size="lg"
-          onClick={() => navigate({ to: "/my/account/details" })}
+          onClick={() => navigate({ to: "/my/account/security" })}
         >
           Back to your account
         </Button>
@@ -110,7 +110,7 @@ function VerifyEmailPage() {
           <p className="text-sm text-muted-foreground">{message}</p>
         </header>
         <Button asChild size="lg" variant="outline">
-          <Link to="/my/account/details">Back to your account</Link>
+          <Link to="/my/account/security">Back to your account</Link>
         </Button>
       </div>
     );


### PR DESCRIPTION
## Summary
- Move email management from **Details** onto the **Sign-in** tab (label rename of Security; URL `/my/account/security` preserved so passkey E2E + existing bookmarks keep working). Emails + passkeys now sit together as the two authentication identifiers.
- Slim **Details** to private PII only — full name, phone, emergency contacts. Add a cross-link to Sign-in for users following the old mental model.
- Move data export + account deletion (`DataAndDeletionSection`) from Security to **Preferences**, where they read more naturally as account-management rather than credential surface.
- Switch the email list rows to shadcn `Item` / `ItemGroup` primitives instead of raw bordered divs.
- Fix the mobile tab strip on `/my/account` — five labels were line-wrapping; the row now scrolls horizontally with a hidden scrollbar and per-link `whitespace-nowrap`.

## Tab map (after)
| Tab | URL | Holds |
|---|---|---|
| Profile | `/my/account` | public-facing fields (avatar, preferred name, UC affiliation, bio) |
| Details | `/my/account/details` | private PII (full name, phone, emergency contacts) |
| Waiver | `/my/account/waiver` | waiver attestation |
| Sign-in | `/my/account/security` _(label-only rename)_ | emails + passkeys |
| Preferences | `/my/account/preferences` | theme + data export + delete account |

## Test plan
- [ ] `/my/account` on mobile width: tabs scroll horizontally instead of wrapping
- [ ] Details tab: only name / phone / emergency contacts visible; cross-link to Sign-in resolves
- [ ] Sign-in tab: email list (with Primary badge, Make primary, Remove, Add email form) renders above passkey list; cross-link to Preferences resolves
- [ ] Preferences tab: theme toggle, "Download my data" link, "Delete my account" dialog all work
- [ ] `passkey.spec.ts` (E2E) still hits `/my/account/security` and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)