### PR TITLE
feat(ucmc-web): wire landing "Meet the officers" to roles

### DIFF
--- a/apps/web/drizzle/migrations/0038_roles_is_officer_and_display_name.sql
+++ b/apps/web/drizzle/migrations/0038_roles_is_officer_and_display_name.sql
@@ -1,0 +1,22 @@
+-- New `display_name` column needs a DEFAULT to satisfy NOT NULL when
+-- ALTERing a non-empty table. The empty default is a one-shot migration
+-- artifact; subsequent inserts go through the role editor which requires
+-- a non-empty display name.
+ALTER TABLE `roles` ADD `display_name` text NOT NULL DEFAULT '';--> statement-breakpoint
+ALTER TABLE `roles` ADD `is_officer` integer DEFAULT false NOT NULL;--> statement-breakpoint
+
+-- Curated labels for the constitutionally-seeded roles.
+UPDATE `roles` SET `display_name` = 'System Admin' WHERE `id` = 'role_system_admin';--> statement-breakpoint
+UPDATE `roles` SET `display_name` = 'Member'       WHERE `id` = 'role_member';--> statement-breakpoint
+UPDATE `roles` SET `display_name` = 'Anonymous'    WHERE `id` = 'role_anonymous';--> statement-breakpoint
+UPDATE `roles` SET `display_name` = 'Advisor'      WHERE `id` = 'role_advisor';--> statement-breakpoint
+UPDATE `roles` SET `display_name` = 'President'    WHERE `id` = 'role_president';--> statement-breakpoint
+UPDATE `roles` SET `display_name` = 'Treasurer'    WHERE `id` = 'role_treasurer';--> statement-breakpoint
+
+-- Best-effort fallback for any admin-created roles not covered above:
+-- capitalize the first letter of the slug and turn underscores into
+-- spaces (e.g. `trip_coordinator` -> `Trip coordinator`). SQLite has no
+-- INITCAP, so this only sentence-cases — admins refine via the editor.
+UPDATE `roles`
+SET `display_name` = UPPER(SUBSTR(`name`, 1, 1)) || REPLACE(SUBSTR(`name`, 2), '_', ' ')
+WHERE `display_name` = '';

--- a/apps/web/drizzle/migrations/0039_officer_roles_seed.sql
+++ b/apps/web/drizzle/migrations/0039_officer_roles_seed.sql
@@ -1,0 +1,11 @@
+-- Flag the constitutionally-seeded officer roles as surfacing on the
+-- public "Meet the officers" home-page section. Subsequent officer roles
+-- (Vice President, Trip Coordinator, Gear Cave Keeper, ...) are
+-- operator-managed via /members/roles and get this flag set through the
+-- editor.
+
+UPDATE `roles` SET `is_officer` = 1
+WHERE `id` IN (
+  'role_president',
+  'role_treasurer'
+);

--- a/apps/web/drizzle/migrations/0040_roles_display_name_non_empty.sql
+++ b/apps/web/drizzle/migrations/0040_roles_display_name_non_empty.sql
@@ -1,0 +1,25 @@
+-- Defense-in-depth: reject empty `display_name` writes at the DB layer.
+--
+-- App-layer validation (zod `.trim().min(1)` in rbac-fns) is the primary
+-- guard — these triggers exist so a future raw-SQL seed, a test fixture,
+-- or a manual D1 console session can't sneak a "" row past the schema
+-- and surface a blank card on the public "Meet the officers" section.
+--
+-- Triggers instead of a CHECK constraint because SQLite has no
+-- `ALTER TABLE ADD CHECK`; the alternative is a full table rebuild,
+-- which is more risk than the defense warrants given the FK references
+-- from `user_roles` and `role_permissions`.
+
+CREATE TRIGGER `roles_display_name_non_empty_insert`
+BEFORE INSERT ON `roles`
+WHEN length(NEW.display_name) = 0
+BEGIN
+  SELECT RAISE(ABORT, 'display_name must not be empty');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `roles_display_name_non_empty_update`
+BEFORE UPDATE OF display_name ON `roles`
+WHEN length(NEW.display_name) = 0
+BEGIN
+  SELECT RAISE(ABORT, 'display_name must not be empty');
+END;

