### PR TITLE
feat(ucmc-web): let system admins emulate any role from the user menu

### DIFF
--- a/apps/web/src/features/audit/server/__tests__/audit-actions.test.ts
+++ b/apps/web/src/features/audit/server/__tests__/audit-actions.test.ts
@@ -62,6 +62,7 @@ async function asViewer(
     hasProfile: false,
     avatarKey: null,
     roles: [],
+    isSystemAdmin: false,
     permissions,
     rolePermissionMap: {},
   });

--- a/apps/web/src/features/auth/api/use-auth.ts
+++ b/apps/web/src/features/auth/api/use-auth.ts
@@ -17,14 +17,18 @@ export function useAuth() {
   const principal = query.data?.principal ?? null;
   const anonymousPermissions = query.data?.anonymousPermissions ?? [];
 
-  // Show the emulation dropdown when the user has more than one role.
-  const isElevated = (principal?.roles.length ?? 0) > 1;
+  // Show the emulation UI when the user has multiple roles to switch
+  // between, or when they're a system admin (who can emulate any role
+  // on the site, even ones they don't personally hold).
+  const isSystemAdmin = principal?.isSystemAdmin ?? false;
+  const isElevated = isSystemAdmin || (principal?.roles.length ?? 0) > 1;
 
   // Resolve emulated permissions from the live principal data (not a
-  // stale localStorage snapshot). If the emulated role was removed from
-  // the user or doesn't exist in the map, treat it as no permissions.
+  // stale localStorage snapshot). Validate against `rolePermissionMap`
+  // rather than `roles` — for a sys admin emulating a role they don't
+  // hold, `roles.includes(emulatedRole)` would always be false.
   const activeEmulatedRole =
-    emulatedRole && principal?.roles.includes(emulatedRole)
+    emulatedRole && principal && emulatedRole in principal.rolePermissionMap
       ? emulatedRole
       : null;
 
@@ -48,6 +52,7 @@ export function useAuth() {
     },
     emulatedRole: activeEmulatedRole,
     isElevated,
+    isSystemAdmin,
     refresh: () =>
       queryClient.invalidateQueries({ queryKey: SESSION_QUERY_KEY }),
     signOut: async () => {

--- a/apps/web/src/features/auth/components/user-menu.tsx
+++ b/apps/web/src/features/auth/components/user-menu.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "#/components/ui/dropdown-menu";
+import { Label } from "#/components/ui/label";
 import {
   Select,
   SelectContent,
@@ -25,11 +26,19 @@ import {
   SelectTrigger,
   SelectValue,
 } from "#/components/ui/select";
+import { Switch } from "#/components/ui/switch";
 import { useAuth } from "#/features/auth/api/use-auth";
 import { useViewMode } from "#/features/auth/api/view-mode";
 
 export function UserMenu() {
-  const { principal, isLoading, isElevated, emulatedRole, signOut } = useAuth();
+  const {
+    principal,
+    isLoading,
+    isElevated,
+    isSystemAdmin,
+    emulatedRole,
+    signOut,
+  } = useAuth();
   const { setEmulatedRole } = useViewMode();
   const navigate = useNavigate();
 
@@ -120,34 +129,64 @@ export function UserMenu() {
             </DropdownMenuItem>
           </>
         )}
-        {/* Role emulation dropdown — only for users with multiple roles */}
+        {/* Role emulation — sys admins get a full role select (any role
+            on the site); non-admin officers get a Switch toggling to
+            member-view; single-role members get nothing. UI-only — route
+            guards still use the raw principal. */}
         {isElevated && principal.status === "approved" ? (
           <>
             <DropdownMenuSeparator />
-            <div
-              className="flex items-center gap-2 px-2 py-1.5"
-              onKeyDown={(e) => e.stopPropagation()}
-            >
-              <Eye className="size-4 shrink-0 text-muted-foreground" />
-              <Select
-                value={emulatedRole ?? "__actual__"}
-                onValueChange={(value) => {
-                  setEmulatedRole(value === "__actual__" ? null : value);
-                }}
+            {isSystemAdmin ? (
+              <div
+                className="flex items-center gap-2 px-2 py-1.5"
+                onKeyDown={(e) => e.stopPropagation()}
               >
-                <SelectTrigger className="h-7 flex-1 text-xs">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__actual__">Actual permissions</SelectItem>
-                  {principal.roles.map((role) => (
-                    <SelectItem key={role} value={role}>
-                      View as {role.replace(/_/g, " ")}
+                <Eye className="size-4 shrink-0 text-muted-foreground" />
+                <Select
+                  value={emulatedRole ?? "__actual__"}
+                  onValueChange={(value) => {
+                    setEmulatedRole(value === "__actual__" ? null : value);
+                  }}
+                >
+                  <SelectTrigger className="h-7 flex-1 text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__actual__">
+                      Actual permissions
                     </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+                    {Object.keys(principal.rolePermissionMap)
+                      .filter((role) => role !== "system_admin")
+                      .map((role) => (
+                        <SelectItem key={role} value={role}>
+                          View as {role.replace(/_/g, " ")}
+                        </SelectItem>
+                      ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            ) : (
+              <div
+                className="flex items-center gap-2 px-2 py-1.5"
+                onKeyDown={(e) => e.stopPropagation()}
+              >
+                <Eye className="size-4 shrink-0 text-muted-foreground" />
+                <Label
+                  htmlFor="view-as-member-switch"
+                  className="flex-1 text-xs font-normal"
+                >
+                  View as member
+                </Label>
+                <Switch
+                  id="view-as-member-switch"
+                  size="sm"
+                  checked={emulatedRole === "member"}
+                  onCheckedChange={(on) =>
+                    setEmulatedRole(on ? "member" : null)
+                  }
+                />
+              </div>
+            )}
           </>
         ) : null}
         <DropdownMenuSeparator />

--- a/apps/web/src/features/auth/components/user-menu.tsx
+++ b/apps/web/src/features/auth/components/user-menu.tsx
@@ -136,12 +136,8 @@ export function UserMenu() {
         {isElevated && principal.status === "approved" ? (
           <>
             <DropdownMenuSeparator />
-            {isSystemAdmin ? (
-              <div
-                className="flex items-center gap-2 px-2 py-1.5"
-                onKeyDown={(e) => e.stopPropagation()}
-              >
-                <Eye className="size-4 shrink-0 text-muted-foreground" />
+            <EmulationRow>
+              {isSystemAdmin ? (
                 <Select
                   value={emulatedRole ?? "__actual__"}
                   onValueChange={(value) => {
@@ -164,29 +160,25 @@ export function UserMenu() {
                       ))}
                   </SelectContent>
                 </Select>
-              </div>
-            ) : (
-              <div
-                className="flex items-center gap-2 px-2 py-1.5"
-                onKeyDown={(e) => e.stopPropagation()}
-              >
-                <Eye className="size-4 shrink-0 text-muted-foreground" />
-                <Label
-                  htmlFor="view-as-member-switch"
-                  className="flex-1 text-xs font-normal"
-                >
-                  View as member
-                </Label>
-                <Switch
-                  id="view-as-member-switch"
-                  size="sm"
-                  checked={emulatedRole === "member"}
-                  onCheckedChange={(on) =>
-                    setEmulatedRole(on ? "member" : null)
-                  }
-                />
-              </div>
-            )}
+              ) : (
+                <>
+                  <Label
+                    htmlFor="view-as-member-switch"
+                    className="flex-1 text-xs font-normal"
+                  >
+                    View as member
+                  </Label>
+                  <Switch
+                    id="view-as-member-switch"
+                    size="sm"
+                    checked={emulatedRole === "member"}
+                    onCheckedChange={(on) =>
+                      setEmulatedRole(on ? "member" : null)
+                    }
+                  />
+                </>
+              )}
+            </EmulationRow>
           </>
         ) : null}
         <DropdownMenuSeparator />
@@ -202,5 +194,17 @@ export function UserMenu() {
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+function EmulationRow({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="flex items-center gap-2 px-2 py-1.5"
+      onKeyDown={(e) => e.stopPropagation()}
+    >
+      <Eye className="size-4 shrink-0 text-muted-foreground" />
+      {children}
+    </div>
   );
 }

--- a/apps/web/src/features/auth/server/__tests__/email-actions.test.ts
+++ b/apps/web/src/features/auth/server/__tests__/email-actions.test.ts
@@ -451,6 +451,7 @@ describe("removeEmailAction", () => {
         hasProfile: false,
         avatarKey: null,
         roles: [],
+        isSystemAdmin: false,
         permissions: [],
         rolePermissionMap: {},
       });

--- a/apps/web/src/features/auth/server/__tests__/webauthn-fns.test.ts
+++ b/apps/web/src/features/auth/server/__tests__/webauthn-fns.test.ts
@@ -115,6 +115,7 @@ function makePrincipal(overrides: Partial<Principal> = {}): Principal {
     hasProfile: true,
     avatarKey: null,
     roles: [],
+    isSystemAdmin: false,
     permissions: [],
     rolePermissionMap: {},
     ...overrides,

--- a/apps/web/src/server/auth/principal.server.ts
+++ b/apps/web/src/server/auth/principal.server.ts
@@ -4,7 +4,7 @@
  * `users`, `profiles`, `user_roles`, and `role_permissions` once per
  * request and handed to loaders/guards/server-fns.
  */
-import { asc, desc, eq, inArray } from "drizzle-orm";
+import { asc, desc, eq, inArray, notInArray } from "drizzle-orm";
 
 import { getDb, schema } from "#/server/db";
 import { getKv } from "#/server/kv";
@@ -28,9 +28,17 @@ export interface Principal {
   hasProfile: boolean;
   avatarKey: string | null;
   roles: string[];
+  /** Whether the user holds the `system_admin` role. Surfaces in the
+   *  client so the view-mode emulator can offer roles the admin
+   *  doesn't personally hold; not used by route guards (those read
+   *  `permissions` directly). */
+  isSystemAdmin: boolean;
   permissions: string[];
   /** Per-role permission breakdown so the view-mode emulator can show
-   *  what a specific role grants without an extra fetch. */
+   *  what a specific role grants without an extra fetch. For system
+   *  admins this includes every role on the site (minus anonymous);
+   *  for everyone else it's keyed by the user's own roles. Insertion
+   *  order matches `roles.position` so iteration is stable. */
   rolePermissionMap: Record<string, string[]>;
 }
 
@@ -119,11 +127,43 @@ export async function loadPrincipal(userId: string): Promise<Principal | null> {
       columns: { name: true },
     });
     permissions = allPerms.map((p) => p.name);
-    // system_admin gets all; other roles still get their individual breakdowns.
     rolePermissionMap["system_admin"] = permissions;
-  }
 
-  if (roleIds.length > 0) {
+    // Load every other role's permission grants so the view-mode
+    // emulator can switch into any role on the site — not just the
+    // ones the admin happens to hold. Ordered by `roles.position` so
+    // the resulting object keys iterate in a stable, UI-friendly order.
+    // `leftJoin` keeps roles with zero permission rows (e.g. a freshly
+    // created officer role) in the map as `[]`. Anonymous and
+    // system_admin are excluded — the former isn't user-facing, the
+    // latter is the "actual permissions" state.
+    const allRoleGrants = await db
+      .select({
+        roleName: schema.roles.name,
+        permName: schema.permissions.name,
+      })
+      .from(schema.roles)
+      .leftJoin(
+        schema.rolePermissions,
+        eq(schema.rolePermissions.roleId, schema.roles.id),
+      )
+      .leftJoin(
+        schema.permissions,
+        eq(schema.permissions.id, schema.rolePermissions.permissionId),
+      )
+      .where(
+        notInArray(schema.roles.id, [ANONYMOUS_ROLE_ID, "role_system_admin"]),
+      )
+      .orderBy(asc(schema.roles.position), asc(schema.roles.name));
+
+    for (const row of allRoleGrants) {
+      const list = rolePermissionMap[row.roleName] ?? [];
+      if (row.permName) {
+        list.push(row.permName);
+      }
+      rolePermissionMap[row.roleName] = list;
+    }
+  } else if (roleIds.length > 0) {
     const rows = await db
       .select({
         roleId: schema.rolePermissions.roleId,
@@ -140,20 +180,17 @@ export async function loadPrincipal(userId: string): Promise<Principal | null> {
     const roleIdToName = new Map(userRoleRows.map((r) => [r.roleId, r.name]));
     for (const row of rows) {
       const roleName = roleIdToName.get(row.roleId);
-      if (roleName && roleName !== "system_admin") {
+      if (roleName) {
         const list = rolePermissionMap[roleName] ?? [];
         list.push(row.permName);
         rolePermissionMap[roleName] = list;
       }
     }
 
-    // For non-admin users, build the aggregated set from the per-role data.
-    if (!isSystemAdmin) {
-      permissions = Array.from(new Set(rows.map((r) => r.permName)));
-    }
+    permissions = Array.from(new Set(rows.map((r) => r.permName)));
   }
 
-  // Ensure every role has an entry (even if empty).
+  // Ensure every role the user holds has an entry (even if empty).
   for (const r of userRoleRows) {
     if (!(r.name in rolePermissionMap)) {
       rolePermissionMap[r.name] = [];
@@ -168,6 +205,7 @@ export async function loadPrincipal(userId: string): Promise<Principal | null> {
     hasProfile: Boolean(profile),
     avatarKey: profile?.avatarKey ?? null,
     roles: userRoleRows.map((r) => r.name),
+    isSystemAdmin,
     permissions,
     rolePermissionMap,
   };

--- a/apps/web/src/server/auth/principal.server.ts
+++ b/apps/web/src/server/auth/principal.server.ts
@@ -123,38 +123,43 @@ export async function loadPrincipal(userId: string): Promise<Principal | null> {
     // System admin always has every permission, including ones added
     // after the role was created. This is the canonical enforcement
     // point — no need to maintain role_permissions rows for system_admin.
-    const allPerms = await db.query.permissions.findMany({
-      columns: { name: true },
-    });
+    //
+    // The second query loads every other role's permission grants so
+    // the view-mode emulator can switch into any role on the site —
+    // not just the ones the admin happens to hold. Ordered by
+    // `roles.position` so the resulting object keys iterate in a
+    // stable, UI-friendly order. `leftJoin` keeps roles with zero
+    // permission rows (e.g. a freshly created officer role) in the
+    // map as `[]`. Anonymous and system_admin are excluded — the
+    // former isn't user-facing, the latter is the "actual permissions"
+    // state. Both reads are sys-admin-only and independent, so we
+    // bundle them in `db.batch` to ride a single D1 HTTP request.
+    const [allPerms, allRoleGrants] = await db.batch([
+      db.select({ name: schema.permissions.name }).from(schema.permissions),
+      db
+        .select({
+          roleName: schema.roles.name,
+          permName: schema.permissions.name,
+        })
+        .from(schema.roles)
+        .leftJoin(
+          schema.rolePermissions,
+          eq(schema.rolePermissions.roleId, schema.roles.id),
+        )
+        .leftJoin(
+          schema.permissions,
+          eq(schema.permissions.id, schema.rolePermissions.permissionId),
+        )
+        .where(
+          notInArray(schema.roles.id, [
+            ANONYMOUS_ROLE_ID,
+            SYSTEM_ADMIN_ROLE_ID,
+          ]),
+        )
+        .orderBy(asc(schema.roles.position), asc(schema.roles.name)),
+    ]);
     permissions = allPerms.map((p) => p.name);
     rolePermissionMap["system_admin"] = permissions;
-
-    // Load every other role's permission grants so the view-mode
-    // emulator can switch into any role on the site — not just the
-    // ones the admin happens to hold. Ordered by `roles.position` so
-    // the resulting object keys iterate in a stable, UI-friendly order.
-    // `leftJoin` keeps roles with zero permission rows (e.g. a freshly
-    // created officer role) in the map as `[]`. Anonymous and
-    // system_admin are excluded — the former isn't user-facing, the
-    // latter is the "actual permissions" state.
-    const allRoleGrants = await db
-      .select({
-        roleName: schema.roles.name,
-        permName: schema.permissions.name,
-      })
-      .from(schema.roles)
-      .leftJoin(
-        schema.rolePermissions,
-        eq(schema.rolePermissions.roleId, schema.roles.id),
-      )
-      .leftJoin(
-        schema.permissions,
-        eq(schema.permissions.id, schema.rolePermissions.permissionId),
-      )
-      .where(
-        notInArray(schema.roles.id, [ANONYMOUS_ROLE_ID, "role_system_admin"]),
-      )
-      .orderBy(asc(schema.roles.position), asc(schema.roles.name));
 
     for (const row of allRoleGrants) {
       const list = rolePermissionMap[row.roleName] ?? [];
@@ -211,9 +216,13 @@ export async function loadPrincipal(userId: string): Promise<Principal | null> {
   };
 }
 
-// ── anonymous permissions ──────────────────────────────────────────────
+// ── role-id constants ──────────────────────────────────────────────────
 
 const ANONYMOUS_ROLE_ID = "role_anonymous";
+const SYSTEM_ADMIN_ROLE_ID = "role_system_admin";
+
+// ── anonymous permissions ──────────────────────────────────────────────
+
 const ANONYMOUS_CACHE_KEY = "anonymous:permissions";
 const ANONYMOUS_CACHE_TTL = 300; // 5 minutes
 


### PR DESCRIPTION
## Summary

- The user-menu's "view as" emulator gated visibility on `principal.roles.length > 1`, hiding it from system admins who typically carry only `system_admin`. Sys admins now see a full role `<Select>` that can switch into any role on the site (minus `anonymous` / `system_admin` itself).
- Non-admin officers (≥2 roles, always including `member`) now get a simpler `<Switch>` toggling to "view as member" instead of a select.
- Single-role members still see nothing.
- Implementation: new `isSystemAdmin: boolean` on the server-built `Principal`; for sys admins, `rolePermissionMap` is widened to every site role ordered by `roles.position`. Both sys-admin-only reads (`allPerms` + `allRoleGrants`) ride a single `db.batch`. Emulation remains UI-only — route guards still read raw `principal.permissions`.

## Test plan

- [x] `pnpm --filter ucmc-web typecheck`
- [x] `pnpm --filter ucmc-web test` (588/588)
- [x] ESLint clean on touched files
- [ ] Sign in on dev as a single-role `system_admin` → confirm user menu shows the full role select; emulate `member` → admin affordances disappear on `/gear`, `/announcements`, `/members/management`; switch to "Actual permissions" → affordances reappear
- [ ] Sign in as a non-admin officer (`member` + `president`) → confirm Switch appears; toggle on → `members:manage` affordances hidden; toggle off → restored
- [ ] Sign in as a plain member → no emulation UI visible
- [ ] Stale `localStorage["ucmc-emulated-role"]` set to a deleted role → reloads cleanly, falls back to "Actual permissions"

🤖 Generated with [Claude Code](https://claude.com/claude-code)