### PR TITLE
fix(ucmc-web): alias colliding name columns in role-grant query

### DIFF
--- a/apps/web/src/server/auth/__tests__/principal.test.ts
+++ b/apps/web/src/server/auth/__tests__/principal.test.ts
@@ -124,6 +124,40 @@ describe("loadPrincipal", () => {
     expect(principal!.permissions).toContain("test:only");
   });
 
+  it("system_admin's rolePermissionMap is keyed by role names, not permission strings", async () => {
+    // Regression for the view-as emulator showing entries like
+    // "members:manage" / "roles:assign" instead of role names. The
+    // sys-admin branch builds rolePermissionMap from a joined SELECT
+    // where both sides project `name` (`roles.name` + `permissions.name`);
+    // without explicit SQL aliases, drizzle's `db.batch` result mapping
+    // collapses both into a single object key and the second value
+    // overwrites the first, keying the map by permission strings.
+    const userId = await seedUser("admin-keys@example.com");
+    await assignRole(userId, "role_system_admin");
+
+    const principal = await loadPrincipal(userId);
+
+    expect(principal).not.toBeNull();
+    const keys = Object.keys(principal!.rolePermissionMap);
+    expect(keys.length).toBeGreaterThan(0);
+    // Role names are lowercase identifier slugs (`member`, `president`,
+    // …); permission names follow `<feature>:<action>` and contain `:`.
+    // No key may contain `:`.
+    for (const k of keys) {
+      expect(k).not.toContain(":");
+    }
+    // The system_admin sentinel is the "actual permissions" entry the
+    // view-as Select filters out before rendering.
+    expect(keys).toContain("system_admin");
+    // And every value is an array of permission names (or empty).
+    for (const perms of Object.values(principal!.rolePermissionMap)) {
+      expect(Array.isArray(perms)).toBe(true);
+      for (const p of perms) {
+        expect(p).toMatch(/^[a-z_]+:[a-z_]+$/);
+      }
+    }
+  });
+
   it("regular user does NOT get unlinked permissions", async () => {
     const userId = await seedUser("regular@example.com");
     await assignRole(userId, "role_member");

--- a/apps/web/src/server/auth/principal.server.ts
+++ b/apps/web/src/server/auth/principal.server.ts
@@ -4,7 +4,7 @@
  * `users`, `profiles`, `user_roles`, and `role_permissions` once per
  * request and handed to loaders/guards/server-fns.
  */
-import { asc, desc, eq, inArray, notInArray } from "drizzle-orm";
+import { asc, desc, eq, inArray, notInArray, sql } from "drizzle-orm";
 
 import { getDb, schema } from "#/server/db";
 import { getKv } from "#/server/kv";
@@ -138,8 +138,19 @@ export async function loadPrincipal(userId: string): Promise<Principal | null> {
       db.select({ name: schema.permissions.name }).from(schema.permissions),
       db
         .select({
-          roleName: schema.roles.name,
-          permName: schema.permissions.name,
+          // Explicit SQL aliases so drizzle emits distinct column
+          // names in the SELECT. Without them both `roles.name` and
+          // `permissions.name` come back keyed as `"name"` in D1's
+          // batch response (drizzle's `d1ToRawMapping` reads keyed
+          // objects, not positional `.raw()` rows, in batch mode), the
+          // second column overwrites the first, and the resulting
+          // `rolePermissionMap` is keyed by permission strings
+          // instead of role names — surfacing as "members:manage"
+          // etc. in the view-as emulator dropdown.
+          roleName: sql<string>`${schema.roles.name}`.as("role_name"),
+          permName: sql<string | null>`${schema.permissions.name}`.as(
+            "perm_name",
+          ),
         })
         .from(schema.roles)
         .leftJoin(


### PR DESCRIPTION
## Summary
- The system-admin branch of `loadPrincipal` joins `roles` to `permissions` and selects `roles.name` + `permissions.name`. In D1 batch mode drizzle maps results from keyed objects, so both columns came back keyed as `"name"` — the second clobbered the first, and `rolePermissionMap` ended up keyed by permission strings (`"members:manage"`, `"roles:assign"`, …) instead of role names.
- The visible symptom was the view-as / role-emulator dropdown on the user menu listing permission strings instead of roles.
- Fix: give each projected column an explicit SQL alias (`role_name`, `perm_name`) so drizzle emits distinct keys.
- Adds a regression test that seeds a `system_admin` user, loads the principal, and asserts every `rolePermissionMap` key is a role name (no `:`) and every value is a list of permission strings.

## Test plan
- [ ] `pnpm --filter ucmc-web test` (workers pool covers the new `principal.test.ts` case)
- [ ] Manually: sign in as a system admin, open the user menu → view-as picker shows role names again