--- a/apps/web/drizzle/migrations/meta/0038_snapshot.json
+++ b/apps/web/drizzle/migrations/meta/0038_snapshot.json
@@ -1,0 +1,2385 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b45b3c90-40f5-42ab-a27e-486c0ef49c24",
+  "prevId": "5c6141e8-dfb2-4265-bac5-6cc257a6d4e8",
+  "tables": {
+    "announcements": {
+      "name": "announcements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "announcements_published_at_idx": {
+          "name": "announcements_published_at_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "announcements_created_by_users_id_fk": {
+          "name": "announcements_created_by_users_id_fk",
+          "tableFrom": "announcements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            "actor_user_id"
+          ],
+          "isUnique": false
+        },
+        "audit_log_target_user_idx": {
+          "name": "audit_log_target_user_idx",
+          "columns": [
+            "target_user_id"
+          ],
+          "isUnique": false
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_log_target_user_id_users_id_fk": {
+          "name": "audit_log_target_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "emergency_contacts": {
+      "name": "emergency_contacts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "emergency_contacts_user_id_users_id_fk": {
+          "name": "emergency_contacts_user_id_users_id_fk",
+          "tableFrom": "emergency_contacts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedback": {
+      "name": "feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_issue_number": {
+          "name": "github_issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "feedback_status_created_at_idx": {
+          "name": "feedback_status_created_at_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "feedback_created_by_idx": {
+          "name": "feedback_created_by_idx",
+          "columns": [
+            "created_by"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "feedback_created_by_users_id_fk": {
+          "name": "feedback_created_by_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gear": {
+      "name": "gear",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thumbnail_key": {
+          "name": "thumbnail_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "acquisition_cost_cents": {
+          "name": "acquisition_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_markdown": {
+          "name": "notes_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lifecycle": {
+          "name": "lifecycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'serviceable'"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retired_by": {
+          "name": "retired_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retired_reason": {
+          "name": "retired_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "gear_public_id_unique": {
+          "name": "gear_public_id_unique",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "gear_code_unique": {
+          "name": "gear_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        },
+        "gear_type_idx": {
+          "name": "gear_type_idx",
+          "columns": [
+            "type_id"
+          ],
+          "isUnique": false
+        },
+        "gear_lifecycle_idx": {
+          "name": "gear_lifecycle_idx",
+          "columns": [
+            "lifecycle"
+          ],
+          "isUnique": false
+        },
+        "gear_condition_idx": {
+          "name": "gear_condition_idx",
+          "columns": [
+            "condition"
+          ],
+          "isUnique": false
+        },
+        "gear_created_at_idx": {
+          "name": "gear_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gear_type_id_gear_types_id_fk": {
+          "name": "gear_type_id_gear_types_id_fk",
+          "tableFrom": "gear",
+          "tableTo": "gear_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "gear_retired_by_users_id_fk": {
+          "name": "gear_retired_by_users_id_fk",
+          "tableFrom": "gear",
+          "tableTo": "users",
+          "columnsFrom": [
+            "retired_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gear_created_by_users_id_fk": {
+          "name": "gear_created_by_users_id_fk",
+          "tableFrom": "gear",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gear_inspections": {
+      "name": "gear_inspections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspector_user_id": {
+          "name": "inspector_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inspector_name_snapshot": {
+          "name": "inspector_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inspected_at": {
+          "name": "inspected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "gear_inspections_public_id_unique": {
+          "name": "gear_inspections_public_id_unique",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "gear_inspections_gear_idx": {
+          "name": "gear_inspections_gear_idx",
+          "columns": [
+            "gear_id"
+          ],
+          "isUnique": false
+        },
+        "gear_inspections_gear_inspected_idx": {
+          "name": "gear_inspections_gear_inspected_idx",
+          "columns": [
+            "gear_id",
+            "inspected_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gear_inspections_gear_id_gear_id_fk": {
+          "name": "gear_inspections_gear_id_gear_id_fk",
+          "tableFrom": "gear_inspections",
+          "tableTo": "gear",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gear_inspections_inspector_user_id_users_id_fk": {
+          "name": "gear_inspections_inspector_user_id_users_id_fk",
+          "tableFrom": "gear_inspections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inspector_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gear_loans": {
+      "name": "gear_loans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_user_id": {
+          "name": "member_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checked_out_by_user_id": {
+          "name": "checked_out_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked_out_at": {
+          "name": "checked_out_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "returned_to_user_id": {
+          "name": "returned_to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checkout_notes": {
+          "name": "checkout_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checkin_notes": {
+          "name": "checkin_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "condition_at_return": {
+          "name": "condition_at_return",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "gear_loans_public_id_unique": {
+          "name": "gear_loans_public_id_unique",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "gear_loans_one_active_per_gear": {
+          "name": "gear_loans_one_active_per_gear",
+          "columns": [
+            "gear_id"
+          ],
+          "isUnique": true,
+          "where": "\"gear_loans\".\"returned_at\" IS NULL"
+        },
+        "gear_loans_member_returned_idx": {
+          "name": "gear_loans_member_returned_idx",
+          "columns": [
+            "member_user_id",
+            "returned_at"
+          ],
+          "isUnique": false
+        },
+        "gear_loans_gear_idx": {
+          "name": "gear_loans_gear_idx",
+          "columns": [
+            "gear_id"
+          ],
+          "isUnique": false
+        },
+        "gear_loans_due_idx": {
+          "name": "gear_loans_due_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gear_loans_gear_id_gear_id_fk": {
+          "name": "gear_loans_gear_id_gear_id_fk",
+          "tableFrom": "gear_loans",
+          "tableTo": "gear",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "gear_loans_member_user_id_users_id_fk": {
+          "name": "gear_loans_member_user_id_users_id_fk",
+          "tableFrom": "gear_loans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "member_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "gear_loans_checked_out_by_user_id_users_id_fk": {
+          "name": "gear_loans_checked_out_by_user_id_users_id_fk",
+          "tableFrom": "gear_loans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "checked_out_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gear_loans_returned_to_user_id_users_id_fk": {
+          "name": "gear_loans_returned_to_user_id_users_id_fk",
+          "tableFrom": "gear_loans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "returned_to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gear_tag_assignments": {
+      "name": "gear_tag_assignments",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "assigned_by": {
+          "name": "assigned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "gear_tag_assignments_tag_idx": {
+          "name": "gear_tag_assignments_tag_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gear_tag_assignments_gear_id_gear_id_fk": {
+          "name": "gear_tag_assignments_gear_id_gear_id_fk",
+          "tableFrom": "gear_tag_assignments",
+          "tableTo": "gear",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gear_tag_assignments_tag_id_gear_tags_id_fk": {
+          "name": "gear_tag_assignments_tag_id_gear_tags_id_fk",
+          "tableFrom": "gear_tag_assignments",
+          "tableTo": "gear_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gear_tag_assignments_assigned_by_users_id_fk": {
+          "name": "gear_tag_assignments_assigned_by_users_id_fk",
+          "tableFrom": "gear_tag_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gear_tag_assignments_gear_id_tag_id_pk": {
+          "columns": [
+            "gear_id",
+            "tag_id"
+          ],
+          "name": "gear_tag_assignments_gear_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gear_tags": {
+      "name": "gear_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'public'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "gear_tags_public_id_unique": {
+          "name": "gear_tags_public_id_unique",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "gear_tags_name_unique": {
+          "name": "gear_tags_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gear_types": {
+      "name": "gear_types",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "gear_types_public_id_unique": {
+          "name": "gear_types_public_id_unique",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "gear_types_name_unique": {
+          "name": "gear_types_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "gear_types_created_by_users_id_fk": {
+          "name": "gear_types_created_by_users_id_fk",
+          "tableFrom": "gear_types",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "landing_activities": {
+      "name": "landing_activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blurb": {
+          "name": "blurb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "landing_activities_sort_idx": {
+          "name": "landing_activities_sort_idx",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "landing_faq_items": {
+      "name": "landing_faq_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "landing_faq_items_sort_idx": {
+          "name": "landing_faq_items_sort_idx",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "landing_hero_slides": {
+      "name": "landing_hero_slides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "landing_hero_slides_sort_idx": {
+          "name": "landing_hero_slides_sort_idx",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "landing_settings": {
+      "name": "landing_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "landing_settings_updated_by_users_id_fk": {
+          "name": "landing_settings_updated_by_users_id_fk",
+          "tableFrom": "landing_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_links": {
+      "name": "magic_links",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "magic_links_target_user_id_users_id_fk": {
+          "name": "magic_links_target_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey_credentials": {
+      "name": "passkey_credentials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkey_credential_id_unique": {
+          "name": "passkey_credential_id_unique",
+          "columns": [
+            "credential_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "passkey_credentials_user_id_users_id_fk": {
+          "name": "passkey_credentials_user_id_users_id_fk",
+          "tableFrom": "passkey_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "permissions": {
+      "name": "permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "permissions_name_unique": {
+          "name": "permissions_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "profiles": {
+      "name": "profiles",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preferred_name": {
+          "name": "preferred_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uc_affiliation": {
+          "name": "uc_affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_key": {
+          "name": "avatar_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policies_acknowledged_at": {
+          "name": "policies_acknowledged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policies_version": {
+          "name": "policies_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_user_id_users_id_fk": {
+          "name": "profiles_user_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "role_permissions": {
+      "name": "role_permissions",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_id_pk": {
+          "columns": [
+            "role_id",
+            "permission_id"
+          ],
+          "name": "role_permissions_role_id_permission_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "roles": {
+      "name": "roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_officer": {
+          "name": "is_officer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_settings": {
+      "name": "site_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "site_settings_updated_by_users_id_fk": {
+          "name": "site_settings_updated_by_users_id_fk",
+          "tableFrom": "site_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_emails": {
+      "name": "user_emails",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "user_emails_email_unique": {
+          "name": "user_emails_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_emails_one_primary_per_user": {
+          "name": "user_emails_one_primary_per_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true,
+          "where": "\"user_emails\".\"is_primary\" = 1"
+        },
+        "user_emails_user_id_idx": {
+          "name": "user_emails_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_emails_user_id_users_id_fk": {
+          "name": "user_emails_user_id_users_id_fk",
+          "tableFrom": "user_emails",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_roles": {
+      "name": "user_roles",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "columns": [
+            "user_id",
+            "role_id"
+          ],
+          "name": "user_roles_user_id_role_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "placeholder_name": {
+          "name": "placeholder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unclaimed_at": {
+          "name": "unclaimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_read_announcements_at": {
+          "name": "last_read_announcements_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_public_id_unique": {
+          "name": "users_public_id_unique",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "waiver_attestations": {
+      "name": "waiver_attestations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attested_at": {
+          "name": "attested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "attested_by": {
+          "name": "attested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "waiver_attestations_user_cycle": {
+          "name": "waiver_attestations_user_cycle",
+          "columns": [
+            "user_id",
+            "cycle"
+          ],
+          "isUnique": false
+        },
+        "waiver_attestations_cycle_version_revoked": {
+          "name": "waiver_attestations_cycle_version_revoked",
+          "columns": [
+            "cycle",
+            "version",
+            "revoked_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "waiver_attestations_user_id_users_id_fk": {
+          "name": "waiver_attestations_user_id_users_id_fk",
+          "tableFrom": "waiver_attestations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "waiver_attestations_attested_by_users_id_fk": {
+          "name": "waiver_attestations_attested_by_users_id_fk",
+          "tableFrom": "waiver_attestations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "attested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "waiver_attestations_revoked_by_users_id_fk": {
+          "name": "waiver_attestations_revoked_by_users_id_fk",
+          "tableFrom": "waiver_attestations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/web/drizzle/migrations/meta/_journal.json
+++ b/apps/web/drizzle/migrations/meta/_journal.json
@@ -267,6 +267,20 @@
       "when": 1778717898519,
       "tag": "0037_settings_manage_permission_seed",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "6",
+      "when": 1778723653417,
+      "tag": "0038_roles_is_officer_and_display_name",
+      "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "6",
+      "when": 1778723653418,
+      "tag": "0039_officer_roles_seed",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/drizzle/migrations/meta/_journal.json
+++ b/apps/web/drizzle/migrations/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1778723653418,
       "tag": "0039_officer_roles_seed",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "6",
+      "when": 1778723653419,
+      "tag": "0040_roles_display_name_non_empty",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/drizzle/schema.ts
+++ b/apps/web/drizzle/schema.ts
@@ -539,6 +539,7 @@ export const auditAction = [
   "email.primary_changed",
   // RBAC.
   "role.created",
+  "role.updated",
   "role.deleted",
   "role.permissions_set",
   "role.assigned",

--- a/apps/web/drizzle/schema.ts
+++ b/apps/web/drizzle/schema.ts
@@ -178,9 +178,22 @@ export const roles = sqliteTable(
   "roles",
   {
     id: text("id").primaryKey(),
+    // Identifier-style slug, regex-constrained at the API layer
+    // (^[a-z][a-z0-9_]*$). Stable; never user-facing.
     name: text("name").notNull(),
+    // Human-readable label shown wherever the role is presented to a
+    // user (role editor, member detail, landing "Meet the officers"
+    // section). Enforced non-empty by the editor; the migration
+    // backfilled existing rows.
+    displayName: text("display_name").notNull(),
     description: text("description"),
     position: integer("position").notNull().default(0),
+    // When true, members assigned to this role surface on the public
+    // home page's "Meet the officers" section. Toggled in the role
+    // editor; no other behavior keys off this flag.
+    isOfficer: integer("is_officer", { mode: "boolean" })
+      .notNull()
+      .default(false),
   },
   (t) => [uniqueIndex("roles_name_unique").on(t.name)],
 );

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -274,6 +274,12 @@ export default [
             {
               target: "./src/features/members",
               from: "./src/features/landing",
+              // The role-update hook invalidates the landing-content
+              // query cache when a role's displayName / isOfficer
+              // changes — those fields surface on the public home page.
+              // Carve out the query-key constant so the hook doesn't
+              // hand-roll a brittle string literal.
+              except: ["./api/query-keys.ts"],
             },
             {
               target: "./src/features/waivers",

--- a/apps/web/src/features/audit/server/audit-fns.ts
+++ b/apps/web/src/features/audit/server/audit-fns.ts
@@ -35,6 +35,7 @@ export const AUDIT_ACTIONS = [
   "email.removed",
   "email.primary_changed",
   "role.created",
+  "role.updated",
   "role.deleted",
   "role.permissions_set",
   "role.assigned",

--- a/apps/web/src/features/auth/server/__tests__/auth-flows.test.ts
+++ b/apps/web/src/features/auth/server/__tests__/auth-flows.test.ts
@@ -147,6 +147,7 @@ async function seedApprover(): Promise<string> {
   await getDb().insert(schema.roles).values({
     id: "role_system_admin",
     name: "system_admin",
+    displayName: "System Admin",
     description: "System administrator",
   });
   await getDb().insert(schema.permissions).values({
@@ -164,7 +165,12 @@ async function seedApprover(): Promise<string> {
   // Also seed the member role (granted on approval).
   await getDb()
     .insert(schema.roles)
-    .values({ id: "role_member", name: "member", description: "Member" })
+    .values({
+      id: "role_member",
+      name: "member",
+      displayName: "Member",
+      description: "Member",
+    })
     .onConflictDoNothing();
   return id;
 }

--- a/apps/web/src/features/landing/api/queries.ts
+++ b/apps/web/src/features/landing/api/queries.ts
@@ -2,10 +2,10 @@ import { LANDING_CONTENT_QUERY_KEY } from "#/features/landing/api/query-keys";
 import { getLandingContentFn } from "#/features/landing/server/landing-fns";
 
 /**
- * Bundled landing-page content (settings + hero slides + FAQ + activities)
- * — the home page route loader prefetches this so SSR has the data baked
- * in. 60s staleTime keeps the page snappy across navigations without
- * hammering the server on every soft nav.
+ * Bundled landing-page content (settings + hero slides + FAQ + activities
+ * + officers) — the home page route loader prefetches this so SSR has the
+ * data baked in. 60s staleTime keeps the page snappy across navigations
+ * without hammering the server on every soft nav.
  */
 export function landingContentQueryOptions() {
   return {

--- a/apps/web/src/features/landing/components/__tests__/officers.test.tsx
+++ b/apps/web/src/features/landing/components/__tests__/officers.test.tsx
@@ -1,0 +1,111 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Officers } from "#/features/landing/components/officers";
+import { LANDING_CONTENT_QUERY_KEY } from "#/features/landing/api/query-keys";
+import type { LandingContent } from "#/features/landing/server/landing-actions.server";
+
+// `Officers` reads the landing content bundle off the React Query cache. The
+// component never calls the server fn in tests because we seed the cache
+// before rendering — but the import graph still pulls in `landing-fns`, so
+// stub the server fn module to keep the test pool boundary clean.
+vi.mock("#/features/landing/server/landing-fns", () => ({
+  getLandingContentFn: vi.fn(),
+}));
+
+function renderWithContent(content: Partial<LandingContent>) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const fullContent: LandingContent = {
+    settings: {},
+    heroSlides: [],
+    faqItems: [],
+    activities: [],
+    officers: [],
+    ...content,
+  };
+  client.setQueryData(LANDING_CONTENT_QUERY_KEY, fullContent);
+  return render(
+    <QueryClientProvider client={client}>
+      <Officers />
+    </QueryClientProvider>,
+  );
+}
+
+describe("Officers", () => {
+  it("renders nothing when no officer roles are present", () => {
+    const { container } = renderWithContent({ officers: [] });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders one card per (role, member) pair with name + role label", () => {
+    renderWithContent({
+      officers: [
+        {
+          roleId: "role_president",
+          displayName: "President",
+          position: 0,
+          members: [
+            {
+              userId: "u_alice",
+              preferredName: "Alice",
+              avatarKey: null,
+            },
+            {
+              userId: "u_bob",
+              preferredName: "Bob",
+              avatarKey: null,
+            },
+          ],
+        },
+        {
+          roleId: "role_treasurer",
+          displayName: "Treasurer",
+          position: 1,
+          members: [
+            {
+              userId: "u_carol",
+              preferredName: "Carol",
+              avatarKey: null,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(
+      screen.getByRole("heading", { name: /meet the officers/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+    expect(screen.getByText("Carol")).toBeInTheDocument();
+    // Two co-presidents → "President" label rendered twice.
+    expect(screen.getAllByText("President")).toHaveLength(2);
+    expect(screen.getByText("Treasurer")).toBeInTheDocument();
+  });
+
+  it("falls back to initials when avatar key is null", () => {
+    renderWithContent({
+      officers: [
+        {
+          roleId: "role_president",
+          displayName: "President",
+          position: 0,
+          members: [
+            {
+              userId: "u_alice",
+              preferredName: "Alice Mountaineer",
+              avatarKey: null,
+            },
+          ],
+        },
+      ],
+    });
+
+    // Initials derive from preferredName via `initialsFor` in UserAvatar:
+    // "Alice Mountaineer" → "AM"
+    expect(screen.getByText("AM")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/landing/components/officers.tsx
+++ b/apps/web/src/features/landing/components/officers.tsx
@@ -1,51 +1,44 @@
-import { Avatar, AvatarFallback, AvatarImage } from "#/components/ui/avatar";
+import { useQuery } from "@tanstack/react-query";
+
 import { Card, CardContent } from "#/components/ui/card";
+import { UserAvatar } from "#/components/user-avatar";
+import { landingContentQueryOptions } from "#/features/landing/api/queries";
 
-type Officer = {
-  name: string;
-  role: string;
-  bio: string;
-  photoSrc?: string;
-};
-
-// TODO(content): replace with the current officer roster. Drop optional
-// headshots into apps/web/public/landing/officers/ and set photoSrc.
-const officers: Array<Officer> = [
-  {
-    name: "TODO(content): Name",
-    role: "President",
-    bio: "TODO(content): one-line bio",
-  },
-  {
-    name: "TODO(content): Name",
-    role: "Vice President",
-    bio: "TODO(content): one-line bio",
-  },
-  {
-    name: "TODO(content): Name",
-    role: "Treasurer",
-    bio: "TODO(content): one-line bio",
-  },
-  {
-    name: "TODO(content): Name",
-    role: "Trip Coordinator",
-    bio: "TODO(content): one-line bio",
-  },
-];
-
-function initials(name: string): string {
-  const cleaned = name.replace(/^TODO\(content\):\s*/i, "").trim();
-  if (!cleaned) {
-    return "?";
-  }
-  return cleaned
-    .split(/\s+/)
-    .slice(0, 2)
-    .map((part) => part[0].toUpperCase())
-    .join("");
+interface OfficerCard {
+  key: string;
+  userId: string;
+  preferredName: string;
+  avatarKey: string | null;
+  roleDisplayName: string;
 }
 
 export function Officers() {
+  const { data } = useQuery(landingContentQueryOptions());
+  const officerRoles = data?.officers ?? [];
+
+  // Flatten the grouped (role, members[]) shape into one card per person.
+  // Role-position ordering is preserved by the server (`ORDER BY position`),
+  // so iterating in order here keeps the visual ordering stable.
+  const cards: OfficerCard[] = [];
+  for (const role of officerRoles) {
+    for (const member of role.members) {
+      cards.push({
+        key: `${role.roleId}:${member.userId}`,
+        userId: member.userId,
+        preferredName: member.preferredName,
+        avatarKey: member.avatarKey,
+        roleDisplayName: role.displayName,
+      });
+    }
+  }
+
+  // Section is hidden entirely when no officer role is flagged or none have
+  // claimed members yet. Keeps the home page from showing a stub block before
+  // the roster is populated.
+  if (cards.length === 0) {
+    return null;
+  }
+
   return (
     <section className="border-b py-16 md:py-20">
       <div className="mx-auto max-w-6xl px-6">
@@ -58,21 +51,18 @@ export function Officers() {
           </p>
         </div>
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          {officers.map((officer) => (
-            <Card key={officer.role}>
+          {cards.map((card) => (
+            <Card key={card.key}>
               <CardContent className="flex flex-col items-center gap-3 pt-6 text-center">
-                <Avatar className="size-20">
-                  {officer.photoSrc ? (
-                    <AvatarImage src={officer.photoSrc} alt={officer.name} />
-                  ) : null}
-                  <AvatarFallback className="text-lg">
-                    {initials(officer.name)}
-                  </AvatarFallback>
-                </Avatar>
+                <UserAvatar
+                  avatarKey={card.avatarKey}
+                  name={card.preferredName}
+                  className="size-20"
+                  fallbackClassName="text-lg"
+                />
                 <div className="space-y-1">
-                  <p className="font-semibold">{officer.name}</p>
-                  <p className="text-sm text-primary">{officer.role}</p>
-                  <p className="text-sm text-muted-foreground">{officer.bio}</p>
+                  <p className="font-semibold">{card.preferredName}</p>
+                  <p className="text-sm text-primary">{card.roleDisplayName}</p>
                 </div>
               </CardContent>
             </Card>

--- a/apps/web/src/features/landing/server/__tests__/landing-officers.test.ts
+++ b/apps/web/src/features/landing/server/__tests__/landing-officers.test.ts
@@ -72,7 +72,7 @@ beforeEach(async () => {
   await db.delete(schema.auditLog);
   // Drop any test-created officer roles to keep `listLandingOfficers`
   // deterministic. Seeded officer roles (role_president, role_treasurer)
-  // are flagged `is_officer = 1` by migration 0037; unflag them here so
+  // are flagged `is_officer = 1` by migration 0039; unflag them here so
   // the empty-case test sees an empty list.
   await db
     .delete(schema.roles)

--- a/apps/web/src/features/landing/server/__tests__/landing-officers.test.ts
+++ b/apps/web/src/features/landing/server/__tests__/landing-officers.test.ts
@@ -1,0 +1,321 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+
+import { getDb, schema } from "#/server/db";
+import { attachPrimaryEmail } from "#/server/db/test-helpers";
+
+const { listLandingOfficers } =
+  await import("#/features/landing/server/landing-officers.server");
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+interface SeedUserOpts {
+  email: string;
+  status?: schema.UserStatus;
+  preferredName?: string;
+  withProfile?: boolean;
+  avatarKey?: string | null;
+}
+
+async function seedUser(opts: SeedUserOpts): Promise<string> {
+  const id = `user_${crypto.randomUUID()}`;
+  const db = getDb();
+  await db.insert(schema.users).values({
+    id,
+    publicId: crypto.randomUUID().replace(/-/g, "").slice(0, 12),
+    status: opts.status ?? "approved",
+  });
+  await attachPrimaryEmail(id, opts.email);
+  if (opts.withProfile ?? true) {
+    await db.insert(schema.profiles).values({
+      userId: id,
+      fullName: opts.preferredName ?? "Test User",
+      preferredName: opts.preferredName ?? "Test",
+      phone: "+15135551212",
+      ucAffiliation: "student",
+      avatarKey: opts.avatarKey ?? null,
+      updatedAt: new Date(),
+    });
+  }
+  return id;
+}
+
+async function seedRole(opts: {
+  id: string;
+  name: string;
+  displayName: string;
+  position: number;
+  isOfficer: boolean;
+}): Promise<void> {
+  await getDb().insert(schema.roles).values(opts);
+}
+
+async function assignRole(userId: string, roleId: string): Promise<void> {
+  await getDb()
+    .insert(schema.userRoles)
+    .values({ userId, roleId })
+    .onConflictDoNothing();
+}
+
+// ── setup ──────────────────────────────────────────────────────────────
+
+beforeEach(async () => {
+  const db = getDb();
+  // Per-file storage isolation: wipe anything we may have written. Audit
+  // log isn't touched by this reader, but other join tables are.
+  await db.delete(schema.userRoles);
+  await db.delete(schema.rolePermissions);
+  await db.delete(schema.sessions);
+  await db.delete(schema.profiles);
+  await db.delete(schema.userEmails);
+  await db.delete(schema.users);
+  await db.delete(schema.auditLog);
+  // Drop any test-created officer roles to keep `listLandingOfficers`
+  // deterministic. Seeded officer roles (role_president, role_treasurer)
+  // are flagged `is_officer = 1` by migration 0037; unflag them here so
+  // the empty-case test sees an empty list.
+  await db
+    .delete(schema.roles)
+    .where(
+      inArray(schema.roles.id, [
+        "role_test_president",
+        "role_test_trip_lead",
+        "role_test_secretary",
+      ]),
+    );
+  await db
+    .update(schema.roles)
+    .set({ isOfficer: false })
+    .where(eq(schema.roles.isOfficer, true));
+});
+
+// ── tests ──────────────────────────────────────────────────────────────
+
+describe("listLandingOfficers", () => {
+  it("returns an empty list when no role is flagged as officer", async () => {
+    const userId = await seedUser({
+      email: "noone@example.com",
+      preferredName: "Nobody",
+    });
+    await assignRole(userId, "role_member");
+
+    const result = await listLandingOfficers();
+
+    expect(result).toEqual([]);
+  });
+
+  it("groups members by role and orders roles by position", async () => {
+    await seedRole({
+      id: "role_test_president",
+      name: "test_president",
+      displayName: "President",
+      position: 0,
+      isOfficer: true,
+    });
+    await seedRole({
+      id: "role_test_secretary",
+      name: "test_secretary",
+      displayName: "Secretary",
+      position: 1,
+      isOfficer: true,
+    });
+
+    const prez = await seedUser({
+      email: "prez@example.com",
+      preferredName: "Alice",
+    });
+    const sec = await seedUser({
+      email: "sec@example.com",
+      preferredName: "Bob",
+    });
+
+    await assignRole(prez, "role_test_president");
+    await assignRole(sec, "role_test_secretary");
+
+    const result = await listLandingOfficers();
+
+    expect(result.map((r) => r.roleId)).toEqual([
+      "role_test_president",
+      "role_test_secretary",
+    ]);
+    expect(result[0].displayName).toBe("President");
+    expect(result[0].members.map((m) => m.preferredName)).toEqual(["Alice"]);
+    expect(result[1].members.map((m) => m.preferredName)).toEqual(["Bob"]);
+  });
+
+  it("sorts members within a role by preferredName", async () => {
+    await seedRole({
+      id: "role_test_trip_lead",
+      name: "test_trip_lead",
+      displayName: "Trip Lead",
+      position: 0,
+      isOfficer: true,
+    });
+    const charlie = await seedUser({
+      email: "c@example.com",
+      preferredName: "Charlie",
+    });
+    const alice = await seedUser({
+      email: "a@example.com",
+      preferredName: "Alice",
+    });
+    const bob = await seedUser({
+      email: "b@example.com",
+      preferredName: "Bob",
+    });
+    await assignRole(charlie, "role_test_trip_lead");
+    await assignRole(alice, "role_test_trip_lead");
+    await assignRole(bob, "role_test_trip_lead");
+
+    const result = await listLandingOfficers();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].members.map((m) => m.preferredName)).toEqual([
+      "Alice",
+      "Bob",
+      "Charlie",
+    ]);
+  });
+
+  it("skips users whose status is not approved", async () => {
+    await seedRole({
+      id: "role_test_president",
+      name: "test_president",
+      displayName: "President",
+      position: 0,
+      isOfficer: true,
+    });
+    const pending = await seedUser({
+      email: "pending@example.com",
+      preferredName: "Pending",
+      status: "pending",
+    });
+    const deactivated = await seedUser({
+      email: "deactivated@example.com",
+      preferredName: "Deactivated",
+      status: "deactivated",
+    });
+    const approved = await seedUser({
+      email: "approved@example.com",
+      preferredName: "Real",
+    });
+
+    await assignRole(pending, "role_test_president");
+    await assignRole(deactivated, "role_test_president");
+    await assignRole(approved, "role_test_president");
+
+    const result = await listLandingOfficers();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].members.map((m) => m.preferredName)).toEqual(["Real"]);
+  });
+
+  it("skips users with no profile row (unclaimed stubs)", async () => {
+    await seedRole({
+      id: "role_test_president",
+      name: "test_president",
+      displayName: "President",
+      position: 0,
+      isOfficer: true,
+    });
+    // Officer pre-add path: user exists but no profiles row. Even if
+    // their status were somehow "approved", the innerJoin on profiles
+    // protects against leaking placeholder identities. We force
+    // "approved" here to make the join the load-bearing guard.
+    const stub = await seedUser({
+      email: "stub@example.com",
+      preferredName: "Stub",
+      withProfile: false,
+    });
+    await assignRole(stub, "role_test_president");
+
+    const result = await listLandingOfficers();
+
+    expect(result).toEqual([]);
+  });
+
+  it("emits a row in each officer role a user holds", async () => {
+    await seedRole({
+      id: "role_test_president",
+      name: "test_president",
+      displayName: "President",
+      position: 0,
+      isOfficer: true,
+    });
+    await seedRole({
+      id: "role_test_trip_lead",
+      name: "test_trip_lead",
+      displayName: "Trip Lead",
+      position: 1,
+      isOfficer: true,
+    });
+    const dualHat = await seedUser({
+      email: "dual@example.com",
+      preferredName: "Dana",
+    });
+    await assignRole(dualHat, "role_test_president");
+    await assignRole(dualHat, "role_test_trip_lead");
+
+    const result = await listLandingOfficers();
+
+    expect(result.map((r) => r.displayName)).toEqual([
+      "President",
+      "Trip Lead",
+    ]);
+    expect(result.flatMap((r) => r.members.map((m) => m.userId))).toEqual([
+      dualHat,
+      dualHat,
+    ]);
+  });
+
+  it("ignores roles that are not flagged as officer", async () => {
+    await seedRole({
+      id: "role_test_secretary",
+      name: "test_secretary",
+      displayName: "Secretary",
+      position: 0,
+      isOfficer: false,
+    });
+    const hidden = await seedUser({
+      email: "hidden@example.com",
+      preferredName: "Hidden",
+    });
+    await assignRole(hidden, "role_test_secretary");
+
+    const result = await listLandingOfficers();
+
+    expect(result).toEqual([]);
+  });
+
+  it("returns avatarKey when present and null when not", async () => {
+    await seedRole({
+      id: "role_test_president",
+      name: "test_president",
+      displayName: "President",
+      position: 0,
+      isOfficer: true,
+    });
+    const withAvatar = await seedUser({
+      email: "withavatar@example.com",
+      preferredName: "Anna",
+      avatarKey: "avatars/anna/abc123.webp",
+    });
+    const noAvatar = await seedUser({
+      email: "noavatar@example.com",
+      preferredName: "Zed",
+    });
+    await assignRole(withAvatar, "role_test_president");
+    await assignRole(noAvatar, "role_test_president");
+
+    const result = await listLandingOfficers();
+
+    expect(result[0].members).toEqual([
+      {
+        userId: withAvatar,
+        preferredName: "Anna",
+        avatarKey: "avatars/anna/abc123.webp",
+      },
+      { userId: noAvatar, preferredName: "Zed", avatarKey: null },
+    ]);
+  });
+});

--- a/apps/web/src/features/landing/server/landing-actions.server.ts
+++ b/apps/web/src/features/landing/server/landing-actions.server.ts
@@ -41,6 +41,8 @@ import {
   putLandingImage,
   shortContentHash,
 } from "#/features/landing/server/landing-image.server";
+import type { LandingOfficerRole } from "#/features/landing/server/landing-officers.server";
+import { listLandingOfficers } from "#/features/landing/server/landing-officers.server";
 import {
   LANDING_LIMITS,
   LANDING_SETTING_KEYS,
@@ -109,17 +111,20 @@ export interface LandingContent {
   heroSlides: HeroSlideSummary[];
   faqItems: FaqItemSummary[];
   activities: ActivitySummary[];
+  officers: LandingOfficerRole[];
 }
 
 // ── read ────────────────────────────────────────────────────────────────
 
 export async function getLandingContentAction(): Promise<LandingContent> {
-  const [settingRows, heroSlides, faqItems, activities] = await Promise.all([
-    listSettings(),
-    listHeroSlides(),
-    listFaqItems(),
-    listActivities(),
-  ]);
+  const [settingRows, heroSlides, faqItems, activities, officers] =
+    await Promise.all([
+      listSettings(),
+      listHeroSlides(),
+      listFaqItems(),
+      listActivities(),
+      listLandingOfficers(),
+    ]);
 
   const settings: Record<string, LandingSettingValue> = {};
   for (const row of settingRows) {
@@ -163,6 +168,7 @@ export async function getLandingContentAction(): Promise<LandingContent> {
       imageKey: a.imageKey,
       sortOrder: a.sortOrder,
     })),
+    officers,
   };
 }
 

--- a/apps/web/src/features/landing/server/landing-officers.server.ts
+++ b/apps/web/src/features/landing/server/landing-officers.server.ts
@@ -1,0 +1,81 @@
+/**
+ * Read side of the public "Meet the officers" home-page section.
+ *
+ * Anonymous-safe: the landing route is public, so this query intentionally
+ * has no auth gate. It only exposes (preferredName, avatarKey, displayName)
+ * — the same identification surface a signed-in member already sees in the
+ * directory, but limited to users assigned to a role flagged `is_officer`.
+ *
+ * Privacy invariants enforced here:
+ *   1. `innerJoin(profiles)` — unclaimed (officer-pre-added) stubs never
+ *      surface; they have no `profiles` row.
+ *   2. `status = "approved"` — pending / rejected / deactivated never surface.
+ *   3. `isOfficer = true` filter — admins explicitly opt a role into the
+ *      public surface.
+ *
+ * Ordering: roles by `position` asc (admin-controlled in the role editor's
+ * drag handle); members within a role by `preferredName` asc (predictable
+ * default; no per-card ordering UI in v1).
+ */
+import { and, asc, eq } from "drizzle-orm";
+
+import { getDb, schema } from "#/server/db";
+
+export interface LandingOfficerMember {
+  userId: string;
+  preferredName: string;
+  avatarKey: string | null;
+}
+
+export interface LandingOfficerRole {
+  roleId: string;
+  displayName: string;
+  position: number;
+  members: LandingOfficerMember[];
+}
+
+export async function listLandingOfficers(): Promise<LandingOfficerRole[]> {
+  const db = getDb();
+  const rows = await db
+    .select({
+      roleId: schema.roles.id,
+      displayName: schema.roles.displayName,
+      position: schema.roles.position,
+      userId: schema.users.id,
+      preferredName: schema.profiles.preferredName,
+      avatarKey: schema.profiles.avatarKey,
+    })
+    .from(schema.roles)
+    .innerJoin(schema.userRoles, eq(schema.userRoles.roleId, schema.roles.id))
+    .innerJoin(schema.users, eq(schema.users.id, schema.userRoles.userId))
+    .innerJoin(schema.profiles, eq(schema.profiles.userId, schema.users.id))
+    .where(
+      and(
+        eq(schema.roles.isOfficer, true),
+        eq(schema.users.status, "approved"),
+      ),
+    )
+    .orderBy(asc(schema.roles.position), asc(schema.profiles.preferredName));
+
+  // Group flat rows into one entry per role while preserving the
+  // role-ordering coming out of the SQL ORDER BY.
+  const byRole = new Map<string, LandingOfficerRole>();
+  for (const r of rows) {
+    let entry = byRole.get(r.roleId);
+    if (!entry) {
+      entry = {
+        roleId: r.roleId,
+        displayName: r.displayName,
+        position: r.position,
+        members: [],
+      };
+      byRole.set(r.roleId, entry);
+    }
+    entry.members.push({
+      userId: r.userId,
+      preferredName: r.preferredName,
+      avatarKey: r.avatarKey,
+    });
+  }
+  return [...byRole.values()];
+}

--- a/apps/web/src/features/members/api/use-create-role.ts
+++ b/apps/web/src/features/members/api/use-create-role.ts
@@ -6,8 +6,12 @@ import { createRoleFn } from "#/features/members/server/rbac-fns";
 export function useCreateRole() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (input: { name: string; description?: string }) =>
-      createRoleFn({ data: input }),
+    mutationFn: (input: {
+      name: string;
+      displayName: string;
+      description?: string;
+      isOfficer?: boolean;
+    }) => createRoleFn({ data: input }),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ROLES_QUERY_KEY });
     },

--- a/apps/web/src/features/members/api/use-update-role.ts
+++ b/apps/web/src/features/members/api/use-update-role.ts
@@ -9,14 +9,22 @@ import { updateRoleFn } from "#/features/members/server/rbac-fns";
 export function useUpdateRole() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (input: { roleId: string; description: string | null }) =>
-      updateRoleFn({ data: input }),
+    mutationFn: (input: {
+      roleId: string;
+      description?: string | null;
+      displayName?: string;
+      isOfficer?: boolean;
+    }) => updateRoleFn({ data: input }),
     onSuccess: async (_data, vars) => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ROLES_QUERY_KEY }),
         queryClient.invalidateQueries({
           queryKey: roleQueryKey(vars.roleId),
         }),
+        // Officer roster surfaces on the public landing page; invalidate
+        // its cached bundle so the new flag/label reflects immediately
+        // for anyone viewing /.
+        queryClient.invalidateQueries({ queryKey: ["landing", "content"] }),
       ]);
     },
   });

--- a/apps/web/src/features/members/api/use-update-role.ts
+++ b/apps/web/src/features/members/api/use-update-role.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
+import { LANDING_CONTENT_QUERY_KEY } from "#/features/landing/api/query-keys";
 import {
   ROLES_QUERY_KEY,
   roleQueryKey,
@@ -16,16 +17,22 @@ export function useUpdateRole() {
       isOfficer?: boolean;
     }) => updateRoleFn({ data: input }),
     onSuccess: async (_data, vars) => {
-      await Promise.all([
+      const invalidations = [
         queryClient.invalidateQueries({ queryKey: ROLES_QUERY_KEY }),
-        queryClient.invalidateQueries({
-          queryKey: roleQueryKey(vars.roleId),
-        }),
-        // Officer roster surfaces on the public landing page; invalidate
-        // its cached bundle so the new flag/label reflects immediately
-        // for anyone viewing /.
-        queryClient.invalidateQueries({ queryKey: ["landing", "content"] }),
-      ]);
+        queryClient.invalidateQueries({ queryKey: roleQueryKey(vars.roleId) }),
+      ];
+      // Only the displayName + isOfficer fields surface on the public
+      // home page. Description-only edits don't change anything the
+      // landing bundle renders, so skip the cross-feature invalidation
+      // in that case.
+      if (vars.displayName !== undefined || vars.isOfficer !== undefined) {
+        invalidations.push(
+          queryClient.invalidateQueries({
+            queryKey: LANDING_CONTENT_QUERY_KEY,
+          }),
+        );
+      }
+      await Promise.all(invalidations);
     },
   });
 }

--- a/apps/web/src/features/members/components/__tests__/role-editor-sheet.test.tsx
+++ b/apps/web/src/features/members/components/__tests__/role-editor-sheet.test.tsx
@@ -1,0 +1,126 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  PERMISSIONS_QUERY_KEY,
+  roleQueryKey,
+} from "#/features/members/api/query-keys";
+import { RoleEditorSheet } from "#/features/members/components/role-editor-sheet";
+import type {
+  PermissionSummary,
+  RoleDetail,
+} from "#/features/members/server/rbac-fns";
+
+// The sheet uses `useQuery` against `roleQueryOptions` + `permissionsQueryOptions`;
+// we seed the cache directly so the server fns are never called. Stub the
+// shell module so the import graph stays clean in the jsdom pool.
+vi.mock("#/features/members/server/rbac-fns", () => ({
+  getRoleFn: vi.fn(),
+  listPermissionsFn: vi.fn(),
+}));
+
+vi.mock("#/features/members/api/use-set-role-permissions", () => ({
+  useSetRolePermissions: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+}));
+
+vi.mock("#/features/members/api/use-update-role", () => ({
+  useUpdateRole: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+}));
+
+function renderWithRole(role: RoleDetail) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(roleQueryKey(role.id), role);
+  const permissions: PermissionSummary[] = [];
+  client.setQueryData(PERMISSIONS_QUERY_KEY, permissions);
+  return render(
+    <QueryClientProvider client={client}>
+      <RoleEditorSheet
+        roleId={role.id}
+        roleName={role.name}
+        open
+        onOpenChange={() => {}}
+        initialTab="metadata"
+      />
+    </QueryClientProvider>,
+  );
+}
+
+function makeRole(overrides: Partial<RoleDetail>): RoleDetail {
+  return {
+    id: "role_test",
+    name: "test",
+    displayName: "Test",
+    description: null,
+    isProtected: false,
+    isOfficer: false,
+    permissionIds: [],
+    memberCount: 0,
+    position: 0,
+    members: [],
+    ...overrides,
+  };
+}
+
+describe("RoleEditorSheet — Details tab", () => {
+  it("disables Display name + Officer + Description + Save for system_admin", () => {
+    renderWithRole(
+      makeRole({
+        id: "role_system_admin",
+        name: "system_admin",
+        displayName: "System Admin",
+        description: "System administrator with full platform control.",
+        isProtected: true,
+      }),
+    );
+
+    expect(screen.getByLabelText(/^display name$/i)).toBeDisabled();
+    expect(screen.getByLabelText(/^description$/i)).toBeDisabled();
+    expect(screen.getByLabelText(/officer position/i)).toBeDisabled();
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled();
+    // Identifier readout remains the slug.
+    expect(screen.getByLabelText(/^identifier$/i)).toHaveValue("system_admin");
+  });
+
+  it("hides the Officer checkbox for the anonymous role", () => {
+    renderWithRole(
+      makeRole({
+        id: "role_anonymous",
+        name: "anonymous",
+        displayName: "Anonymous",
+        isProtected: true,
+      }),
+    );
+
+    expect(screen.queryByLabelText(/officer position/i)).toBeNull();
+    // Display name remains editable so admins can polish the label.
+    expect(screen.getByLabelText(/^display name$/i)).toBeEnabled();
+  });
+
+  it("enables all controls for a regular non-protected role", () => {
+    renderWithRole(
+      makeRole({
+        id: "role_trip_leader",
+        name: "trip_leader",
+        displayName: "Trip Leader",
+        description: "Leads trips.",
+      }),
+    );
+
+    expect(screen.getByLabelText(/^display name$/i)).toBeEnabled();
+    expect(screen.getByLabelText(/^description$/i)).toBeEnabled();
+    expect(screen.getByLabelText(/officer position/i)).toBeEnabled();
+  });
+});

--- a/apps/web/src/features/members/components/role-editor-sheet.tsx
+++ b/apps/web/src/features/members/components/role-editor-sheet.tsx
@@ -122,9 +122,13 @@ export function RoleEditorSheet({
   const [baselineDisplayName, setBaselineDisplayName] = useState("");
   const [isOfficer, setIsOfficer] = useState(false);
   const [baselineIsOfficer, setBaselineIsOfficer] = useState(false);
+  // Compare trim-symmetric on both sides so a trailing space alone
+  // doesn't flip dirty — the server trims on persist, so a baseline
+  // never carries whitespace and a typed trailing space shouldn't ride
+  // a saved-clean state back into dirty after save.
   const metadataDirty =
     initialized &&
-    (description !== baselineDescription ||
+    (description.trim() !== baselineDescription ||
       displayName.trim() !== baselineDisplayName ||
       isOfficer !== baselineIsOfficer);
   const updateRole = useUpdateRole();
@@ -227,7 +231,7 @@ export function RoleEditorSheet({
           const latest = latestRef.current;
           const stillDirty =
             latest.initialized &&
-            (latest.description !== latest.baselineDescription ||
+            (latest.description.trim() !== latest.baselineDescription ||
               latest.displayName.trim() !== latest.baselineDisplayName ||
               latest.isOfficer !== latest.baselineIsOfficer);
           if (!stillDirty) onOpenChange(false);
@@ -436,12 +440,12 @@ export function RoleEditorSheet({
                 value={displayName}
                 onChange={(e) => setDisplayName(e.target.value)}
                 maxLength={80}
-                disabled={!initialized}
+                disabled={isAdmin || !initialized}
               />
               <p className="text-xs text-muted-foreground">
-                Shown wherever this role is presented to members, and on the
-                public home page when the role is flagged as an officer
-                position.
+                {isAdmin
+                  ? "The system_admin role’s label is fixed."
+                  : "Shown wherever this role is presented to members, and on the public home page when the role is flagged as an officer position."}
               </p>
             </div>
             <div className="space-y-2">
@@ -485,17 +489,16 @@ export function RoleEditorSheet({
                 <Checkbox
                   id="role-meta-is-officer"
                   checked={isOfficer}
-                  disabled={!initialized}
-                  onCheckedChange={(checked) =>
-                    setIsOfficer(checked === true)
-                  }
+                  disabled={isAdmin || !initialized}
+                  onCheckedChange={(checked) => setIsOfficer(checked === true)}
                   className="mt-0.5"
                 />
                 <div>
                   <span className="text-sm font-medium">Officer position</span>
                   <p className="text-xs text-muted-foreground">
-                    Show members holding this role on the public &ldquo;Meet
-                    the officers&rdquo; section of the home page.
+                    {isAdmin
+                      ? "system_admin cannot be flagged as an officer position."
+                      : "Show members holding this role on the public “Meet the officers” section of the home page."}
                   </p>
                 </div>
               </label>

--- a/apps/web/src/features/members/components/role-editor-sheet.tsx
+++ b/apps/web/src/features/members/components/role-editor-sheet.tsx
@@ -118,7 +118,15 @@ export function RoleEditorSheet({
 
   // ── metadata tab state ────────────────────────────────────────────────
   const [description, setDescription] = useState("");
-  const metadataDirty = initialized && description !== baselineDescription;
+  const [displayName, setDisplayName] = useState("");
+  const [baselineDisplayName, setBaselineDisplayName] = useState("");
+  const [isOfficer, setIsOfficer] = useState(false);
+  const [baselineIsOfficer, setBaselineIsOfficer] = useState(false);
+  const metadataDirty =
+    initialized &&
+    (description !== baselineDescription ||
+      displayName.trim() !== baselineDisplayName ||
+      isOfficer !== baselineIsOfficer);
   const updateRole = useUpdateRole();
 
   // Initialize local edit state and baselines once per open session.
@@ -138,6 +146,10 @@ export function RoleEditorSheet({
     setPendingGrants(grants);
     setBaselineDescription(role.description ?? "");
     setDescription(role.description ?? "");
+    setBaselineDisplayName(role.displayName);
+    setDisplayName(role.displayName);
+    setBaselineIsOfficer(role.isOfficer);
+    setIsOfficer(role.isOfficer);
     setTab(initialTab);
     setInitialized(true);
   }, [open, role, initialTab, initialized]);
@@ -152,23 +164,35 @@ export function RoleEditorSheet({
   const latestRef = useRef({
     pendingGrants,
     description,
+    displayName,
+    isOfficer,
     baselineGrants,
     baselineDescription,
+    baselineDisplayName,
+    baselineIsOfficer,
     initialized,
   });
   useEffect(() => {
     latestRef.current = {
       pendingGrants,
       description,
+      displayName,
+      isOfficer,
       baselineGrants,
       baselineDescription,
+      baselineDisplayName,
+      baselineIsOfficer,
       initialized,
     };
   }, [
     pendingGrants,
     description,
+    displayName,
+    isOfficer,
     baselineGrants,
     baselineDescription,
+    baselineDisplayName,
+    baselineIsOfficer,
     initialized,
   ]);
 
@@ -203,7 +227,9 @@ export function RoleEditorSheet({
           const latest = latestRef.current;
           const stillDirty =
             latest.initialized &&
-            latest.description !== latest.baselineDescription;
+            (latest.description !== latest.baselineDescription ||
+              latest.displayName.trim() !== latest.baselineDisplayName ||
+              latest.isOfficer !== latest.baselineIsOfficer);
           if (!stillDirty) onOpenChange(false);
         },
       },
@@ -211,13 +237,25 @@ export function RoleEditorSheet({
   }
 
   function handleSaveMetadata() {
-    const trimmed = description.trim();
+    const trimmedDescription = description.trim();
+    const trimmedDisplayName = displayName.trim();
+    if (trimmedDisplayName.length === 0) {
+      return;
+    }
     updateRole.mutate(
-      { roleId, description: trimmed || null },
+      {
+        roleId,
+        description: trimmedDescription || null,
+        displayName: trimmedDisplayName,
+        isOfficer,
+      },
       {
         onSuccess: () => {
-          setBaselineDescription(trimmed);
-          setDescription(trimmed);
+          setBaselineDescription(trimmedDescription);
+          setDescription(trimmedDescription);
+          setBaselineDisplayName(trimmedDisplayName);
+          setDisplayName(trimmedDisplayName);
+          setBaselineIsOfficer(isOfficer);
           const latest = latestRef.current;
           const stillDirty =
             latest.initialized &&
@@ -241,7 +279,7 @@ export function RoleEditorSheet({
     <Sheet open={open} onOpenChange={handleOpenChange}>
       <SheetContent className="flex w-full flex-col gap-0 sm:max-w-lg">
         <SheetHeader>
-          <SheetTitle>{roleName}</SheetTitle>
+          <SheetTitle>{role?.displayName ?? roleName}</SheetTitle>
           <SheetDescription>
             {isAnonymous
               ? "Manage the permissions granted to signed-out visitors."
@@ -391,7 +429,23 @@ export function RoleEditorSheet({
             className="flex-1 space-y-4 overflow-y-auto px-4 pt-3"
           >
             <div className="space-y-2">
-              <Label htmlFor="role-meta-name">Name</Label>
+              <Label htmlFor="role-meta-display-name">Display name</Label>
+              <Input
+                id="role-meta-display-name"
+                placeholder="e.g. Trip Leader"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                maxLength={80}
+                disabled={!initialized}
+              />
+              <p className="text-xs text-muted-foreground">
+                Shown wherever this role is presented to members, and on the
+                public home page when the role is flagged as an officer
+                position.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="role-meta-name">Identifier</Label>
               <Input
                 id="role-meta-name"
                 value={roleName}
@@ -399,7 +453,7 @@ export function RoleEditorSheet({
                 className="bg-muted/40"
               />
               <p className="text-xs text-muted-foreground">
-                Role names are immutable.
+                Identifiers are immutable.
               </p>
             </div>
             <div className="space-y-2">
@@ -423,6 +477,29 @@ export function RoleEditorSheet({
                 </p>
               ) : null}
             </div>
+            {!isAnonymous ? (
+              <label
+                htmlFor="role-meta-is-officer"
+                className="flex items-start gap-3 rounded-md border px-3 py-2"
+              >
+                <Checkbox
+                  id="role-meta-is-officer"
+                  checked={isOfficer}
+                  disabled={!initialized}
+                  onCheckedChange={(checked) =>
+                    setIsOfficer(checked === true)
+                  }
+                  className="mt-0.5"
+                />
+                <div>
+                  <span className="text-sm font-medium">Officer position</span>
+                  <p className="text-xs text-muted-foreground">
+                    Show members holding this role on the public &ldquo;Meet
+                    the officers&rdquo; section of the home page.
+                  </p>
+                </div>
+              </label>
+            ) : null}
             {updateRole.isError ? (
               <p className="text-sm text-destructive">
                 {updateRole.error.message}
@@ -453,7 +530,12 @@ export function RoleEditorSheet({
             <Button
               type="button"
               onClick={handleSaveMetadata}
-              disabled={isAdmin || !metadataDirty || isPending || loadFailed}
+              disabled={
+                !metadataDirty ||
+                isPending ||
+                Boolean(loadFailed) ||
+                displayName.trim().length === 0
+              }
             >
               {updateRole.isPending ? "Saving…" : "Save"}
             </Button>

--- a/apps/web/src/features/members/components/roles-list-editor.tsx
+++ b/apps/web/src/features/members/components/roles-list-editor.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { GripVertical, Pencil, Plus, Shield, Trash2 } from "lucide-react";
+import { GripVertical, Pencil, Plus, Shield, Star, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { z } from "zod";
 
@@ -15,6 +15,7 @@ import {
 } from "#/components/ui/alert-dialog";
 import { Badge } from "#/components/ui/badge";
 import { Button } from "#/components/ui/button";
+import { Checkbox } from "#/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -131,7 +132,9 @@ export function RolesListEditor() {
       <Sortable
         value={order}
         onValueChange={setOrder}
-        getItemLabel={(id) => rolesById.get(String(id))?.name ?? String(id)}
+        getItemLabel={(id) =>
+          rolesById.get(String(id))?.displayName ?? String(id)
+        }
       >
         <SortableContent asChild>
           <ul className="divide-y rounded-md border">
@@ -150,7 +153,7 @@ export function RolesListEditor() {
                 >
                   <li className="flex items-center gap-2 bg-background px-3 py-2 data-dragging:bg-muted data-dragging:shadow-md">
                     <SortableItemHandle
-                      aria-label={`Drag ${role.name}`}
+                      aria-label={`Drag ${role.displayName}`}
                       className="flex size-7 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
                     >
                       <GripVertical className="size-4" />
@@ -160,20 +163,35 @@ export function RolesListEditor() {
 
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
-                        <span className="truncate font-medium">
-                          {role.name}
-                        </span>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="truncate font-medium">
+                              {role.displayName}
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom" className="max-w-xs">
+                            {role.description ?? "No description."}
+                          </TooltipContent>
+                        </Tooltip>
                         {role.isProtected ? (
                           <Badge variant="outline" className="text-xs">
                             protected
                           </Badge>
                         ) : null}
+                        {role.isOfficer ? (
+                          <Badge
+                            variant="secondary"
+                            className="text-xs"
+                            title="Surfaces on the public home page"
+                          >
+                            <Star className="mr-1 size-3" />
+                            officer
+                          </Badge>
+                        ) : null}
                       </div>
-                      {role.description ? (
-                        <p className="truncate text-xs text-muted-foreground">
-                          {role.description}
-                        </p>
-                      ) : null}
+                      <p className="truncate text-xs text-muted-foreground">
+                        {role.name}
+                      </p>
                     </div>
 
                     <div className="hidden shrink-0 items-center gap-4 text-xs text-muted-foreground sm:flex">
@@ -197,7 +215,7 @@ export function RolesListEditor() {
                                 roleName: role.name,
                               })
                             }
-                            aria-label={`Edit ${role.name}`}
+                            aria-label={`Edit ${role.displayName}`}
                           >
                             <Pencil className="size-4" />
                           </Button>
@@ -211,7 +229,7 @@ export function RolesListEditor() {
                               variant="ghost"
                               size="icon"
                               onClick={() => setDeleteTarget(role)}
-                              aria-label={`Delete ${role.name}`}
+                              aria-label={`Delete ${role.displayName}`}
                             >
                               <Trash2 className="size-4" />
                             </Button>
@@ -281,7 +299,7 @@ export function RolesListEditor() {
             <AlertDialogTitle>Delete role</AlertDialogTitle>
             <AlertDialogDescription>
               Are you sure you want to delete the role &ldquo;
-              {deleteTarget?.name}&rdquo;? This will remove it from all{" "}
+              {deleteTarget?.displayName}&rdquo;? This will remove it from all{" "}
               {deleteTarget?.memberCount ?? 0} member(s) who have it.
             </AlertDialogDescription>
           </AlertDialogHeader>
@@ -316,6 +334,12 @@ const roleNameSchema = z
     "Lowercase letters, digits, and underscores only; must start with a letter",
   );
 
+const displayNameSchema = z
+  .string()
+  .trim()
+  .min(1, "Required")
+  .max(80, "At most 80 characters");
+
 function CreateRoleDialog({
   open,
   onOpenChange,
@@ -324,28 +348,41 @@ function CreateRoleDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const [name, setName] = useState("");
+  const [displayName, setDisplayName] = useState("");
   const [description, setDescription] = useState("");
+  const [isOfficer, setIsOfficer] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const mutation = useCreateRole();
 
   function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    const parsed = roleNameSchema.safeParse(name);
-    if (!parsed.success) {
-      setError(parsed.error.issues[0]?.message ?? "Invalid name");
+    const parsedName = roleNameSchema.safeParse(name);
+    if (!parsedName.success) {
+      setError(parsedName.error.issues[0]?.message ?? "Invalid name");
+      return;
+    }
+    const parsedDisplay = displayNameSchema.safeParse(displayName);
+    if (!parsedDisplay.success) {
+      setError(
+        parsedDisplay.error.issues[0]?.message ?? "Invalid display name",
+      );
       return;
     }
     setError(null);
     mutation.mutate(
       {
-        name: parsed.data,
+        name: parsedName.data,
+        displayName: parsedDisplay.data,
         description: description.trim() || undefined,
+        isOfficer,
       },
       {
         onSuccess: () => {
           setName("");
+          setDisplayName("");
           setDescription("");
+          setIsOfficer(false);
           setError(null);
           onOpenChange(false);
         },
@@ -376,7 +413,20 @@ function CreateRoleDialog({
           </DialogHeader>
           <div className="mt-4 space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="role-name">Name</Label>
+              <Label htmlFor="role-display-name">Display name</Label>
+              <Input
+                id="role-display-name"
+                placeholder="e.g. Trip Leader"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                maxLength={80}
+              />
+              <p className="text-xs text-muted-foreground">
+                Shown wherever this role is presented to members.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="role-name">Identifier</Label>
               <Input
                 id="role-name"
                 placeholder="e.g. trip_leader"
@@ -400,6 +450,24 @@ function CreateRoleDialog({
                 rows={2}
               />
             </div>
+            <label
+              htmlFor="role-is-officer"
+              className="flex items-start gap-3 rounded-md border px-3 py-2"
+            >
+              <Checkbox
+                id="role-is-officer"
+                checked={isOfficer}
+                onCheckedChange={(checked) => setIsOfficer(checked === true)}
+                className="mt-0.5"
+              />
+              <div>
+                <span className="text-sm font-medium">Officer position</span>
+                <p className="text-xs text-muted-foreground">
+                  Show members holding this role on the public &ldquo;Meet the
+                  officers&rdquo; section of the home page.
+                </p>
+              </div>
+            </label>
             {error ? <p className="text-sm text-destructive">{error}</p> : null}
           </div>
           <DialogFooter className="mt-6">

--- a/apps/web/src/features/members/server/__tests__/member-actions.test.ts
+++ b/apps/web/src/features/members/server/__tests__/member-actions.test.ts
@@ -137,7 +137,11 @@ async function signInWithPermission(
   const roleId = `role_test_${permissionName.replace(":", "_")}`;
   await db
     .insert(schema.roles)
-    .values({ id: roleId, name: `test_${permissionName.replace(":", "_")}` })
+    .values({
+      id: roleId,
+      name: `test_${permissionName.replace(":", "_")}`,
+      displayName: `Test ${permissionName}`,
+    })
     .onConflictDoNothing();
   await db
     .insert(schema.rolePermissions)
@@ -973,8 +977,8 @@ describe("role list ordering matches reorderRolesAction", () => {
     await db.delete(schema.roles).where(eq(schema.roles.id, "role_zeta"));
     await db.delete(schema.roles).where(eq(schema.roles.id, "role_alpha"));
     await db.insert(schema.roles).values([
-      { id: "role_zeta", name: "zeta", position: 0 },
-      { id: "role_alpha", name: "alpha", position: 1 },
+      { id: "role_zeta", name: "zeta", displayName: "Zeta", position: 0 },
+      { id: "role_alpha", name: "alpha", displayName: "Alpha", position: 1 },
     ]);
 
     // Assign both new roles + system_admin to the admin user so the

--- a/apps/web/src/features/members/server/__tests__/rbac-actions.test.ts
+++ b/apps/web/src/features/members/server/__tests__/rbac-actions.test.ts
@@ -83,6 +83,7 @@ async function signInAs(userId: string): Promise<void> {
 beforeEach(async () => {
   cookieJar.clear();
   const db = getDb();
+  await db.delete(schema.auditLog);
   await db.delete(schema.userRoles);
   await db.delete(schema.rolePermissions);
   await db.delete(schema.sessions);
@@ -278,6 +279,139 @@ describe("updateRoleAction", () => {
       where: eq(schema.roles.id, roleId),
     });
     expect(role!.isOfficer).toBe(false);
+  });
+
+  it("rejects flagging system_admin as an officer", async () => {
+    await signInAsAdmin();
+    await expect(
+      updateRoleAction({ roleId: "role_system_admin", isOfficer: true }),
+    ).rejects.toThrow(/Cannot flag system_admin/);
+  });
+
+  it("rejects renaming system_admin", async () => {
+    await signInAsAdmin();
+    await expect(
+      updateRoleAction({
+        roleId: "role_system_admin",
+        displayName: "Owner",
+      }),
+    ).rejects.toThrow(/Cannot change the system_admin display name/);
+  });
+
+  it("rejects flagging anonymous as an officer", async () => {
+    await signInAsAdmin();
+    await expect(
+      updateRoleAction({ roleId: "role_anonymous", isOfficer: true }),
+    ).rejects.toThrow(/Cannot flag the anonymous role/);
+  });
+
+  it("emits a role.updated audit row capturing only the fields that changed", async () => {
+    const adminId = await signInAsAdmin();
+    const { roleId } = await createRoleAction({
+      name: "test_trip_leader",
+      displayName: "Trip Leader",
+    });
+
+    // Reset the audit log so the assertion only sees this update's row.
+    await getDb().delete(schema.auditLog);
+
+    await updateRoleAction({
+      roleId,
+      displayName: "Trip Lead",
+      isOfficer: true,
+    });
+
+    const rows = await getDb()
+      .select()
+      .from(schema.auditLog)
+      .where(eq(schema.auditLog.action, "role.updated"));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].actorUserId).toBe(adminId);
+    expect(rows[0].targetType).toBe("role");
+    expect(rows[0].targetId).toBe(roleId);
+    const meta = JSON.parse(rows[0].metadataJson ?? "{}") as {
+      name: string;
+      changed: Record<string, { from: unknown; to: unknown }>;
+    };
+    expect(meta.name).toBe("test_trip_leader");
+    expect(meta.changed).toEqual({
+      displayName: { from: "Trip Leader", to: "Trip Lead" },
+      isOfficer: { from: false, to: true },
+    });
+  });
+
+  it("DB-layer trigger blocks empty display_name writes (defense in depth)", async () => {
+    // Bypass the action's validation by going straight at the table.
+    // The migration 0040 trigger is the last line of defense if a
+    // future seed / fixture / D1 console session forgets to validate.
+    // Drizzle wraps D1 errors in a generic "Failed query" prefix, so
+    // assert on the underlying message via error.cause instead of the
+    // top-level Error.message.
+    const db = getDb();
+    let insertErr: unknown;
+    try {
+      await db.insert(schema.roles).values({
+        id: "role_empty_label",
+        name: "empty_label",
+        displayName: "",
+      });
+    } catch (e) {
+      insertErr = e;
+    }
+    expect(insertErr).toBeInstanceOf(Error);
+    expect(String((insertErr as Error).cause ?? insertErr)).toMatch(
+      /display_name must not be empty/,
+    );
+    // And the row really wasn't inserted.
+    expect(
+      await db.query.roles.findFirst({
+        where: eq(schema.roles.id, "role_empty_label"),
+      }),
+    ).toBeUndefined();
+
+    // Update path: existing row gets blanked.
+    await db.insert(schema.roles).values({
+      id: "role_has_label",
+      name: "has_label",
+      displayName: "Has Label",
+    });
+    let updateErr: unknown;
+    try {
+      await db
+        .update(schema.roles)
+        .set({ displayName: "" })
+        .where(eq(schema.roles.id, "role_has_label"));
+    } catch (e) {
+      updateErr = e;
+    }
+    expect(updateErr).toBeInstanceOf(Error);
+    expect(String((updateErr as Error).cause ?? updateErr)).toMatch(
+      /display_name must not be empty/,
+    );
+    const after = await db.query.roles.findFirst({
+      where: eq(schema.roles.id, "role_has_label"),
+    });
+    expect(after?.displayName).toBe("Has Label");
+    // Cleanup so other tests in this file don't trip on the leftover row.
+    await db.delete(schema.roles).where(eq(schema.roles.id, "role_has_label"));
+  });
+
+  it("does not emit an audit row when the patch is a no-op", async () => {
+    await signInAsAdmin();
+    const { roleId } = await createRoleAction({
+      name: "test_trip_leader",
+      displayName: "Trip Leader",
+    });
+    await getDb().delete(schema.auditLog);
+
+    // Re-asserting the same values produces no diff.
+    await updateRoleAction({ roleId, displayName: "Trip Leader" });
+
+    const rows = await getDb()
+      .select()
+      .from(schema.auditLog)
+      .where(eq(schema.auditLog.action, "role.updated"));
+    expect(rows).toHaveLength(0);
   });
 });
 

--- a/apps/web/src/features/members/server/__tests__/rbac-actions.test.ts
+++ b/apps/web/src/features/members/server/__tests__/rbac-actions.test.ts
@@ -89,7 +89,11 @@ beforeEach(async () => {
   await db.delete(schema.profiles);
   await db.delete(schema.users);
   // Remove any test-created roles (keep seeded ones).
-  for (const id of ["role_test_custom", "role_another"]) {
+  for (const id of [
+    "role_test_custom",
+    "role_another",
+    "role_test_trip_leader",
+  ]) {
     await db.delete(schema.roles).where(eq(schema.roles.id, id));
   }
   // Remove test-only permissions.
@@ -178,6 +182,7 @@ describe("createRoleAction", () => {
     await signInAsAdmin();
     const { roleId } = await createRoleAction({
       name: "test_custom",
+      displayName: "Test Custom",
       description: "A test role",
     });
     expect(roleId).toBe("role_test_custom");
@@ -187,22 +192,41 @@ describe("createRoleAction", () => {
     });
     expect(role).toBeDefined();
     expect(role!.name).toBe("test_custom");
+    expect(role!.displayName).toBe("Test Custom");
     expect(role!.description).toBe("A test role");
+    expect(role!.isOfficer).toBe(false);
+  });
+
+  it("persists isOfficer when set", async () => {
+    await signInAsAdmin();
+    const { roleId } = await createRoleAction({
+      name: "test_trip_leader",
+      displayName: "Trip Leader",
+      isOfficer: true,
+    });
+
+    const role = await getDb().query.roles.findFirst({
+      where: eq(schema.roles.id, roleId),
+    });
+    expect(role!.isOfficer).toBe(true);
   });
 
   it("rejects duplicate role names", async () => {
     await signInAsAdmin();
-    await createRoleAction({ name: "test_custom" });
-    await expect(createRoleAction({ name: "test_custom" })).rejects.toThrow(
-      'Role "test_custom" already exists',
-    );
+    await createRoleAction({ name: "test_custom", displayName: "Test Custom" });
+    await expect(
+      createRoleAction({ name: "test_custom", displayName: "Test Custom" }),
+    ).rejects.toThrow('Role "test_custom" already exists');
   });
 });
 
 describe("updateRoleAction", () => {
   it("updates description of a role", async () => {
     await signInAsAdmin();
-    const { roleId } = await createRoleAction({ name: "test_custom" });
+    const { roleId } = await createRoleAction({
+      name: "test_custom",
+      displayName: "Test Custom",
+    });
 
     await updateRoleAction({ roleId, description: "Updated desc" });
 
@@ -218,12 +242,52 @@ describe("updateRoleAction", () => {
       updateRoleAction({ roleId: "role_fake", description: "x" }),
     ).rejects.toThrow("Role not found");
   });
+
+  it("updates displayName without touching other fields", async () => {
+    await signInAsAdmin();
+    const { roleId } = await createRoleAction({
+      name: "test_trip_leader",
+      displayName: "Trip Leader",
+      description: "Leads trips",
+    });
+    await updateRoleAction({ roleId, displayName: "Trip Lead" });
+
+    const role = await getDb().query.roles.findFirst({
+      where: eq(schema.roles.id, roleId),
+    });
+    expect(role!.displayName).toBe("Trip Lead");
+    expect(role!.description).toBe("Leads trips");
+    expect(role!.isOfficer).toBe(false);
+  });
+
+  it("toggles isOfficer", async () => {
+    await signInAsAdmin();
+    const { roleId } = await createRoleAction({
+      name: "test_trip_leader",
+      displayName: "Trip Leader",
+    });
+
+    await updateRoleAction({ roleId, isOfficer: true });
+    let role = await getDb().query.roles.findFirst({
+      where: eq(schema.roles.id, roleId),
+    });
+    expect(role!.isOfficer).toBe(true);
+
+    await updateRoleAction({ roleId, isOfficer: false });
+    role = await getDb().query.roles.findFirst({
+      where: eq(schema.roles.id, roleId),
+    });
+    expect(role!.isOfficer).toBe(false);
+  });
 });
 
 describe("deleteRoleAction", () => {
   it("deletes a non-protected role", async () => {
     await signInAsAdmin();
-    const { roleId } = await createRoleAction({ name: "test_custom" });
+    const { roleId } = await createRoleAction({
+      name: "test_custom",
+      displayName: "Test Custom",
+    });
 
     await deleteRoleAction(roleId);
 
@@ -279,7 +343,10 @@ describe("listPermissionsAction", () => {
 describe("setRolePermissionsAction", () => {
   it("replaces permission grants for a role", async () => {
     await signInAsAdmin();
-    const { roleId } = await createRoleAction({ name: "test_custom" });
+    const { roleId } = await createRoleAction({
+      name: "test_custom",
+      displayName: "Test Custom",
+    });
 
     // Grant one permission.
     await setRolePermissionsAction({
@@ -321,7 +388,10 @@ describe("setRolePermissionsAction", () => {
 
   it("clears grants when given an empty array", async () => {
     await signInAsAdmin();
-    const { roleId } = await createRoleAction({ name: "test_custom" });
+    const { roleId } = await createRoleAction({
+      name: "test_custom",
+      displayName: "Test Custom",
+    });
     await setRolePermissionsAction({
       roleId,
       permissionIds: ["perm_roles_manage"],
@@ -362,7 +432,7 @@ describe("getUserRolesAction / setUserRolesAction", () => {
     expect(before.map((r) => r.name)).toEqual(["member"]);
 
     // Create a custom role and assign it.
-    await createRoleAction({ name: "test_custom" });
+    await createRoleAction({ name: "test_custom", displayName: "Test Custom" });
     await setUserRolesAction({
       userId: memberId,
       roleIds: ["role_member", "role_test_custom"],
@@ -432,8 +502,8 @@ describe("getUserRolesAction / setUserRolesAction", () => {
 describe("reorderRolesAction", () => {
   it("writes positions in the supplied order", async () => {
     await signInAsAdmin();
-    await createRoleAction({ name: "test_custom" });
-    await createRoleAction({ name: "another" });
+    await createRoleAction({ name: "test_custom", displayName: "Test Custom" });
+    await createRoleAction({ name: "another", displayName: "Another" });
 
     const before = await listRolesDetailedAction();
     const ids = before.map((r) => r.id);

--- a/apps/web/src/features/members/server/rbac-actions.server.ts
+++ b/apps/web/src/features/members/server/rbac-actions.server.ts
@@ -259,36 +259,84 @@ export async function updateRoleAction(input: {
   displayName?: string;
   isOfficer?: boolean;
 }): Promise<{ ok: true }> {
-  await requireRolesManager();
+  const principal = await requireRolesManager();
   const db = getDb();
 
   const role = await db.query.roles.findFirst({
     where: eq(schema.roles.id, input.roleId),
-    columns: { id: true },
+    columns: {
+      id: true,
+      name: true,
+      displayName: true,
+      description: true,
+      isOfficer: true,
+    },
   });
   if (!role) {
     throw new Error("Role not found");
   }
 
+  // Constitutional-role protections. system_admin's identity is system-
+  // shaped, not a public-facing label, and surfacing every system_admin
+  // on the public home page would leak the role assignment. anonymous
+  // has no users so officer-flagging it is a no-op at best and a
+  // misleading audit row at worst — reject explicitly. Other officer
+  // roles (advisor, president, treasurer) remain editable because that's
+  // exactly the surface the editor exists for.
+  if (input.roleId === SYSTEM_ADMIN_ROLE_ID) {
+    if (
+      input.displayName !== undefined &&
+      input.displayName !== role.displayName
+    ) {
+      throw new Error("Cannot change the system_admin display name");
+    }
+    if (input.isOfficer === true) {
+      throw new Error("Cannot flag system_admin as an officer position");
+    }
+  }
+  if (input.roleId === ANONYMOUS_ROLE_ID && input.isOfficer === true) {
+    throw new Error("Cannot flag the anonymous role as an officer position");
+  }
+
   const patch: Partial<typeof schema.roles.$inferInsert> = {};
-  if (input.description !== undefined) {
+  const changed: Record<string, { from: unknown; to: unknown }> = {};
+  if (
+    input.description !== undefined &&
+    input.description !== role.description
+  ) {
     patch.description = input.description;
+    changed.description = { from: role.description, to: input.description };
   }
-  if (input.displayName !== undefined) {
+  if (
+    input.displayName !== undefined &&
+    input.displayName !== role.displayName
+  ) {
     patch.displayName = input.displayName;
+    changed.displayName = { from: role.displayName, to: input.displayName };
   }
-  if (input.isOfficer !== undefined) {
+  if (input.isOfficer !== undefined && input.isOfficer !== role.isOfficer) {
     patch.isOfficer = input.isOfficer;
+    changed.isOfficer = { from: role.isOfficer, to: input.isOfficer };
   }
 
   if (Object.keys(patch).length === 0) {
     return { ok: true };
   }
 
-  await db
-    .update(schema.roles)
-    .set(patch)
-    .where(eq(schema.roles.id, input.roleId));
+  // Atomic with the audit row. `role.updated` lets us correlate
+  // public-surface flips (`isOfficer`) and visible-label edits
+  // (`displayName`) back to an actor — important now that toggling
+  // `is_officer` directly changes what unauthenticated visitors see.
+  await db.batch([
+    db.update(schema.roles).set(patch).where(eq(schema.roles.id, input.roleId)),
+    buildAuditEventStatement({
+      actorUserId: principal.userId,
+      action: "role.updated",
+      targetType: "role",
+      targetId: input.roleId,
+      metadata: { name: role.name, changed },
+    }),
+  ]);
 
   return { ok: true };
 }

--- a/apps/web/src/features/members/server/rbac-actions.server.ts
+++ b/apps/web/src/features/members/server/rbac-actions.server.ts
@@ -40,8 +40,10 @@ const MEMBER_ROLE_ID = "role_member";
 export interface RoleWithPermissions {
   id: string;
   name: string;
+  displayName: string;
   description: string | null;
   isProtected: boolean;
+  isOfficer: boolean;
   permissionIds: string[];
   memberCount: number;
   position: number;
@@ -127,8 +129,10 @@ export async function listRolesDetailedAction(): Promise<
   return roles.map((r) => ({
     id: r.id,
     name: r.name,
+    displayName: r.displayName,
     description: r.description,
     isProtected: PROTECTED_ROLE_IDS.has(r.id),
+    isOfficer: r.isOfficer,
     permissionIds: permsByRole.get(r.id) ?? [],
     memberCount: countByRole.get(r.id) ?? 0,
     position: r.position,
@@ -175,8 +179,10 @@ export async function getRoleAction(roleId: string): Promise<RoleDetail> {
   return {
     id: role.id,
     name: role.name,
+    displayName: role.displayName,
     description: role.description,
     isProtected: PROTECTED_ROLE_IDS.has(role.id),
+    isOfficer: role.isOfficer,
     permissionIds: permGrants.map((g) => g.permissionId),
     memberCount: memberRows.length,
     position: role.position,
@@ -192,7 +198,9 @@ export async function getRoleAction(roleId: string): Promise<RoleDetail> {
 
 export async function createRoleAction(input: {
   name: string;
+  displayName: string;
   description?: string;
+  isOfficer?: boolean;
 }): Promise<{ roleId: string }> {
   const principal = await requireRolesManager();
   const db = getDb();
@@ -207,6 +215,7 @@ export async function createRoleAction(input: {
     .select({ maxPos: max(schema.roles.position) })
     .from(schema.roles);
   const nextPos = (maxPos ?? -1) + 1;
+  const isOfficer = input.isOfficer ?? false;
 
   try {
     // Atomic with the audit row.
@@ -214,15 +223,21 @@ export async function createRoleAction(input: {
       db.insert(schema.roles).values({
         id: roleId,
         name: input.name,
+        displayName: input.displayName,
         description: input.description ?? null,
         position: nextPos,
+        isOfficer,
       }),
       buildAuditEventStatement({
         actorUserId: principal.userId,
         action: "role.created",
         targetType: "role",
         targetId: roleId,
-        metadata: { name: input.name },
+        metadata: {
+          name: input.name,
+          displayName: input.displayName,
+          isOfficer,
+        },
       }),
     ]);
   } catch (err) {
@@ -240,7 +255,9 @@ export async function createRoleAction(input: {
 
 export async function updateRoleAction(input: {
   roleId: string;
-  description: string | null;
+  description?: string | null;
+  displayName?: string;
+  isOfficer?: boolean;
 }): Promise<{ ok: true }> {
   await requireRolesManager();
   const db = getDb();
@@ -253,9 +270,24 @@ export async function updateRoleAction(input: {
     throw new Error("Role not found");
   }
 
+  const patch: Partial<typeof schema.roles.$inferInsert> = {};
+  if (input.description !== undefined) {
+    patch.description = input.description;
+  }
+  if (input.displayName !== undefined) {
+    patch.displayName = input.displayName;
+  }
+  if (input.isOfficer !== undefined) {
+    patch.isOfficer = input.isOfficer;
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return { ok: true };
+  }
+
   await db
     .update(schema.roles)
-    .set({ description: input.description })
+    .set(patch)
     .where(eq(schema.roles.id, input.roleId));
 
   return { ok: true };

--- a/apps/web/src/features/members/server/rbac-fns.ts
+++ b/apps/web/src/features/members/server/rbac-fns.ts
@@ -45,11 +45,19 @@ const roleNameSchema = z
     "Lowercase letters, digits, and underscores only; must start with a letter",
   );
 
+const displayNameSchema = z
+  .string()
+  .trim()
+  .min(1, "Required")
+  .max(80, "At most 80 characters");
+
 export const createRoleFn = createServerFn({ method: "POST" })
   .inputValidator(
     z.object({
       name: roleNameSchema,
+      displayName: displayNameSchema,
       description: z.string().trim().max(200).optional(),
+      isOfficer: z.boolean().optional(),
     }),
   )
   .handler(async ({ data }): Promise<{ roleId: string }> => {
@@ -62,7 +70,9 @@ export const updateRoleFn = createServerFn({ method: "POST" })
   .inputValidator(
     z.object({
       roleId: z.string().min(1),
-      description: z.string().trim().max(200).nullable(),
+      description: z.string().trim().max(200).nullable().optional(),
+      displayName: displayNameSchema.optional(),
+      isOfficer: z.boolean().optional(),
     }),
   )
   .handler(async ({ data }): Promise<{ ok: true }> => {


### PR DESCRIPTION
## Summary

- New `is_officer` flag + `display_name` text on `roles`. The landing-page "Meet the officers" section is now driven by role assignments instead of a hardcoded array. Toggle in `/members/roles` to opt a role into the public surface; `position` controls ordering.
- One card per (officer-role, member) pair: avatar → preferred name → role display name. Multiple co-officers each get their own card. Section auto-hides when nothing is configured.
- Privacy preserved by `innerJoin profiles` (unclaimed stubs never leak) + `status = approved` filter. No emails, phones, bios, or UC affiliation exposed.

## Migrations

- `0036_roles_is_officer_and_display_name.sql` — adds both columns. `display_name` is backfilled: curated values for the constitutionally-seeded roles (President, Treasurer, Advisor, Member, …), slug-sentence-case fallback for admin-created roles.
- `0037_officer_roles_seed.sql` — flags `role_president` + `role_treasurer` as officers out of the box.

## Test plan

- [x] Workers-pool tests for `listLandingOfficers` (ordering, status filter, unclaimed-stub exclusion, multi-role users, avatar nullability).
- [x] Extended RBAC tests cover `displayName` + `isOfficer` create/update behavior.
- [x] DOM test for the `Officers` component (empty hide, card grid, initials fallback).
- [x] `pnpm typecheck` + `pnpm test` + ESLint clean on touched files.
- [ ] Manual smoke: home page hides the section with no flagged officers; flag a role + assign two users → both cards render; mobile width collapses to one column; signed-out anonymous visit still renders the section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)