### PR TITLE
feat(ucmc-web): extended gear attributes (msrp, manufacturer, serial, condition grade)

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -4,6 +4,11 @@
       "version": "1.1.0",
       "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
       "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/node:2": {
+      "version": "2.0.0",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f",
+      "integrity": "sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f"
     }
   }
 }

--- a/apps/web/drizzle/migrations/0041_gear_extended_attributes.sql
+++ b/apps/web/drizzle/migrations/0041_gear_extended_attributes.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `gear` ADD `msrp_cents` integer;--> statement-breakpoint
+ALTER TABLE `gear` ADD `manufacturer` text;--> statement-breakpoint
+ALTER TABLE `gear` ADD `serial_number` text;--> statement-breakpoint
+ALTER TABLE `gear` ADD `condition_grade` text;

--- a/apps/web/drizzle/migrations/meta/0041_snapshot.json
+++ b/apps/web/drizzle/migrations/meta/0041_snapshot.json
@@ -1,0 +1,2413 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f568302d-bd00-4039-be92-0e3d775e510f",
+  "prevId": "b45b3c90-40f5-42ab-a27e-486c0ef49c24",
+  "tables": {
+    "announcements": {
+      "name": "announcements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "announcements_published_at_idx": {
+          "name": "announcements_published_at_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "announcements_created_by_users_id_fk": {
+          "name": "announcements_created_by_users_id_fk",
+          "tableFrom": "announcements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            "actor_user_id"
+          ],
+          "isUnique": false
+        },
+        "audit_log_target_user_idx": {
+          "name": "audit_log_target_user_idx",
+          "columns": [
+            "target_user_id"
+          ],
+          "isUnique": false
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_log_target_user_id_users_id_fk": {
+          "name": "audit_log_target_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "emergency_contacts": {
+      "name": "emergency_contacts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "emergency_contacts_user_id_users_id_fk": {
+          "name": "emergency_contacts_user_id_users_id_fk",
+          "tableFrom": "emergency_contacts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedback": {
+      "name": "feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_issue_number": {
+          "name": "github_issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "feedback_status_created_at_idx": {
+          "name": "feedback_status_created_at_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "feedback_created_by_idx": {
+          "name": "feedback_created_by_idx",
+          "columns": [
+            "created_by"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "feedback_created_by_users_id_fk": {
+          "name": "feedback_created_by_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gear": {
+      "name": "gear",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thumbnail_key": {
+          "name": "thumbnail_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "acquisition_cost_cents": {
+          "name": "acquisition_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "msrp_cents": {
+          "name": "msrp_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "condition_grade": {
+          "name": "condition_grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_markdown": {
+          "name": "notes_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lifecycle": {
+          "name": "lifecycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'serviceable'"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retired_by": {
+          "name": "retired_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retired_reason": {
+          "name": "retired_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "gear_public_id_unique": {
+          "name": "gear_public_id_unique",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "gear_code_unique": {
+          "name": "gear_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        },
+        "gear_type_idx": {
+          "name": "gear_type_idx",
+          "columns": [
+            "type_id"
+          ],
+          "isUnique": false
+        },
+        "gear_lifecycle_idx": {
+          "name": "gear_lifecycle_idx",
+          "columns": [
+            "lifecycle"
+          ],
+          "isUnique": false
+        },
+        "gear_condition_idx": {
+          "name": "gear_condition_idx",
+          "columns": [
+            "condition"
+          ],
+          "isUnique": false
+        },
+        "gear_created_at_idx": {
+          "name": "gear_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gear_type_id_gear_types_id_fk": {
+          "name": "gear_type_id_gear_types_id_fk",
+          "tableFrom": "gear",
+          "tableTo": "gear_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "gear_retired_by_users_id_fk": {
+          "name": "gear_retired_by_users_id_fk",
+          "tableFrom": "gear",
+          "tableTo": "users",
+          "columnsFrom": [
+            "retired_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gear_created_by_users_id_fk": {
+          "name": "gear_created_by_users_id_fk",
+          "tableFrom": "gear",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gear_inspections": {
+      "name": "gear_inspections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspector_user_id": {
+          "name": "inspector_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inspector_name_snapshot": {
+          "name": "inspector_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inspected_at": {
+          "name": "inspected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "gear_inspections_public_id_unique": {
+          "name": "gear_inspections_public_id_unique",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "gear_inspections_gear_idx": {
+          "name": "gear_inspections_gear_idx",
+          "columns": [
+            "gear_id"
+          ],
+          "isUnique": false
+        },
+        "gear_inspections_gear_inspected_idx": {
+          "name": "gear_inspections_gear_inspected_idx",
+          "columns": [
+            "gear_id",
+            "inspected_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gear_inspections_gear_id_gear_id_fk": {
+          "name": "gear_inspections_gear_id_gear_id_fk",
+          "tableFrom": "gear_inspections",
+          "tableTo": "gear",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gear_inspections_inspector_user_id_users_id_fk": {
+          "name": "gear_inspections_inspector_user_id_users_id_fk",
+          "tableFrom": "gear_inspections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inspector_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gear_loans": {
+      "name": "gear_loans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_user_id": {
+          "name": "member_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checked_out_by_user_id": {
+          "name": "checked_out_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked_out_at": {
+          "name": "checked_out_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "returned_to_user_id": {
+          "name": "returned_to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checkout_notes": {
+          "name": "checkout_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checkin_notes": {
+          "name": "checkin_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "condition_at_return": {
+          "name": "condition_at_return",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "gear_loans_public_id_unique": {
+          "name": "gear_loans_public_id_unique",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "gear_loans_one_active_per_gear": {
+          "name": "gear_loans_one_active_per_gear",
+          "columns": [
+            "gear_id"
+          ],
+          "isUnique": true,
+          "where": "\"gear_loans\".\"returned_at\" IS NULL"
+        },
+        "gear_loans_member_returned_idx": {
+          "name": "gear_loans_member_returned_idx",
+          "columns": [
+            "member_user_id",
+            "returned_at"
+          ],
+          "isUnique": false
+        },
+        "gear_loans_gear_idx": {
+          "name": "gear_loans_gear_idx",
+          "columns": [
+            "gear_id"
+          ],
+          "isUnique": false
+        },
+        "gear_loans_due_idx": {
+          "name": "gear_loans_due_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gear_loans_gear_id_gear_id_fk": {
+          "name": "gear_loans_gear_id_gear_id_fk",
+          "tableFrom": "gear_loans",
+          "tableTo": "gear",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "gear_loans_member_user_id_users_id_fk": {
+          "name": "gear_loans_member_user_id_users_id_fk",
+          "tableFrom": "gear_loans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "member_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "gear_loans_checked_out_by_user_id_users_id_fk": {
+          "name": "gear_loans_checked_out_by_user_id_users_id_fk",
+          "tableFrom": "gear_loans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "checked_out_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gear_loans_returned_to_user_id_users_id_fk": {
+          "name": "gear_loans_returned_to_user_id_users_id_fk",
+          "tableFrom": "gear_loans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "returned_to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gear_tag_assignments": {
+      "name": "gear_tag_assignments",
+      "columns": {
+        "gear_id": {
+          "name": "gear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "assigned_by": {
+          "name": "assigned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "gear_tag_assignments_tag_idx": {
+          "name": "gear_tag_assignments_tag_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gear_tag_assignments_gear_id_gear_id_fk": {
+          "name": "gear_tag_assignments_gear_id_gear_id_fk",
+          "tableFrom": "gear_tag_assignments",
+          "tableTo": "gear",
+          "columnsFrom": [
+            "gear_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gear_tag_assignments_tag_id_gear_tags_id_fk": {
+          "name": "gear_tag_assignments_tag_id_gear_tags_id_fk",
+          "tableFrom": "gear_tag_assignments",
+          "tableTo": "gear_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gear_tag_assignments_assigned_by_users_id_fk": {
+          "name": "gear_tag_assignments_assigned_by_users_id_fk",
+          "tableFrom": "gear_tag_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gear_tag_assignments_gear_id_tag_id_pk": {
+          "columns": [
+            "gear_id",
+            "tag_id"
+          ],
+          "name": "gear_tag_assignments_gear_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gear_tags": {
+      "name": "gear_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'public'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "gear_tags_public_id_unique": {
+          "name": "gear_tags_public_id_unique",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "gear_tags_name_unique": {
+          "name": "gear_tags_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gear_types": {
+      "name": "gear_types",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "gear_types_public_id_unique": {
+          "name": "gear_types_public_id_unique",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "gear_types_name_unique": {
+          "name": "gear_types_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "gear_types_created_by_users_id_fk": {
+          "name": "gear_types_created_by_users_id_fk",
+          "tableFrom": "gear_types",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "landing_activities": {
+      "name": "landing_activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blurb": {
+          "name": "blurb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "landing_activities_sort_idx": {
+          "name": "landing_activities_sort_idx",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "landing_faq_items": {
+      "name": "landing_faq_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "landing_faq_items_sort_idx": {
+          "name": "landing_faq_items_sort_idx",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "landing_hero_slides": {
+      "name": "landing_hero_slides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "landing_hero_slides_sort_idx": {
+          "name": "landing_hero_slides_sort_idx",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "landing_settings": {
+      "name": "landing_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "landing_settings_updated_by_users_id_fk": {
+          "name": "landing_settings_updated_by_users_id_fk",
+          "tableFrom": "landing_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_links": {
+      "name": "magic_links",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "magic_links_target_user_id_users_id_fk": {
+          "name": "magic_links_target_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey_credentials": {
+      "name": "passkey_credentials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkey_credential_id_unique": {
+          "name": "passkey_credential_id_unique",
+          "columns": [
+            "credential_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "passkey_credentials_user_id_users_id_fk": {
+          "name": "passkey_credentials_user_id_users_id_fk",
+          "tableFrom": "passkey_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "permissions": {
+      "name": "permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "permissions_name_unique": {
+          "name": "permissions_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "profiles": {
+      "name": "profiles",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preferred_name": {
+          "name": "preferred_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uc_affiliation": {
+          "name": "uc_affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_key": {
+          "name": "avatar_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policies_acknowledged_at": {
+          "name": "policies_acknowledged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policies_version": {
+          "name": "policies_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_user_id_users_id_fk": {
+          "name": "profiles_user_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "role_permissions": {
+      "name": "role_permissions",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_id_pk": {
+          "columns": [
+            "role_id",
+            "permission_id"
+          ],
+          "name": "role_permissions_role_id_permission_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "roles": {
+      "name": "roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_officer": {
+          "name": "is_officer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_settings": {
+      "name": "site_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "site_settings_updated_by_users_id_fk": {
+          "name": "site_settings_updated_by_users_id_fk",
+          "tableFrom": "site_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_emails": {
+      "name": "user_emails",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "user_emails_email_unique": {
+          "name": "user_emails_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_emails_one_primary_per_user": {
+          "name": "user_emails_one_primary_per_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true,
+          "where": "\"user_emails\".\"is_primary\" = 1"
+        },
+        "user_emails_user_id_idx": {
+          "name": "user_emails_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_emails_user_id_users_id_fk": {
+          "name": "user_emails_user_id_users_id_fk",
+          "tableFrom": "user_emails",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_roles": {
+      "name": "user_roles",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "columns": [
+            "user_id",
+            "role_id"
+          ],
+          "name": "user_roles_user_id_role_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "placeholder_name": {
+          "name": "placeholder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unclaimed_at": {
+          "name": "unclaimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_read_announcements_at": {
+          "name": "last_read_announcements_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_public_id_unique": {
+          "name": "users_public_id_unique",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "waiver_attestations": {
+      "name": "waiver_attestations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cycle": {
+          "name": "cycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attested_at": {
+          "name": "attested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "attested_by": {
+          "name": "attested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "waiver_attestations_user_cycle": {
+          "name": "waiver_attestations_user_cycle",
+          "columns": [
+            "user_id",
+            "cycle"
+          ],
+          "isUnique": false
+        },
+        "waiver_attestations_cycle_version_revoked": {
+          "name": "waiver_attestations_cycle_version_revoked",
+          "columns": [
+            "cycle",
+            "version",
+            "revoked_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "waiver_attestations_user_id_users_id_fk": {
+          "name": "waiver_attestations_user_id_users_id_fk",
+          "tableFrom": "waiver_attestations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "waiver_attestations_attested_by_users_id_fk": {
+          "name": "waiver_attestations_attested_by_users_id_fk",
+          "tableFrom": "waiver_attestations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "attested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "waiver_attestations_revoked_by_users_id_fk": {
+          "name": "waiver_attestations_revoked_by_users_id_fk",
+          "tableFrom": "waiver_attestations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/web/drizzle/migrations/meta/_journal.json
+++ b/apps/web/drizzle/migrations/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1778723653419,
       "tag": "0040_roles_display_name_non_empty",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "6",
+      "when": 1778961884496,
+      "tag": "0041_gear_extended_attributes",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/drizzle/schema.ts
+++ b/apps/web/drizzle/schema.ts
@@ -726,6 +726,19 @@ export const gearCondition = [
 ] as const;
 export type GearCondition = (typeof gearCondition)[number];
 
+/**
+ * Optional wear-level grade independent of {@link gearCondition}.
+ *
+ * `condition` is operational state ("can this be loaned out?"); the
+ * grade is a coarse subjective wear assessment carried over from
+ * legacy paper inventories. A piece can be `condition=serviceable,
+ * conditionGrade=fair` (loanable but visibly worn) or
+ * `condition=needs_repair, conditionGrade=excellent` (only just
+ * developed a defect on a near-new item).
+ */
+export const gearConditionGrade = ["excellent", "good", "fair"] as const;
+export type GearConditionGrade = (typeof gearConditionGrade)[number];
+
 export const gearTypes = sqliteTable(
   "gear_types",
   {
@@ -775,6 +788,14 @@ export const gear = sqliteTable(
     thumbnailKey: text("thumbnail_key"),
     acquiredAt: timestamp("acquired_at"),
     acquisitionCostCents: integer("acquisition_cost_cents"),
+    // Manufacturer's listed retail price at acquisition, in cents.
+    // Separate from `acquisitionCostCents` so the club can report
+    // replacement value for pieces that were donated or bought at
+    // steep discount.
+    msrpCents: integer("msrp_cents"),
+    manufacturer: text("manufacturer"),
+    serialNumber: text("serial_number"),
+    conditionGrade: text("condition_grade", { enum: gearConditionGrade }),
     notesMarkdown: text("notes_markdown"),
     lifecycle: text("lifecycle", { enum: gearLifecycle })
       .notNull()

--- a/apps/web/src/features/gear/components/gear-bulk-import-sheet.tsx
+++ b/apps/web/src/features/gear/components/gear-bulk-import-sheet.tsx
@@ -596,31 +596,6 @@ function GearImportRow({
           />
         </div>
         <div className="flex flex-col gap-1">
-          <Label className="text-xs" htmlFor={`acquired-${row.key}`}>
-            Acquired
-          </Label>
-          <Input
-            id={`acquired-${row.key}`}
-            type="date"
-            value={row.acquiredAt}
-            onChange={(e) => onChange({ acquiredAt: e.target.value })}
-          />
-        </div>
-        <div className="flex flex-col gap-1">
-          <Label className="text-xs" htmlFor={`cost-${row.key}`}>
-            Cost (USD)
-          </Label>
-          <Input
-            id={`cost-${row.key}`}
-            type="number"
-            step="0.01"
-            min="0"
-            value={row.costDollars}
-            onChange={(e) => onChange({ costDollars: e.target.value })}
-            placeholder="60.00"
-          />
-        </div>
-        <div className="flex flex-col gap-1">
           <Label className="text-xs" htmlFor={`manufacturer-${row.key}`}>
             Manufacturer
           </Label>
@@ -645,17 +620,14 @@ function GearImportRow({
           />
         </div>
         <div className="flex flex-col gap-1">
-          <Label className="text-xs" htmlFor={`msrp-${row.key}`}>
-            MSRP (USD)
+          <Label className="text-xs" htmlFor={`acquired-${row.key}`}>
+            Acquired
           </Label>
           <Input
-            id={`msrp-${row.key}`}
-            type="number"
-            step="0.01"
-            min="0"
-            value={row.msrpDollars}
-            onChange={(e) => onChange({ msrpDollars: e.target.value })}
-            placeholder="84.95"
+            id={`acquired-${row.key}`}
+            type="date"
+            value={row.acquiredAt}
+            onChange={(e) => onChange({ acquiredAt: e.target.value })}
           />
         </div>
         <div className="flex flex-col gap-1">
@@ -686,6 +658,34 @@ function GearImportRow({
               ))}
             </SelectContent>
           </Select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label className="text-xs" htmlFor={`cost-${row.key}`}>
+            Cost (USD)
+          </Label>
+          <Input
+            id={`cost-${row.key}`}
+            type="number"
+            step="0.01"
+            min="0"
+            value={row.costDollars}
+            onChange={(e) => onChange({ costDollars: e.target.value })}
+            placeholder="60.00"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label className="text-xs" htmlFor={`msrp-${row.key}`}>
+            MSRP (USD)
+          </Label>
+          <Input
+            id={`msrp-${row.key}`}
+            type="number"
+            step="0.01"
+            min="0"
+            value={row.msrpDollars}
+            onChange={(e) => onChange({ msrpDollars: e.target.value })}
+            placeholder="84.95"
+          />
         </div>
         <div className="flex flex-col gap-1 sm:col-span-2">
           <Label className="text-xs" htmlFor={`tags-${row.key}`}>

--- a/apps/web/src/features/gear/components/gear-bulk-import-sheet.tsx
+++ b/apps/web/src/features/gear/components/gear-bulk-import-sheet.tsx
@@ -549,7 +549,7 @@ function GearImportRow({
             value={row.typePublicId}
             onValueChange={(v) => onChange({ typePublicId: v })}
           >
-            <SelectTrigger id={`type-${row.key}`} className="h-9">
+            <SelectTrigger id={`type-${row.key}`} className="h-9 w-full">
               <SelectValue placeholder="Select…" />
             </SelectTrigger>
             <SelectContent>
@@ -644,7 +644,7 @@ function GearImportRow({
               })
             }
           >
-            <SelectTrigger id={`grade-${row.key}`} className="h-9">
+            <SelectTrigger id={`grade-${row.key}`} className="h-9 w-full">
               <SelectValue placeholder="—" />
             </SelectTrigger>
             <SelectContent>

--- a/apps/web/src/features/gear/components/gear-bulk-import-sheet.tsx
+++ b/apps/web/src/features/gear/components/gear-bulk-import-sheet.tsx
@@ -365,10 +365,12 @@ export function GearBulkImportSheet({
             </div>
             <p className="mt-1 text-xs text-muted-foreground">
               Columns: type (name or prefix, required), code, description,
-              acquired_at (YYYY-MM-DD), cost. Header row optional. Header-only
-              extras: manufacturer, serial_number, msrp, condition_grade
-              (excellent|good|fair), tags (comma-separated names). Tags must
-              already exist — create canonical names in the Tags dialog first.
+              acquired_at (YYYY-MM-DD), cost. Money cells are always read as
+              dollars (60 and 60.00 both = $60.00). Header row optional.
+              Header-only extras: manufacturer, serial_number, msrp,
+              condition_grade (excellent|good|fair), tags (comma-separated
+              names). Tags must already exist — create canonical names in the
+              Tags dialog first.
             </p>
             {importSummary ? (
               <div className="mt-2 text-xs">

--- a/apps/web/src/features/gear/components/gear-bulk-import-sheet.tsx
+++ b/apps/web/src/features/gear/components/gear-bulk-import-sheet.tsx
@@ -45,6 +45,7 @@ import type {
 import type {
   BulkImportResult,
   BulkImportSkipped,
+  GearConditionGrade,
   GearTypeSummary,
 } from "#/features/gear/server/gear-fns";
 
@@ -60,6 +61,15 @@ interface RowState {
   acquiredAt: string;
   /** Dollar amount as typed, e.g. "60.00". Converted to cents at submit. */
   costDollars: string;
+  // CSV-only fields. The manual row editor doesn't surface inputs for
+  // these to keep the sheet compact; they ride through silently from
+  // import → submit. Officers who want to tweak an extended field on
+  // a single piece use the singular Add/Edit sheet instead.
+  msrpCents: number | null;
+  manufacturer: string | null;
+  serialNumber: string | null;
+  conditionGrade: GearConditionGrade | null;
+  tagNames: string[];
 }
 
 function makeRow(initial: Partial<RowState> = {}): RowState {
@@ -70,6 +80,11 @@ function makeRow(initial: Partial<RowState> = {}): RowState {
     description: initial.description ?? "",
     acquiredAt: initial.acquiredAt ?? "",
     costDollars: initial.costDollars ?? "",
+    msrpCents: initial.msrpCents ?? null,
+    manufacturer: initial.manufacturer ?? null,
+    serialNumber: initial.serialNumber ?? null,
+    conditionGrade: initial.conditionGrade ?? null,
+    tagNames: initial.tagNames ?? [],
   };
 }
 
@@ -194,6 +209,11 @@ export function GearBulkImportSheet({
             r.acquisitionCostCents !== null
               ? (r.acquisitionCostCents / 100).toFixed(2)
               : "",
+          msrpCents: r.msrpCents,
+          manufacturer: r.manufacturer,
+          serialNumber: r.serialNumber,
+          conditionGrade: r.conditionGrade,
+          tagNames: r.tagNames,
         }),
       );
       const merged = [...existing, ...incoming];
@@ -257,6 +277,11 @@ export function GearBulkImportSheet({
         row.costDollars.trim().length === 0
           ? null
           : Math.round(Number(row.costDollars) * 100),
+      msrpCents: row.msrpCents,
+      manufacturer: row.manufacturer,
+      serialNumber: row.serialNumber,
+      conditionGrade: row.conditionGrade,
+      tagNames: row.tagNames,
     }));
     try {
       const result = await bulkImport.mutateAsync({ rows: payload });
@@ -340,7 +365,10 @@ export function GearBulkImportSheet({
             </div>
             <p className="mt-1 text-xs text-muted-foreground">
               Columns: type (name or prefix, required), code, description,
-              acquired_at (YYYY-MM-DD), cost. Header row optional.
+              acquired_at (YYYY-MM-DD), cost. Header row optional. Header-only
+              extras: manufacturer, serial_number, msrp, condition_grade
+              (excellent|good|fair), tags (comma-separated names). Tags must
+              already exist — create canonical names in the Tags dialog first.
             </p>
             {importSummary ? (
               <div className="mt-2 text-xs">
@@ -583,6 +611,13 @@ function skippedLabel(s: BulkImportSkipped): string {
       return `code "${s.code ?? ""}" appears twice in this import`;
     case "missing_description":
       return "description is required";
+    case "tag_not_found": {
+      const list =
+        s.missingTags && s.missingTags.length > 0
+          ? ` (${s.missingTags.join(", ")})`
+          : "";
+      return `unknown tag${list} — create it in the Tags dialog first`;
+    }
     case "invalid":
       return "invalid";
     default:

--- a/apps/web/src/features/gear/components/gear-bulk-import-sheet.tsx
+++ b/apps/web/src/features/gear/components/gear-bulk-import-sheet.tsx
@@ -42,6 +42,7 @@ import type {
   ParseGearCsvError,
   ParsedGearRow,
 } from "#/features/gear/lib/parse-gear-csv";
+import { GEAR_CONDITION_GRADE_VALUES } from "#/features/gear/server/gear-fns";
 import type {
   BulkImportResult,
   BulkImportSkipped,
@@ -50,6 +51,16 @@ import type {
 } from "#/features/gear/server/gear-fns";
 
 const MAX_ROWS = 200;
+
+// Sentinel for the condition-grade `<Select>` — same trick as the
+// singular gear form, since shadcn's Select can't take an empty value.
+const CONDITION_GRADE_NONE = "__none__";
+
+const CONDITION_GRADE_LABEL: Record<GearConditionGrade, string> = {
+  excellent: "Excellent",
+  good: "Good",
+  fair: "Fair",
+};
 
 interface RowState {
   /** Stable key so React doesn't remount inputs as the array shifts. */
@@ -61,15 +72,13 @@ interface RowState {
   acquiredAt: string;
   /** Dollar amount as typed, e.g. "60.00". Converted to cents at submit. */
   costDollars: string;
-  // CSV-only fields. The manual row editor doesn't surface inputs for
-  // these to keep the sheet compact; they ride through silently from
-  // import → submit. Officers who want to tweak an extended field on
-  // a single piece use the singular Add/Edit sheet instead.
-  msrpCents: number | null;
-  manufacturer: string | null;
-  serialNumber: string | null;
-  conditionGrade: GearConditionGrade | null;
-  tagNames: string[];
+  /** Dollar amount as typed. Converted to cents at submit. */
+  msrpDollars: string;
+  manufacturer: string;
+  serialNumber: string;
+  conditionGrade: GearConditionGrade | typeof CONDITION_GRADE_NONE;
+  /** Raw comma-separated text. Split + trimmed at submit. */
+  tagsInput: string;
 }
 
 function makeRow(initial: Partial<RowState> = {}): RowState {
@@ -80,12 +89,19 @@ function makeRow(initial: Partial<RowState> = {}): RowState {
     description: initial.description ?? "",
     acquiredAt: initial.acquiredAt ?? "",
     costDollars: initial.costDollars ?? "",
-    msrpCents: initial.msrpCents ?? null,
-    manufacturer: initial.manufacturer ?? null,
-    serialNumber: initial.serialNumber ?? null,
-    conditionGrade: initial.conditionGrade ?? null,
-    tagNames: initial.tagNames ?? [],
+    msrpDollars: initial.msrpDollars ?? "",
+    manufacturer: initial.manufacturer ?? "",
+    serialNumber: initial.serialNumber ?? "",
+    conditionGrade: initial.conditionGrade ?? CONDITION_GRADE_NONE,
+    tagsInput: initial.tagsInput ?? "",
   };
+}
+
+function splitTagsInput(input: string): string[] {
+  return input
+    .split(",")
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
 }
 
 function rowHasContent(row: RowState): boolean {
@@ -94,7 +110,12 @@ function rowHasContent(row: RowState): boolean {
     row.code.trim().length > 0 ||
     row.description.trim().length > 0 ||
     row.acquiredAt.length > 0 ||
-    row.costDollars.trim().length > 0
+    row.costDollars.trim().length > 0 ||
+    row.msrpDollars.trim().length > 0 ||
+    row.manufacturer.trim().length > 0 ||
+    row.serialNumber.trim().length > 0 ||
+    row.conditionGrade !== CONDITION_GRADE_NONE ||
+    row.tagsInput.trim().length > 0
   );
 }
 
@@ -105,6 +126,10 @@ function rowIsValid(row: RowState): boolean {
   if (row.description.trim().length === 0) return false;
   if (row.costDollars.trim().length > 0) {
     const n = Number(row.costDollars);
+    if (!Number.isFinite(n) || n < 0) return false;
+  }
+  if (row.msrpDollars.trim().length > 0) {
+    const n = Number(row.msrpDollars);
     if (!Number.isFinite(n) || n < 0) return false;
   }
   if (row.acquiredAt.length > 0) {
@@ -209,11 +234,12 @@ export function GearBulkImportSheet({
             r.acquisitionCostCents !== null
               ? (r.acquisitionCostCents / 100).toFixed(2)
               : "",
-          msrpCents: r.msrpCents,
-          manufacturer: r.manufacturer,
-          serialNumber: r.serialNumber,
-          conditionGrade: r.conditionGrade,
-          tagNames: r.tagNames,
+          msrpDollars:
+            r.msrpCents !== null ? (r.msrpCents / 100).toFixed(2) : "",
+          manufacturer: r.manufacturer ?? "",
+          serialNumber: r.serialNumber ?? "",
+          conditionGrade: r.conditionGrade ?? CONDITION_GRADE_NONE,
+          tagsInput: r.tagNames.join(", "),
         }),
       );
       const merged = [...existing, ...incoming];
@@ -277,11 +303,17 @@ export function GearBulkImportSheet({
         row.costDollars.trim().length === 0
           ? null
           : Math.round(Number(row.costDollars) * 100),
-      msrpCents: row.msrpCents,
-      manufacturer: row.manufacturer,
-      serialNumber: row.serialNumber,
-      conditionGrade: row.conditionGrade,
-      tagNames: row.tagNames,
+      msrpCents:
+        row.msrpDollars.trim().length === 0
+          ? null
+          : Math.round(Number(row.msrpDollars) * 100),
+      manufacturer:
+        row.manufacturer.trim().length === 0 ? null : row.manufacturer.trim(),
+      serialNumber:
+        row.serialNumber.trim().length === 0 ? null : row.serialNumber.trim(),
+      conditionGrade:
+        row.conditionGrade === CONDITION_GRADE_NONE ? null : row.conditionGrade,
+      tagNames: splitTagsInput(row.tagsInput),
     }));
     try {
       const result = await bulkImport.mutateAsync({ rows: payload });
@@ -587,6 +619,87 @@ function GearImportRow({
             onChange={(e) => onChange({ costDollars: e.target.value })}
             placeholder="60.00"
           />
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label className="text-xs" htmlFor={`manufacturer-${row.key}`}>
+            Manufacturer
+          </Label>
+          <Input
+            id={`manufacturer-${row.key}`}
+            value={row.manufacturer}
+            onChange={(e) => onChange({ manufacturer: e.target.value })}
+            placeholder="Petzl"
+            maxLength={100}
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label className="text-xs" htmlFor={`serial-${row.key}`}>
+            Serial number
+          </Label>
+          <Input
+            id={`serial-${row.key}`}
+            value={row.serialNumber}
+            onChange={(e) => onChange({ serialNumber: e.target.value })}
+            placeholder="ABC-12345"
+            maxLength={100}
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label className="text-xs" htmlFor={`msrp-${row.key}`}>
+            MSRP (USD)
+          </Label>
+          <Input
+            id={`msrp-${row.key}`}
+            type="number"
+            step="0.01"
+            min="0"
+            value={row.msrpDollars}
+            onChange={(e) => onChange({ msrpDollars: e.target.value })}
+            placeholder="84.95"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label className="text-xs" htmlFor={`grade-${row.key}`}>
+            Condition grade
+          </Label>
+          <Select
+            value={row.conditionGrade}
+            onValueChange={(v) =>
+              onChange({
+                conditionGrade: v as
+                  | GearConditionGrade
+                  | typeof CONDITION_GRADE_NONE,
+              })
+            }
+          >
+            <SelectTrigger id={`grade-${row.key}`} className="h-9">
+              <SelectValue placeholder="—" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={CONDITION_GRADE_NONE}>
+                <span className="text-muted-foreground">No grade</span>
+              </SelectItem>
+              {GEAR_CONDITION_GRADE_VALUES.map((g) => (
+                <SelectItem key={g} value={g}>
+                  {CONDITION_GRADE_LABEL[g]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-1 sm:col-span-2">
+          <Label className="text-xs" htmlFor={`tags-${row.key}`}>
+            Tags
+          </Label>
+          <Input
+            id={`tags-${row.key}`}
+            value={row.tagsInput}
+            onChange={(e) => onChange({ tagsInput: e.target.value })}
+            placeholder="color:red, size:m"
+          />
+          <p className="text-xs text-muted-foreground">
+            Comma-separated names. Must already exist in the Tags dialog.
+          </p>
         </div>
       </div>
       <Button

--- a/apps/web/src/features/gear/components/gear-detail-card.tsx
+++ b/apps/web/src/features/gear/components/gear-detail-card.tsx
@@ -19,6 +19,15 @@ const CONDITION_LABEL: Record<GearDetail["condition"], string> = {
   lost: "Lost",
 };
 
+const CONDITION_GRADE_LABEL: Record<
+  NonNullable<GearDetail["conditionGrade"]>,
+  string
+> = {
+  excellent: "Excellent",
+  good: "Good",
+  fair: "Fair",
+};
+
 // Mirrors the placeholder used on the list page so the detail view
 // matches visually. Swap for a real per-gear thumbnail key when that
 // feature lands.
@@ -72,6 +81,11 @@ export function GearDetailCard({
               {isRetired ? "Retired" : "Active"}
             </Badge>
             <Badge variant="outline">{CONDITION_LABEL[gear.condition]}</Badge>
+            {gear.conditionGrade ? (
+              <Badge variant="outline">
+                {CONDITION_GRADE_LABEL[gear.conditionGrade]}
+              </Badge>
+            ) : null}
           </div>
           {gear.tags.length > 0 ? (
             <div className="flex flex-wrap items-center gap-1.5 text-xs">
@@ -86,6 +100,18 @@ export function GearDetailCard({
       </CardHeader>
       <CardContent className="space-y-4 text-sm">
         <dl className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+          {gear.manufacturer ? (
+            <div>
+              <dt className="text-xs text-muted-foreground">Manufacturer</dt>
+              <dd>{gear.manufacturer}</dd>
+            </div>
+          ) : null}
+          {gear.serialNumber ? (
+            <div>
+              <dt className="text-xs text-muted-foreground">Serial</dt>
+              <dd className="font-mono text-xs">{gear.serialNumber}</dd>
+            </div>
+          ) : null}
           {gear.acquiredAt ? (
             <div>
               <dt className="text-xs text-muted-foreground">Acquired</dt>
@@ -96,6 +122,12 @@ export function GearDetailCard({
             <div>
               <dt className="text-xs text-muted-foreground">Cost</dt>
               <dd>${(gear.acquisitionCostCents / 100).toFixed(2)}</dd>
+            </div>
+          ) : null}
+          {canManage && gear.msrpCents !== null ? (
+            <div>
+              <dt className="text-xs text-muted-foreground">MSRP</dt>
+              <dd>${(gear.msrpCents / 100).toFixed(2)}</dd>
             </div>
           ) : null}
           <div>

--- a/apps/web/src/features/gear/components/gear-form-sheet.tsx
+++ b/apps/web/src/features/gear/components/gear-form-sheet.tsx
@@ -31,9 +31,13 @@ import { useCreateGear } from "#/features/gear/api/use-create-gear";
 import { useEditGear } from "#/features/gear/api/use-edit-gear";
 import { GearTagMultiselect } from "#/features/gear/components/gear-tag-multiselect";
 import { gearThumbnailUrlFor } from "#/features/gear/lib/thumbnail-url";
-import { GEAR_CONDITION_VALUES } from "#/features/gear/server/gear-fns";
+import {
+  GEAR_CONDITION_GRADE_VALUES,
+  GEAR_CONDITION_VALUES,
+} from "#/features/gear/server/gear-fns";
 import type {
   GearCondition,
+  GearConditionGrade,
   GearDetail,
   GearSummary,
 } from "#/features/gear/server/gear-fns";
@@ -63,6 +67,17 @@ const CONDITION_LABEL: Record<GearCondition, string> = {
   missing: "Missing",
   lost: "Lost",
 };
+
+const CONDITION_GRADE_LABEL: Record<GearConditionGrade, string> = {
+  excellent: "Excellent",
+  good: "Good",
+  fair: "Fair",
+};
+
+// Sentinel value for "no grade" — `<Select>` can't accept an empty
+// string as an item value, so we round-trip through a literal that
+// won't collide with any real enum member.
+const CONDITION_GRADE_NONE = "__none__";
 
 export type GearFormMode =
   | { mode: "create" }
@@ -126,6 +141,26 @@ function GearForm({
     isEdit && intent.gear.acquisitionCostCents !== null
       ? (intent.gear.acquisitionCostCents / 100).toFixed(2)
       : "",
+  );
+  const [msrpDollars, setMsrpDollars] = useState<string>(
+    isEdit && intent.gear.msrpCents !== null
+      ? (intent.gear.msrpCents / 100).toFixed(2)
+      : "",
+  );
+  const [manufacturer, setManufacturer] = useState<string>(
+    isEdit ? (intent.gear.manufacturer ?? "") : "",
+  );
+  const [serialNumber, setSerialNumber] = useState<string>(
+    isEdit && "serialNumber" in intent.gear
+      ? (intent.gear.serialNumber ?? "")
+      : "",
+  );
+  const [conditionGrade, setConditionGrade] = useState<
+    GearConditionGrade | typeof CONDITION_GRADE_NONE
+  >(
+    isEdit && intent.gear.conditionGrade !== null
+      ? intent.gear.conditionGrade
+      : CONDITION_GRADE_NONE,
   );
   const [notes, setNotes] = useState<string>(
     isEdit && "notesMarkdown" in intent.gear
@@ -236,12 +271,25 @@ function GearForm({
       setError("Cost must be a non-negative number.");
       return;
     }
+    const msrp =
+      msrpDollars.trim().length > 0
+        ? Math.round(Number(msrpDollars) * 100)
+        : null;
+    if (msrp !== null && (!Number.isFinite(msrp) || msrp < 0)) {
+      setError("MSRP must be a non-negative number.");
+      return;
+    }
     const basePayload = {
       typePublicId,
       code: code.trim().length === 0 ? null : code.trim(),
       description: trimmedDescription,
       acquiredAt: acquiredAtMs,
       acquisitionCostCents: cents,
+      msrpCents: msrp,
+      manufacturer: manufacturer.trim().length === 0 ? null : manufacturer,
+      serialNumber: serialNumber.trim().length === 0 ? null : serialNumber,
+      conditionGrade:
+        conditionGrade === CONDITION_GRADE_NONE ? null : conditionGrade,
       notesMarkdown: notes.trim().length === 0 ? null : notes,
       condition,
       tagPublicIds,
@@ -431,6 +479,28 @@ function GearForm({
         </div>
         <div className="grid grid-cols-2 gap-3">
           <div className="space-y-1.5">
+            <Label htmlFor="gear-manufacturer">Manufacturer</Label>
+            <Input
+              id="gear-manufacturer"
+              value={manufacturer}
+              onChange={(e) => setManufacturer(e.target.value)}
+              placeholder="Petzl"
+              maxLength={100}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="gear-serial">Serial number</Label>
+            <Input
+              id="gear-serial"
+              value={serialNumber}
+              onChange={(e) => setSerialNumber(e.target.value)}
+              placeholder="ABC-12345"
+              maxLength={100}
+            />
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1.5">
             <Label htmlFor="gear-acquired">Acquired</Label>
             <Input
               id="gear-acquired"
@@ -450,6 +520,52 @@ function GearForm({
               onChange={(e) => setCostDollars(e.target.value)}
               placeholder="60.00"
             />
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="gear-msrp">MSRP (USD)</Label>
+            <Input
+              id="gear-msrp"
+              type="number"
+              step="0.01"
+              min="0"
+              value={msrpDollars}
+              onChange={(e) => setMsrpDollars(e.target.value)}
+              placeholder="84.95"
+            />
+            <p className="text-xs text-muted-foreground">
+              Manufacturer's listed price — used for replacement-value
+              reporting.
+            </p>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="gear-condition-grade">Condition grade</Label>
+            <Select
+              value={conditionGrade}
+              onValueChange={(v) =>
+                setConditionGrade(
+                  v as GearConditionGrade | typeof CONDITION_GRADE_NONE,
+                )
+              }
+            >
+              <SelectTrigger id="gear-condition-grade">
+                <SelectValue placeholder="—" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={CONDITION_GRADE_NONE}>
+                  <span className="text-muted-foreground">No grade</span>
+                </SelectItem>
+                {GEAR_CONDITION_GRADE_VALUES.map((g) => (
+                  <SelectItem key={g} value={g}>
+                    {CONDITION_GRADE_LABEL[g]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              Subjective wear level — independent of repair status.
+            </p>
           </div>
         </div>
         <div className="space-y-1.5">

--- a/apps/web/src/features/gear/components/gear-form-sheet.tsx
+++ b/apps/web/src/features/gear/components/gear-form-sheet.tsx
@@ -95,7 +95,7 @@ export function GearFormSheet({
   const isEdit = intent.mode === "edit";
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="flex flex-col gap-0">
+      <SheetContent className="flex w-full flex-col gap-0 sm:max-w-xl">
         <SheetHeader>
           <SheetTitle>{isEdit ? "Edit gear" : "Add gear"}</SheetTitle>
           <SheetDescription>
@@ -549,7 +549,7 @@ function GearForm({
                 )
               }
             >
-              <SelectTrigger id="gear-condition-grade">
+              <SelectTrigger id="gear-condition-grade" className="w-full">
                 <SelectValue placeholder="—" />
               </SelectTrigger>
               <SelectContent>
@@ -574,7 +574,7 @@ function GearForm({
             value={condition}
             onValueChange={(v) => setCondition(v as GearCondition)}
           >
-            <SelectTrigger id="gear-condition">
+            <SelectTrigger id="gear-condition" className="w-full">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/apps/web/src/features/gear/components/gear-form-sheet.tsx
+++ b/apps/web/src/features/gear/components/gear-form-sheet.tsx
@@ -120,6 +120,12 @@ function GearForm({
   onClose: () => void;
 }) {
   const isEdit = intent.mode === "edit";
+  // True only when the caller handed us a GearDetail (the gear detail
+  // page does; the list page passes a GearSummary, which omits
+  // `serialNumber`). Drives whether to render the serial input — if we
+  // never received the real value we shouldn't offer to overwrite it.
+  const hasDetailFields = isEdit && "serialNumber" in intent.gear;
+  const showSerialNumber = !isEdit || hasDetailFields;
   const { data: types } = useQuery(gearTypesQueryOptions());
   const { data: tags } = useQuery(gearTagsQueryOptions());
   const createMutation = useCreateGear();
@@ -279,6 +285,15 @@ function GearForm({
       setError("MSRP must be a non-negative number.");
       return;
     }
+    const trimmedSerial =
+      serialNumber.trim().length === 0 ? null : serialNumber;
+    // `serialNumber` lives only on GearDetail. When the sheet is
+    // opened from the gear list (which passes a GearSummary), the
+    // form falls back to empty, and naively including it in the edit
+    // payload would clobber the stored value — `editGearAction`
+    // treats any present-but-different field as an intentional
+    // change. Only send it on edit when the caller gave us a
+    // detail-shaped source so it round-trips safely.
     const basePayload = {
       typePublicId,
       code: code.trim().length === 0 ? null : code.trim(),
@@ -287,7 +302,6 @@ function GearForm({
       acquisitionCostCents: cents,
       msrpCents: msrp,
       manufacturer: manufacturer.trim().length === 0 ? null : manufacturer,
-      serialNumber: serialNumber.trim().length === 0 ? null : serialNumber,
       conditionGrade:
         conditionGrade === CONDITION_GRADE_NONE ? null : conditionGrade,
       notesMarkdown: notes.trim().length === 0 ? null : notes,
@@ -296,7 +310,7 @@ function GearForm({
     };
 
     if (isEdit) {
-      // Three-way:
+      // Three-way thumbnail handling:
       //   - new image picked → send the new data URL
       //   - explicitly cleared → send null (server deletes the R2 object)
       //   - neither → omit so the existing key stays untouched
@@ -304,6 +318,9 @@ function GearForm({
         publicId: intent.gear.publicId,
         ...basePayload,
       };
+      if (hasDetailFields) {
+        editPayload.serialNumber = trimmedSerial;
+      }
       if (newThumbnailDataUrl !== null) {
         editPayload.thumbnailDataUrl = newThumbnailDataUrl;
       } else if (thumbnailCleared) {
@@ -325,6 +342,7 @@ function GearForm({
     createMutation.mutate(
       {
         ...basePayload,
+        serialNumber: trimmedSerial,
         thumbnailDataUrl: newThumbnailDataUrl,
       },
       {
@@ -477,7 +495,11 @@ function GearForm({
             Primary heading on the gear card.
           </p>
         </div>
-        <div className="grid grid-cols-2 gap-3">
+        <div
+          className={
+            showSerialNumber ? "grid grid-cols-2 gap-3" : "space-y-1.5"
+          }
+        >
           <div className="space-y-1.5">
             <Label htmlFor="gear-manufacturer">Manufacturer</Label>
             <Input
@@ -488,16 +510,18 @@ function GearForm({
               maxLength={100}
             />
           </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="gear-serial">Serial number</Label>
-            <Input
-              id="gear-serial"
-              value={serialNumber}
-              onChange={(e) => setSerialNumber(e.target.value)}
-              placeholder="ABC-12345"
-              maxLength={100}
-            />
-          </div>
+          {showSerialNumber ? (
+            <div className="space-y-1.5">
+              <Label htmlFor="gear-serial">Serial number</Label>
+              <Input
+                id="gear-serial"
+                value={serialNumber}
+                onChange={(e) => setSerialNumber(e.target.value)}
+                placeholder="ABC-12345"
+                maxLength={100}
+              />
+            </div>
+          ) : null}
         </div>
         <div className="grid grid-cols-2 gap-3">
           <div className="space-y-1.5">

--- a/apps/web/src/features/gear/components/gear-table-view.tsx
+++ b/apps/web/src/features/gear/components/gear-table-view.tsx
@@ -94,6 +94,7 @@ export function GearTableView({
             <TableHead className="w-22">Code</TableHead>
             <TableHead>Description</TableHead>
             <TableHead className="hidden sm:table-cell">Type</TableHead>
+            <TableHead className="hidden md:table-cell">Manufacturer</TableHead>
             <TableHead className="hidden sm:table-cell">Condition</TableHead>
             <TableHead className="w-12 text-right">
               <span className="sr-only">Actions</span>
@@ -151,6 +152,13 @@ export function GearTableView({
                 </TableCell>
                 <TableCell className="hidden text-sm sm:table-cell">
                   {g.type.name}
+                </TableCell>
+                <TableCell className="hidden text-sm md:table-cell">
+                  {g.manufacturer ? (
+                    g.manufacturer
+                  ) : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
                 </TableCell>
                 <TableCell className="hidden sm:table-cell">
                   <div className="flex flex-wrap items-center gap-1.5 text-xs">

--- a/apps/web/src/features/gear/lib/__tests__/parse-gear-csv.test.ts
+++ b/apps/web/src/features/gear/lib/__tests__/parse-gear-csv.test.ts
@@ -40,6 +40,34 @@ describe("parseGearCsv extended columns", () => {
     expect(errors[0].message).toMatch(/condition_grade must be/);
   });
 
+  it("reads integer cost/msrp cells as dollars (not cents)", async () => {
+    const csv = [
+      "type,description,cost,msrp",
+      "CH,Petzl Sama,60,175",
+      'CH,Black Diamond,"$1,200",250.00',
+    ].join("\n");
+    const { rows, errors } = await parseGearCsv(csv, TYPES);
+    expect(errors).toEqual([]);
+    expect(rows).toHaveLength(2);
+    // 60 → $60.00 → 6000 cents (not 60).
+    expect(rows[0].acquisitionCostCents).toBe(6000);
+    expect(rows[0].msrpCents).toBe(17500);
+    // Currency punctuation tolerated; decimal forms unchanged.
+    expect(rows[1].acquisitionCostCents).toBe(120000);
+    expect(rows[1].msrpCents).toBe(25000);
+  });
+
+  it("rejects `status` as a condition_grade alias", async () => {
+    // `status` was dropped from the header set because it's too
+    // generic — the user's legacy `Status` column gets renamed to
+    // `condition_grade` before import.
+    const csv = ["type,description,status", "CH,Petzl Sama,good"].join("\n");
+    const { rows, errors } = await parseGearCsv(csv, TYPES);
+    expect(errors).toEqual([]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].conditionGrade).toBeNull();
+  });
+
   it("leaves extended fields null when the columns are absent", async () => {
     const csv = ["type,code,description", "CH,CH1,Petzl Sama"].join("\n");
     const { rows, errors } = await parseGearCsv(csv, TYPES);

--- a/apps/web/src/features/gear/lib/__tests__/parse-gear-csv.test.ts
+++ b/apps/web/src/features/gear/lib/__tests__/parse-gear-csv.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { parseGearCsv } from "#/features/gear/lib/parse-gear-csv";
+
+const TYPES = [
+  { publicId: "type_harness", name: "Climbing Harness", prefix: "CH" },
+];
+
+describe("parseGearCsv extended columns", () => {
+  it("threads manufacturer, serial, msrp, condition_grade, tags through", async () => {
+    const csv = [
+      "type,code,description,acquired_at,cost,manufacturer,serial_number,msrp,condition_grade,tags",
+      'CH,CH1,Petzl Sama,2024-06-01,60.00,Petzl,ABC-123,84.95,good,"color:red, size:m"',
+    ].join("\n");
+    const { rows, errors } = await parseGearCsv(csv, TYPES);
+    expect(errors).toEqual([]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      typePublicId: "type_harness",
+      code: "CH1",
+      description: "Petzl Sama",
+      acquisitionCostCents: 6000,
+      msrpCents: 8495,
+      manufacturer: "Petzl",
+      serialNumber: "ABC-123",
+      conditionGrade: "good",
+      tagNames: ["color:red", "size:m"],
+    });
+  });
+
+  it("rejects an out-of-range condition_grade as a parse error", async () => {
+    const csv = [
+      "type,description,condition_grade",
+      "CH,Petzl Sama,perfect",
+    ].join("\n");
+    const { rows, errors } = await parseGearCsv(csv, TYPES);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].conditionGrade).toBeNull();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toMatch(/condition_grade must be/);
+  });
+
+  it("leaves extended fields null when the columns are absent", async () => {
+    const csv = ["type,code,description", "CH,CH1,Petzl Sama"].join("\n");
+    const { rows, errors } = await parseGearCsv(csv, TYPES);
+    expect(errors).toEqual([]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      manufacturer: null,
+      serialNumber: null,
+      msrpCents: null,
+      conditionGrade: null,
+      tagNames: [],
+    });
+  });
+});

--- a/apps/web/src/features/gear/lib/parse-gear-csv.ts
+++ b/apps/web/src/features/gear/lib/parse-gear-csv.ts
@@ -6,21 +6,32 @@
  * Supported columns (matched case-insensitively against the header row;
  * positional fallback if no header is detected):
  *
- *   - type     (required) — matches against either the type's name OR
- *                            its prefix, in that order; case-insensitive
- *   - code     (optional) — freeform short identifier; left blank for
- *                            unlabeled gear
- *   - description (required) — primary heading on the gear card
- *   - acquired_at (optional) — ISO date (YYYY-MM-DD); parsed to ms
- *   - cost_cents (optional) — integer; non-numeric values flag the row
+ *   - type           (required) — matches against either the type's name
+ *                                  OR its prefix; case-insensitive
+ *   - code           (optional) — freeform short identifier; left blank
+ *                                  for unlabeled gear
+ *   - description    (required) — primary heading on the gear card
+ *   - acquired_at    (optional) — ISO date (YYYY-MM-DD); parsed to ms
+ *   - cost / cost_cents (optional) — non-numeric values flag the row
+ *   - manufacturer   (optional) — free-text brand
+ *   - serial_number  (optional) — free-text serial
+ *   - msrp / msrp_cents (optional) — same dollars-or-cents heuristic as
+ *                                     `cost`
+ *   - condition_grade (optional) — must be excellent|good|fair if present
+ *   - tags           (optional) — comma-separated list of tag NAMES; the
+ *                                  server resolves each to an existing
+ *                                  tag (case-insensitive) and skips the
+ *                                  whole row if any tag doesn't exist
  *
  * Rows whose `type` can't be resolved against the supplied
  * `typeLookup` map are surfaced as an error in `errors`; rows whose
  * type DOES match get their `typePublicId` filled in. The server is
- * the source of truth for code uniqueness — duplicates are caught
- * there.
+ * the source of truth for code uniqueness AND tag-name resolution —
+ * both are re-checked there.
  */
 import Papa from "papaparse";
+
+import type { GearConditionGrade } from "#/features/gear/server/gear-fns";
 
 export interface ParsedGearRow {
   typePublicId: string;
@@ -28,6 +39,14 @@ export interface ParsedGearRow {
   description: string;
   acquiredAt: number | null;
   acquisitionCostCents: number | null;
+  msrpCents: number | null;
+  manufacturer: string | null;
+  serialNumber: string | null;
+  conditionGrade: GearConditionGrade | null;
+  /** Tag names as written in the CSV. The server resolves these to
+   *  IDs at import time. Empty array when the column is absent or
+   *  blank for this row. */
+  tagNames: string[];
 }
 
 export interface ParseGearCsvError {
@@ -65,8 +84,35 @@ const COST_HEADERS = new Set([
   "price",
   "amount",
 ]);
+const MSRP_HEADERS = new Set([
+  "msrp",
+  "msrp_cents",
+  "msrp cents",
+  "list_price",
+]);
+const MANUFACTURER_HEADERS = new Set(["manufacturer", "brand", "maker"]);
+const SERIAL_HEADERS = new Set([
+  "serial_number",
+  "serial number",
+  "serial",
+  "serial_no",
+]);
+const CONDITION_GRADE_HEADERS = new Set([
+  "condition_grade",
+  "condition grade",
+  "grade",
+  "wear",
+  "status",
+]);
+const TAGS_HEADERS = new Set(["tags", "tag", "labels"]);
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+const VALID_CONDITION_GRADES: readonly GearConditionGrade[] = [
+  "excellent",
+  "good",
+  "fair",
+];
 
 function normalize(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
@@ -78,6 +124,11 @@ interface ColumnMap {
   description: number;
   acquiredAt: number;
   cost: number;
+  msrp: number;
+  manufacturer: number;
+  serial: number;
+  conditionGrade: number;
+  tags: number;
   hasHeader: boolean;
 }
 
@@ -89,6 +140,11 @@ function detectColumns(firstRow: string[]): ColumnMap {
   const description = find(DESCRIPTION_HEADERS);
   const acquiredAt = find(ACQUIRED_AT_HEADERS);
   const cost = find(COST_HEADERS);
+  const msrp = find(MSRP_HEADERS);
+  const manufacturer = find(MANUFACTURER_HEADERS);
+  const serial = find(SERIAL_HEADERS);
+  const conditionGrade = find(CONDITION_GRADE_HEADERS);
+  const tags = find(TAGS_HEADERS);
   if (type !== -1) {
     return {
       type,
@@ -96,16 +152,29 @@ function detectColumns(firstRow: string[]): ColumnMap {
       description,
       acquiredAt,
       cost,
+      msrp,
+      manufacturer,
+      serial,
+      conditionGrade,
+      tags,
       hasHeader: true,
     };
   }
-  // Positional fallback: type, code, description, acquired_at, cost_cents.
+  // Positional fallback: only the original 5 columns are positional.
+  // The new fields are header-driven only — sites relying on the
+  // positional fallback shouldn't silently start picking up the wrong
+  // cells if their sheet happens to have 6+ columns.
   return {
     type: 0,
     code: 1,
     description: 2,
     acquiredAt: 3,
     cost: 4,
+    msrp: -1,
+    manufacturer: -1,
+    serial: -1,
+    conditionGrade: -1,
+    tags: -1,
     hasHeader: false,
   };
 }
@@ -158,8 +227,9 @@ function parseAcquiredAt(
   return { value: ms };
 }
 
-function parseCost(
+function parseMoney(
   cell: string,
+  label: string,
   line: number,
 ): {
   value: number | null;
@@ -174,12 +244,39 @@ function parseCost(
   // if the value has a decimal point regardless.
   const asNumber = Number(cleaned);
   if (!Number.isFinite(asNumber)) {
-    return { value: null, error: `cost is not a number (line ${line})` };
+    return { value: null, error: `${label} is not a number (line ${line})` };
   }
   if (cleaned.includes(".")) {
     return { value: Math.round(asNumber * 100) };
   }
   return { value: Math.round(asNumber) };
+}
+
+function parseConditionGrade(
+  cell: string,
+  line: number,
+): {
+  value: GearConditionGrade | null;
+  error?: string;
+} {
+  if (cell.length === 0) return { value: null };
+  const lower = cell.toLowerCase();
+  const match = VALID_CONDITION_GRADES.find((g) => g === lower);
+  if (!match) {
+    return {
+      value: null,
+      error: `condition_grade must be excellent|good|fair (line ${line})`,
+    };
+  }
+  return { value: match };
+}
+
+function parseTags(cell: string): string[] {
+  if (cell.length === 0) return [];
+  return cell
+    .split(",")
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
 }
 
 export async function parseGearCsv(
@@ -222,16 +319,32 @@ export async function parseGearCsv(
     const acquiredAtCell =
       cols.acquiredAt === -1 ? "" : normalize(row[cols.acquiredAt]);
     const costCell = cols.cost === -1 ? "" : normalize(row[cols.cost]);
+    const msrpCell = cols.msrp === -1 ? "" : normalize(row[cols.msrp]);
+    const manufacturerCell =
+      cols.manufacturer === -1 ? "" : normalize(row[cols.manufacturer]);
+    const serialCell = cols.serial === -1 ? "" : normalize(row[cols.serial]);
+    const gradeCell =
+      cols.conditionGrade === -1 ? "" : normalize(row[cols.conditionGrade]);
+    const tagsCell = cols.tags === -1 ? "" : normalize(row[cols.tags]);
     const acquired = parseAcquiredAt(acquiredAtCell, line);
     if (acquired.error) errors.push({ line, message: acquired.error });
-    const cost = parseCost(costCell, line);
+    const cost = parseMoney(costCell, "cost", line);
     if (cost.error) errors.push({ line, message: cost.error });
+    const msrp = parseMoney(msrpCell, "msrp", line);
+    if (msrp.error) errors.push({ line, message: msrp.error });
+    const grade = parseConditionGrade(gradeCell, line);
+    if (grade.error) errors.push({ line, message: grade.error });
     rows.push({
       typePublicId,
       code: code.length === 0 ? null : code,
       description,
       acquiredAt: acquired.value,
       acquisitionCostCents: cost.value,
+      msrpCents: msrp.value,
+      manufacturer: manufacturerCell.length === 0 ? null : manufacturerCell,
+      serialNumber: serialCell.length === 0 ? null : serialCell,
+      conditionGrade: grade.value,
+      tagNames: parseTags(tagsCell),
     });
   }
   return { rows, errors };

--- a/apps/web/src/features/gear/lib/parse-gear-csv.ts
+++ b/apps/web/src/features/gear/lib/parse-gear-csv.ts
@@ -12,12 +12,15 @@
  *                                  for unlabeled gear
  *   - description    (required) — primary heading on the gear card
  *   - acquired_at    (optional) — ISO date (YYYY-MM-DD); parsed to ms
- *   - cost / cost_cents (optional) — non-numeric values flag the row
+ *   - cost / price / amount (optional) — **always interpreted as
+ *                                  dollars**, integer or decimal. `60`
+ *                                  and `60.00` both become 6000 cents.
+ *                                  Non-numeric values flag the row.
  *   - manufacturer   (optional) — free-text brand
  *   - serial_number  (optional) — free-text serial
- *   - msrp / msrp_cents (optional) — same dollars-or-cents heuristic as
- *                                     `cost`
- *   - condition_grade (optional) — must be excellent|good|fair if present
+ *   - msrp / list_price (optional) — same always-dollars rule as `cost`
+ *   - condition_grade / grade / wear (optional) — must be
+ *                                  excellent|good|fair if present
  *   - tags           (optional) — comma-separated list of tag NAMES; the
  *                                  server resolves each to an existing
  *                                  tag (case-insensitive) and skips the
@@ -77,19 +80,8 @@ const ACQUIRED_AT_HEADERS = new Set([
   "purchased",
   "date",
 ]);
-const COST_HEADERS = new Set([
-  "cost",
-  "cost_cents",
-  "cost cents",
-  "price",
-  "amount",
-]);
-const MSRP_HEADERS = new Set([
-  "msrp",
-  "msrp_cents",
-  "msrp cents",
-  "list_price",
-]);
+const COST_HEADERS = new Set(["cost", "price", "amount"]);
+const MSRP_HEADERS = new Set(["msrp", "list_price"]);
 const MANUFACTURER_HEADERS = new Set(["manufacturer", "brand", "maker"]);
 const SERIAL_HEADERS = new Set([
   "serial_number",
@@ -97,12 +89,15 @@ const SERIAL_HEADERS = new Set([
   "serial",
   "serial_no",
 ]);
+// `status` is intentionally NOT an alias here — too generic, would
+// collide with lifecycle/availability columns on other sheets. The
+// legacy paper inventory's `Status` column is renamed by the officer
+// to `condition_grade` (or `grade` / `wear`) before import.
 const CONDITION_GRADE_HEADERS = new Set([
   "condition_grade",
   "condition grade",
   "grade",
   "wear",
-  "status",
 ]);
 const TAGS_HEADERS = new Set(["tags", "tag", "labels"]);
 
@@ -160,9 +155,10 @@ function detectColumns(firstRow: string[]): ColumnMap {
       hasHeader: true,
     };
   }
-  // Positional fallback: only the original 5 columns are positional.
-  // The new fields are header-driven only — sites relying on the
-  // positional fallback shouldn't silently start picking up the wrong
+  // Positional fallback: type, code, description, acquired_at, cost.
+  // Only the original 5 columns are positional — extended fields
+  // (manufacturer, msrp, etc.) are header-driven so sites that rely on
+  // the positional fallback don't silently start picking up the wrong
   // cells if their sheet happens to have 6+ columns.
   return {
     type: 0,
@@ -238,18 +234,22 @@ function parseMoney(
   if (cell.length === 0) return { value: null };
   const cleaned = cell.replace(/[$,_\s]/g, "");
   if (cleaned.length === 0) return { value: null };
-  // Accept either dollar amounts (with optional decimal) or raw cents.
-  // The header set distinguishes "cost" / "price" (dollars) from
-  // "cost_cents" / "amount" (cents). Keep it lenient — multiply by 100
-  // if the value has a decimal point regardless.
+  // Always dollars, integer or decimal. `60` and `60.00` both become
+  // 6000 cents. Officers reading from a spreadsheet think in dollars;
+  // the old "integer = cents" heuristic was a footgun. Negatives are
+  // rejected — the schema's z.number().int().min(0) would catch them
+  // server-side, but failing here gives a per-line error message.
   const asNumber = Number(cleaned);
   if (!Number.isFinite(asNumber)) {
     return { value: null, error: `${label} is not a number (line ${line})` };
   }
-  if (cleaned.includes(".")) {
-    return { value: Math.round(asNumber * 100) };
+  if (asNumber < 0) {
+    return {
+      value: null,
+      error: `${label} must be non-negative (line ${line})`,
+    };
   }
-  return { value: Math.round(asNumber) };
+  return { value: Math.round(asNumber * 100) };
 }
 
 function parseConditionGrade(

--- a/apps/web/src/features/gear/server/__tests__/gear-actions.test.ts
+++ b/apps/web/src/features/gear/server/__tests__/gear-actions.test.ts
@@ -195,6 +195,87 @@ describe("authorization", () => {
     expect(list.rows[0]?.code).toBe("CH1");
   });
 
+  it("round-trips msrp, manufacturer, serial, condition grade through create + detail", async () => {
+    await signInAsManager();
+    const typePublicId = await createTypeOk({ name: "Harness", prefix: "CH" });
+    const created = await createGearAction({
+      typePublicId,
+      code: "CH1",
+      description: "Petzl Sama",
+      thumbnailDataUrl: null,
+      acquiredAt: null,
+      acquisitionCostCents: 6000,
+      msrpCents: 7500,
+      manufacturer: " Petzl ",
+      serialNumber: " ABC-123 ",
+      conditionGrade: "good",
+      notesMarkdown: null,
+      condition: "serviceable",
+      tagPublicIds: [],
+    });
+    if (!created.ok) throw new Error("seed failed");
+
+    const detail = await getGearDetailAction({ publicId: created.publicId });
+    expect(detail.msrpCents).toBe(7500);
+    expect(detail.manufacturer).toBe("Petzl");
+    expect(detail.serialNumber).toBe("ABC-123");
+    expect(detail.conditionGrade).toBe("good");
+
+    // Manufacturer + grade are public; msrp is officer-only (same gate
+    // as acquisition cost).
+    await signInAsRegularMember();
+    const memberDetail = await getGearDetailAction({
+      publicId: created.publicId,
+    });
+    expect(memberDetail.manufacturer).toBe("Petzl");
+    expect(memberDetail.conditionGrade).toBe("good");
+    expect(memberDetail.msrpCents).toBeNull();
+  });
+
+  it("editGearAction diffs the new attributes and emits gear.updated", async () => {
+    const actorId = await signInAsManager();
+    const typePublicId = await createTypeOk({ name: "Harness", prefix: "CH" });
+    const publicId = await createGearOk({ typePublicId, code: "CH1" });
+
+    const result = await editGearAction({
+      publicId,
+      typePublicId,
+      code: "CH1",
+      description: "Test gear",
+      thumbnailDataUrl: null,
+      acquiredAt: null,
+      acquisitionCostCents: null,
+      msrpCents: 4500,
+      manufacturer: "Black Diamond",
+      serialNumber: null,
+      conditionGrade: "fair",
+      notesMarkdown: null,
+      condition: "serviceable",
+      tagPublicIds: [],
+    });
+    expect(result.ok).toBe(true);
+
+    const detail = await getGearDetailAction({ publicId });
+    expect(detail.msrpCents).toBe(4500);
+    expect(detail.manufacturer).toBe("Black Diamond");
+    expect(detail.conditionGrade).toBe("fair");
+
+    const audit = await getDb()
+      .select()
+      .from(schema.auditLog)
+      .where(eq(schema.auditLog.action, "gear.updated"));
+    expect(audit).toHaveLength(1);
+    expect(audit[0]?.actorUserId).toBe(actorId);
+    const meta = JSON.parse(audit[0]?.metadataJson ?? "{}") as {
+      changedFields: string[];
+    };
+    expect(meta.changedFields).toEqual(
+      expect.arrayContaining(["msrp_cents", "manufacturer", "condition_grade"]),
+    );
+    // serialNumber went from null → null: not a change.
+    expect(meta.changedFields).not.toContain("serial_number");
+  });
+
   it("strips acquisitionCostCents for non-manager readers", async () => {
     await signInAsManager();
     const typePublicId = await createTypeOk({ name: "Harness", prefix: "CH" });

--- a/apps/web/src/features/gear/server/__tests__/gear-actions.test.ts
+++ b/apps/web/src/features/gear/server/__tests__/gear-actions.test.ts
@@ -276,6 +276,56 @@ describe("authorization", () => {
     expect(meta.changedFields).not.toContain("serial_number");
   });
 
+  it("editGearAction preserves serialNumber when the field is omitted", async () => {
+    // The form sheet opened from the gear list page passes a
+    // GearSummary, which doesn't include `serialNumber`. The submit
+    // path omits `serialNumber` in that scenario; this test pins the
+    // server contract that an omitted (undefined) field is a no-op,
+    // not a clearing edit.
+    await signInAsManager();
+    const typePublicId = await createTypeOk({ name: "Harness", prefix: "CH" });
+    const created = await createGearAction({
+      typePublicId,
+      code: "CH1",
+      description: "Test gear",
+      thumbnailDataUrl: null,
+      acquiredAt: null,
+      acquisitionCostCents: null,
+      serialNumber: "ABC-123",
+      notesMarkdown: null,
+      condition: "serviceable",
+      tagPublicIds: [],
+    });
+    if (!created.ok) throw new Error("seed failed");
+
+    const result = await editGearAction({
+      publicId: created.publicId,
+      typePublicId,
+      code: "CH1",
+      description: "Renamed",
+      thumbnailDataUrl: null,
+      acquiredAt: null,
+      acquisitionCostCents: null,
+      // serialNumber intentionally omitted — simulates list-page edit.
+      notesMarkdown: null,
+      condition: "serviceable",
+      tagPublicIds: [],
+    });
+    expect(result.ok).toBe(true);
+
+    const detail = await getGearDetailAction({ publicId: created.publicId });
+    expect(detail.serialNumber).toBe("ABC-123");
+
+    const audit = await getDb()
+      .select()
+      .from(schema.auditLog)
+      .where(eq(schema.auditLog.action, "gear.updated"));
+    const meta = JSON.parse(audit[0]?.metadataJson ?? "{}") as {
+      changedFields: string[];
+    };
+    expect(meta.changedFields).not.toContain("serial_number");
+  });
+
   it("strips officer-only fields (cost, msrp, serial) for non-manager readers", async () => {
     await signInAsManager();
     const typePublicId = await createTypeOk({ name: "Harness", prefix: "CH" });

--- a/apps/web/src/features/gear/server/__tests__/gear-actions.test.ts
+++ b/apps/web/src/features/gear/server/__tests__/gear-actions.test.ts
@@ -276,10 +276,11 @@ describe("authorization", () => {
     expect(meta.changedFields).not.toContain("serial_number");
   });
 
-  it("strips acquisitionCostCents for non-manager readers", async () => {
+  it("strips officer-only fields (cost, msrp, serial) for non-manager readers", async () => {
     await signInAsManager();
     const typePublicId = await createTypeOk({ name: "Harness", prefix: "CH" });
-    // Seed gear with a non-null cost so the strip is observable.
+    // Seed gear with non-null values on every officer-gated field so
+    // the strip is observable.
     const created = await createGearAction({
       typePublicId,
       code: "CH1",
@@ -287,28 +288,43 @@ describe("authorization", () => {
       thumbnailDataUrl: null,
       acquiredAt: null,
       acquisitionCostCents: 6000,
+      msrpCents: 8495,
+      manufacturer: "Petzl",
+      serialNumber: "ABC-123",
+      conditionGrade: "good",
       notesMarkdown: null,
       condition: "serviceable",
       tagPublicIds: [],
     });
     if (!created.ok) throw new Error("seed failed");
 
-    // Manager view: cost is present.
+    // Manager view: every field is present.
     const managerList = await listGearAction({});
     expect(managerList.rows[0]?.acquisitionCostCents).toBe(6000);
+    expect(managerList.rows[0]?.msrpCents).toBe(8495);
+    expect(managerList.rows[0]?.manufacturer).toBe("Petzl");
     const managerDetail = await getGearDetailAction({
       publicId: created.publicId,
     });
     expect(managerDetail.acquisitionCostCents).toBe(6000);
+    expect(managerDetail.msrpCents).toBe(8495);
+    expect(managerDetail.serialNumber).toBe("ABC-123");
 
-    // Regular member view: cost is null.
+    // Regular member view: financial + serial are null; brand and
+    // grade remain visible (intentional — useful for browsing).
     await signInAsRegularMember();
     const memberList = await listGearAction({});
     expect(memberList.rows[0]?.acquisitionCostCents).toBeNull();
+    expect(memberList.rows[0]?.msrpCents).toBeNull();
+    expect(memberList.rows[0]?.manufacturer).toBe("Petzl");
     const memberDetail = await getGearDetailAction({
       publicId: created.publicId,
     });
     expect(memberDetail.acquisitionCostCents).toBeNull();
+    expect(memberDetail.msrpCents).toBeNull();
+    expect(memberDetail.serialNumber).toBeNull();
+    expect(memberDetail.manufacturer).toBe("Petzl");
+    expect(memberDetail.conditionGrade).toBe("good");
   });
 });
 

--- a/apps/web/src/features/gear/server/__tests__/gear-bulk-import.test.ts
+++ b/apps/web/src/features/gear/server/__tests__/gear-bulk-import.test.ts
@@ -1,3 +1,4 @@
+import { eq } from "drizzle-orm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getDb, schema } from "#/server/db";
@@ -241,6 +242,22 @@ describe("bulkImportGearAction", () => {
       "color:red",
       "size:m",
     ]);
+
+    // The per-row gear.added audit event carries the assigned tag IDs
+    // so a future audit query can find this attachment without
+    // walking gear_tag_assignments.
+    const auditRows = await getDb()
+      .select()
+      .from(schema.auditLog)
+      .where(eq(schema.auditLog.action, "gear.added"));
+    expect(auditRows).toHaveLength(1);
+    const meta = JSON.parse(auditRows[0]?.metadataJson ?? "{}") as {
+      source?: string;
+      tagIds?: string[];
+    };
+    expect(meta.source).toBe("bulk_import");
+    expect(meta.tagIds).toBeDefined();
+    expect(meta.tagIds).toHaveLength(2);
   });
 
   it("skips rows whose tags don't exist", async () => {

--- a/apps/web/src/features/gear/server/__tests__/gear-bulk-import.test.ts
+++ b/apps/web/src/features/gear/server/__tests__/gear-bulk-import.test.ts
@@ -24,8 +24,10 @@ const { bulkImportGearAction } =
   await import("#/features/gear/server/gear-bulk-import-actions.server");
 const { createGearTypeAction } =
   await import("#/features/gear/server/gear-types-actions.server");
-const { createGearAction } =
+const { createGearAction, getGearDetailAction } =
   await import("#/features/gear/server/gear-actions.server");
+const { createGearTagAction } =
+  await import("#/features/gear/server/gear-tags-actions.server");
 const { openSession } = await import("#/server/auth/session.server");
 
 async function seedManager(): Promise<string> {
@@ -188,6 +190,103 @@ describe("bulkImportGearAction", () => {
     expect(result.skipped).toEqual([
       { rowIndex: 0, reason: "code_in_use", code: "CH1" },
     ]);
+  });
+
+  it("writes extended attributes through and assigns named tags", async () => {
+    await seedManager();
+    const t = await createGearTypeAction({
+      name: "Harness",
+      prefix: "CH",
+      description: "Test gear",
+    });
+    if (!t.ok) throw new Error("type setup failed");
+    const tagRed = await createGearTagAction({
+      name: "color:red",
+      visibility: "public",
+    });
+    const tagM = await createGearTagAction({
+      name: "size:m",
+      visibility: "public",
+    });
+    if (!tagRed.ok || !tagM.ok) throw new Error("tag setup failed");
+
+    const result = await bulkImportGearAction({
+      rows: [
+        {
+          typePublicId: t.publicId,
+          code: "CH1",
+          description: "Petzl Sama",
+          acquiredAt: null,
+          acquisitionCostCents: 0,
+          msrpCents: 8495,
+          manufacturer: "Petzl",
+          serialNumber: "ABC-123",
+          conditionGrade: "good",
+          // case-insensitive resolve + duplicate tolerated
+          tagNames: ["Color:Red", "size:m", "color:red"],
+        },
+      ],
+    });
+
+    expect(result.skipped).toEqual([]);
+    expect(result.created).toHaveLength(1);
+    const detail = await getGearDetailAction({
+      publicId: result.created[0].publicId,
+    });
+    expect(detail.msrpCents).toBe(8495);
+    expect(detail.manufacturer).toBe("Petzl");
+    expect(detail.serialNumber).toBe("ABC-123");
+    expect(detail.conditionGrade).toBe("good");
+    expect(detail.tags.map((tag) => tag.name).sort()).toEqual([
+      "color:red",
+      "size:m",
+    ]);
+  });
+
+  it("skips rows whose tags don't exist", async () => {
+    await seedManager();
+    const t = await createGearTypeAction({
+      name: "Harness",
+      prefix: "CH",
+      description: "Test gear",
+    });
+    if (!t.ok) throw new Error("type setup failed");
+    const tagRed = await createGearTagAction({
+      name: "color:red",
+      visibility: "public",
+    });
+    if (!tagRed.ok) throw new Error("tag setup failed");
+
+    const result = await bulkImportGearAction({
+      rows: [
+        {
+          typePublicId: t.publicId,
+          code: "CH1",
+          description: "Test gear",
+          acquiredAt: null,
+          acquisitionCostCents: null,
+          tagNames: ["color:red", "size:xl"],
+        },
+        {
+          typePublicId: t.publicId,
+          code: "CH2",
+          description: "Test gear",
+          acquiredAt: null,
+          acquisitionCostCents: null,
+          tagNames: ["color:red"],
+        },
+      ],
+    });
+
+    expect(result.created).toHaveLength(1);
+    expect(result.created[0].code).toBe("CH2");
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]).toMatchObject({
+      rowIndex: 0,
+      reason: "tag_not_found",
+      code: "CH1",
+      missingTags: ["size:xl"],
+    });
   });
 
   it("flags duplicate codes within the same import", async () => {

--- a/apps/web/src/features/gear/server/gear-actions.server.ts
+++ b/apps/web/src/features/gear/server/gear-actions.server.ts
@@ -90,6 +90,9 @@ export interface GearSummary {
 
 export interface GearDetail extends GearSummary {
   notesMarkdown: string | null;
+  /** Manufacturer's serial number. Officer-only (same gate as
+   *  `acquisitionCostCents` / `msrpCents`) — stripped for callers
+   *  without `gear:manage`. */
   serialNumber: string | null;
   /** Currently open loan, if any. The `memberFullName` field is
    *  populated ONLY for officers (gear:loan) OR for the borrower
@@ -315,7 +318,11 @@ export async function getGearDetailAction(input: {
   return {
     ...summary,
     notesMarkdown: row.notesMarkdown,
-    serialNumber: row.serialNumber,
+    // Serial rides the same officer-only gate as the financial fields.
+    // Leaking serials to all approved members hands a thief a shopping
+    // list — name/brand alone isn't enough to flip a piece, but serial
+    // + brand correlates against marketplace listings.
+    serialNumber: canSeeCost ? row.serialNumber : null,
     currentLoan,
   };
 }

--- a/apps/web/src/features/gear/server/gear-actions.server.ts
+++ b/apps/web/src/features/gear/server/gear-actions.server.ts
@@ -71,8 +71,15 @@ export interface GearSummary {
   thumbnailKey: string | null;
   lifecycle: schema.GearLifecycle;
   condition: schema.GearCondition;
+  /** Coarse wear grade (excellent/good/fair) carried over from the
+   *  legacy paper inventory. Orthogonal to `condition`. Null when no
+   *  grade has been assigned. */
+  conditionGrade: schema.GearConditionGrade | null;
   acquiredAt: Date | null;
   acquisitionCostCents: number | null;
+  /** Officer-only (same gate as `acquisitionCostCents`). */
+  msrpCents: number | null;
+  manufacturer: string | null;
   retiredAt: Date | null;
   retiredReason: string | null;
   createdAt: Date;
@@ -83,6 +90,7 @@ export interface GearSummary {
 
 export interface GearDetail extends GearSummary {
   notesMarkdown: string | null;
+  serialNumber: string | null;
   /** Currently open loan, if any. The `memberFullName` field is
    *  populated ONLY for officers (gear:loan) OR for the borrower
    *  themselves — anyone else with `gear:read` sees the borrower's
@@ -134,11 +142,14 @@ function toSummary(
     thumbnailKey: row.thumbnailKey,
     lifecycle: row.lifecycle,
     condition: row.condition,
+    conditionGrade: row.conditionGrade,
     acquiredAt: row.acquiredAt,
     // Cost is officer-only: budget detail shouldn't be readable by
     // every approved member. The UI hides the field, but stripping it
     // here keeps the JSON response honest even for a direct fetch.
     acquisitionCostCents: canSeeCost ? row.acquisitionCostCents : null,
+    msrpCents: canSeeCost ? row.msrpCents : null,
+    manufacturer: row.manufacturer,
     retiredAt: row.retiredAt,
     retiredReason: row.retiredReason,
     createdAt: row.createdAt,
@@ -169,6 +180,14 @@ async function resolveTagIds(tagPublicIds: string[]): Promise<string[]> {
 function normalizeCode(code: string | null | undefined): string | null {
   if (code === null || code === undefined) return null;
   const trimmed = code.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+function normalizeOptionalText(
+  value: string | null | undefined,
+): string | null {
+  if (value === null || value === undefined) return null;
+  const trimmed = value.trim();
   return trimmed.length === 0 ? null : trimmed;
 }
 
@@ -293,7 +312,12 @@ export async function getGearDetailAction(input: {
     };
   }
 
-  return { ...summary, notesMarkdown: row.notesMarkdown, currentLoan };
+  return {
+    ...summary,
+    notesMarkdown: row.notesMarkdown,
+    serialNumber: row.serialNumber,
+    currentLoan,
+  };
 }
 
 export interface CreateGearInput {
@@ -309,6 +333,13 @@ export interface CreateGearInput {
   /** Acquisition date as ms since epoch, or null. */
   acquiredAt: number | null;
   acquisitionCostCents: number | null;
+  // Extended attributes carried over from the legacy paper inventory.
+  // Optional on the wire (omit = unknown / not supplied). The action
+  // normalizes `undefined` to `null` at the boundary.
+  msrpCents?: number | null;
+  manufacturer?: string | null;
+  serialNumber?: string | null;
+  conditionGrade?: schema.GearConditionGrade | null;
   notesMarkdown: string | null;
   condition: schema.GearCondition;
   tagPublicIds: string[];
@@ -360,6 +391,10 @@ export async function createGearAction(
       thumbnailKey,
       acquiredAt: msToDate(input.acquiredAt),
       acquisitionCostCents: input.acquisitionCostCents,
+      msrpCents: input.msrpCents,
+      manufacturer: normalizeOptionalText(input.manufacturer),
+      serialNumber: normalizeOptionalText(input.serialNumber),
+      conditionGrade: input.conditionGrade,
       notesMarkdown: input.notesMarkdown,
       condition: input.condition,
       createdBy: principal.userId,
@@ -409,6 +444,12 @@ export interface EditGearInput {
   /** Acquisition date as ms since epoch, or null. */
   acquiredAt: number | null;
   acquisitionCostCents: number | null;
+  // Same omit-means-no-change semantics as `thumbnailDataUrl`. Pass
+  // `null` to clear the field, omit to leave it unchanged.
+  msrpCents?: number | null;
+  manufacturer?: string | null;
+  serialNumber?: string | null;
+  conditionGrade?: schema.GearConditionGrade | null;
   notesMarkdown: string | null;
   condition: schema.GearCondition;
   tagPublicIds: string[];
@@ -451,6 +492,31 @@ export async function editGearAction(
   if (input.acquisitionCostCents !== existing.acquisitionCostCents) {
     patch.acquisitionCostCents = input.acquisitionCostCents;
     changedFields.push("acquisition_cost_cents");
+  }
+  if (input.msrpCents !== undefined && input.msrpCents !== existing.msrpCents) {
+    patch.msrpCents = input.msrpCents;
+    changedFields.push("msrp_cents");
+  }
+  if (input.manufacturer !== undefined) {
+    const next = normalizeOptionalText(input.manufacturer);
+    if (next !== existing.manufacturer) {
+      patch.manufacturer = next;
+      changedFields.push("manufacturer");
+    }
+  }
+  if (input.serialNumber !== undefined) {
+    const next = normalizeOptionalText(input.serialNumber);
+    if (next !== existing.serialNumber) {
+      patch.serialNumber = next;
+      changedFields.push("serial_number");
+    }
+  }
+  if (
+    input.conditionGrade !== undefined &&
+    input.conditionGrade !== existing.conditionGrade
+  ) {
+    patch.conditionGrade = input.conditionGrade;
+    changedFields.push("condition_grade");
   }
   if (input.notesMarkdown !== existing.notesMarkdown) {
     patch.notesMarkdown = input.notesMarkdown;

--- a/apps/web/src/features/gear/server/gear-bulk-import-actions.server.ts
+++ b/apps/web/src/features/gear/server/gear-bulk-import-actions.server.ts
@@ -213,6 +213,14 @@ export async function bulkImportGearAction(
       throw err;
     }
 
+    // setGearTags runs after the insert — the gear row already exists
+    // when this fires. A failure here throws out of the loop, leaving
+    // a tag-less gear row behind. That's the same partial-failure
+    // shape the per-row audit emission carries (see the file-level
+    // comment): observability and tag attachment are non-load-bearing
+    // for any RBAC / billing path, so we accept the risk rather than
+    // rolling back the insert. An officer can re-tag the orphan row
+    // via the singular Edit sheet.
     if (tagIds.length > 0) {
       await setGearTags({
         gearId: id,
@@ -221,12 +229,22 @@ export async function bulkImportGearAction(
       });
     }
 
+    // Pull the assigned tag IDs into the per-row audit metadata so a
+    // future "who attached `color:red` to this piece?" query lands on
+    // the import event without needing a join through
+    // gear_tag_assignments. Tag IDs (not names) keep the metadata
+    // stable across tag renames.
     await recordAuditEvent({
       actorUserId: principal.userId,
       action: "gear.added",
       targetType: "gear",
       targetId: id,
-      metadata: { typeId, code, source: "bulk_import" },
+      metadata: {
+        typeId,
+        code,
+        source: "bulk_import",
+        ...(tagIds.length > 0 ? { tagIds } : {}),
+      },
     });
     created.push({ rowIndex: i, publicId, code });
   }

--- a/apps/web/src/features/gear/server/gear-bulk-import-actions.server.ts
+++ b/apps/web/src/features/gear/server/gear-bulk-import-actions.server.ts
@@ -23,10 +23,13 @@ import { requireGearManager } from "#/features/gear/server/permissions.server";
 import {
   getGearTypeByPublicId,
   insertGear,
+  listGearTags,
+  setGearTags,
 } from "#/features/gear/server/repo.server";
 import { recordAuditEvent } from "#/server/audit/audit-log.server";
 import { generatePublicId } from "#/server/auth/ids";
 import { isUniqueViolation } from "#/server/db";
+import type { schema } from "#/server/db";
 
 export interface BulkImportRow {
   typePublicId: string;
@@ -37,6 +40,16 @@ export interface BulkImportRow {
   /** Acquisition date as ms since epoch, or null. */
   acquiredAt: number | null;
   acquisitionCostCents: number | null;
+  // Optional extended attributes — passthroughs from the CSV. Omit /
+  // null means "not supplied" (the column stays NULL).
+  msrpCents?: number | null;
+  manufacturer?: string | null;
+  serialNumber?: string | null;
+  conditionGrade?: schema.GearConditionGrade | null;
+  /** Tag NAMES (not publicIds). Resolved server-side against
+   *  `gear_tags.name` (case-insensitive). Any unknown name skips the
+   *  whole row with reason `tag_not_found`. */
+  tagNames?: string[];
 }
 
 export interface BulkImportInput {
@@ -56,8 +69,12 @@ export interface BulkImportSkipped {
     | "code_in_use"
     | "code_duplicate_in_import"
     | "missing_description"
+    | "tag_not_found"
     | "invalid";
   code: string | null;
+  /** Populated when `reason === "tag_not_found"`: the tag name(s) that
+   *  didn't match an existing `gear_tags.name` row. */
+  missingTags?: string[];
 }
 
 export interface BulkImportResult {
@@ -71,6 +88,12 @@ function normalizeCode(code: string | null | undefined): string | null {
   return trimmed.length === 0 ? null : trimmed;
 }
 
+function normalizeOptional(value: string | null | undefined): string | null {
+  if (value === null || value === undefined) return null;
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
 export async function bulkImportGearAction(
   input: BulkImportInput,
 ): Promise<BulkImportResult> {
@@ -80,6 +103,25 @@ export async function bulkImportGearAction(
 
   const typeCache = new Map<string, string | null>(); // typePublicId -> typeId (null = not found)
   const seenCodes = new Set<string>();
+
+  // Resolve every tag name in the payload up-front against the
+  // (typically small) `gear_tags` table. One round-trip vs. one per
+  // row. Indexed by lowercased name for case-insensitive lookup; the
+  // canonical id is what we'll insert into `gear_tag_assignments`.
+  const tagsNeeded = new Set<string>();
+  for (const row of input.rows) {
+    for (const name of row.tagNames ?? []) {
+      const lower = name.trim().toLowerCase();
+      if (lower.length > 0) tagsNeeded.add(lower);
+    }
+  }
+  const tagByLowerName = new Map<string, string>(); // lowerName -> tagId
+  if (tagsNeeded.size > 0) {
+    const allTags = await listGearTags({ includeInternal: true });
+    for (const t of allTags) {
+      tagByLowerName.set(t.name.toLowerCase(), t.id);
+    }
+  }
 
   for (let i = 0; i < input.rows.length; i++) {
     const row = input.rows[i];
@@ -115,6 +157,32 @@ export async function bulkImportGearAction(
       continue;
     }
 
+    // Resolve tag names → ids. Unknown tags fail the whole row so the
+    // import never silently drops officer-supplied tags; the officer
+    // creates the canonical tag (via the tag-management dialog) and
+    // re-runs the import.
+    const tagIds: string[] = [];
+    const missingTags: string[] = [];
+    for (const rawName of row.tagNames ?? []) {
+      const lower = rawName.trim().toLowerCase();
+      if (lower.length === 0) continue;
+      const id = tagByLowerName.get(lower);
+      if (id === undefined) {
+        missingTags.push(rawName.trim());
+      } else if (!tagIds.includes(id)) {
+        tagIds.push(id);
+      }
+    }
+    if (missingTags.length > 0) {
+      skipped.push({
+        rowIndex: i,
+        reason: "tag_not_found",
+        code,
+        missingTags,
+      });
+      continue;
+    }
+
     const id = `g_${uuidv7()}`;
     const publicId = generatePublicId();
     try {
@@ -129,6 +197,10 @@ export async function bulkImportGearAction(
         thumbnailKey: null,
         acquiredAt: row.acquiredAt === null ? null : new Date(row.acquiredAt),
         acquisitionCostCents: row.acquisitionCostCents,
+        msrpCents: row.msrpCents ?? null,
+        manufacturer: normalizeOptional(row.manufacturer),
+        serialNumber: normalizeOptional(row.serialNumber),
+        conditionGrade: row.conditionGrade ?? null,
         notesMarkdown: null,
         condition: "serviceable",
         createdBy: principal.userId,
@@ -139,6 +211,14 @@ export async function bulkImportGearAction(
         continue;
       }
       throw err;
+    }
+
+    if (tagIds.length > 0) {
+      await setGearTags({
+        gearId: id,
+        tagIds,
+        assignedBy: principal.userId,
+      });
     }
 
     await recordAuditEvent({

--- a/apps/web/src/features/gear/server/gear-fns.ts
+++ b/apps/web/src/features/gear/server/gear-fns.ts
@@ -87,6 +87,13 @@ export const GEAR_CONDITION_VALUES = [
 ] as const;
 export type GearCondition = (typeof GEAR_CONDITION_VALUES)[number];
 
+export const GEAR_CONDITION_GRADE_VALUES = [
+  "excellent",
+  "good",
+  "fair",
+] as const;
+export type GearConditionGrade = (typeof GEAR_CONDITION_GRADE_VALUES)[number];
+
 export const GEAR_INSPECTION_RESULT_VALUES = [
   "pass",
   "fail",
@@ -189,6 +196,13 @@ export const createGearInputSchema = z.object({
   thumbnailDataUrl: thumbnailDataUrlSchema.nullable(),
   acquiredAt: acquiredAtSchema,
   acquisitionCostCents: z.number().int().min(0).nullable(),
+  // Optional on the wire — omit means "unknown / not provided" on
+  // create, and "no change" on edit. The action normalizes undefined
+  // to null at the boundary.
+  msrpCents: z.number().int().min(0).nullable().optional(),
+  manufacturer: z.string().trim().max(100).nullable().optional(),
+  serialNumber: z.string().trim().max(100).nullable().optional(),
+  conditionGrade: z.enum(GEAR_CONDITION_GRADE_VALUES).nullable().optional(),
   notesMarkdown: z.string().max(10_000).nullable(),
   condition: z.enum(GEAR_CONDITION_VALUES),
   tagPublicIds: z.array(z.string().min(1)),

--- a/apps/web/src/features/gear/server/gear-fns.ts
+++ b/apps/web/src/features/gear/server/gear-fns.ts
@@ -294,6 +294,15 @@ const bulkImportInputSchema = z.object({
         description: z.string().max(500),
         acquiredAt: acquiredAtSchema,
         acquisitionCostCents: z.number().int().min(0).nullable(),
+        // Optional passthroughs — see BulkImportRow.
+        msrpCents: z.number().int().min(0).nullable().optional(),
+        manufacturer: z.string().trim().max(100).nullable().optional(),
+        serialNumber: z.string().trim().max(100).nullable().optional(),
+        conditionGrade: z
+          .enum(GEAR_CONDITION_GRADE_VALUES)
+          .nullable()
+          .optional(),
+        tagNames: z.array(z.string().min(1).max(40)).max(50).optional(),
       }),
     )
     .min(1)

--- a/apps/web/src/features/gear/server/repo.server.ts
+++ b/apps/web/src/features/gear/server/repo.server.ts
@@ -20,6 +20,10 @@ export interface GearRow {
   thumbnailKey: string | null;
   acquiredAt: Date | null;
   acquisitionCostCents: number | null;
+  msrpCents: number | null;
+  manufacturer: string | null;
+  serialNumber: string | null;
+  conditionGrade: schema.GearConditionGrade | null;
   notesMarkdown: string | null;
   lifecycle: schema.GearLifecycle;
   condition: schema.GearCondition;
@@ -126,6 +130,10 @@ export async function listGear(
       thumbnailKey: schema.gear.thumbnailKey,
       acquiredAt: schema.gear.acquiredAt,
       acquisitionCostCents: schema.gear.acquisitionCostCents,
+      msrpCents: schema.gear.msrpCents,
+      manufacturer: schema.gear.manufacturer,
+      serialNumber: schema.gear.serialNumber,
+      conditionGrade: schema.gear.conditionGrade,
       notesMarkdown: schema.gear.notesMarkdown,
       lifecycle: schema.gear.lifecycle,
       condition: schema.gear.condition,
@@ -167,6 +175,10 @@ export async function getGearByPublicId(
       thumbnailKey: schema.gear.thumbnailKey,
       acquiredAt: schema.gear.acquiredAt,
       acquisitionCostCents: schema.gear.acquisitionCostCents,
+      msrpCents: schema.gear.msrpCents,
+      manufacturer: schema.gear.manufacturer,
+      serialNumber: schema.gear.serialNumber,
+      conditionGrade: schema.gear.conditionGrade,
       notesMarkdown: schema.gear.notesMarkdown,
       lifecycle: schema.gear.lifecycle,
       condition: schema.gear.condition,
@@ -241,6 +253,10 @@ export async function insertGear(input: {
   thumbnailKey: string | null;
   acquiredAt: Date | null;
   acquisitionCostCents: number | null;
+  msrpCents?: number | null;
+  manufacturer?: string | null;
+  serialNumber?: string | null;
+  conditionGrade?: schema.GearConditionGrade | null;
   notesMarkdown: string | null;
   condition: schema.GearCondition;
   createdBy: string;
@@ -256,6 +272,10 @@ export async function insertGear(input: {
     thumbnailKey: input.thumbnailKey,
     acquiredAt: input.acquiredAt,
     acquisitionCostCents: input.acquisitionCostCents,
+    msrpCents: input.msrpCents ?? null,
+    manufacturer: input.manufacturer ?? null,
+    serialNumber: input.serialNumber ?? null,
+    conditionGrade: input.conditionGrade ?? null,
     notesMarkdown: input.notesMarkdown,
     lifecycle: "active",
     condition: input.condition,
@@ -274,6 +294,10 @@ export async function updateGearById(
     thumbnailKey: string | null;
     acquiredAt: Date | null;
     acquisitionCostCents: number | null;
+    msrpCents: number | null;
+    manufacturer: string | null;
+    serialNumber: string | null;
+    conditionGrade: schema.GearConditionGrade | null;
     notesMarkdown: string | null;
     condition: schema.GearCondition;
   }>,


### PR DESCRIPTION
## Summary

- Add four nullable gear columns — `msrp_cents`, `manufacturer`, `serial_number`, `condition_grade` — and wire them end-to-end through validators, repo, server fns, detail/form/table UI, and the bulk-import CSV path.
- Officer-gate sensitive fields: `serialNumber` joins `acquisitionCostCents` + `msrpCents` behind the `gear:manage` strip on both list and detail reads (leaking serials hands a thief a resale-correlation shopping list). `manufacturer` + `conditionGrade` remain visible to all `gear:read` members.
- CSV importer: header-detection only for the new columns (legacy 5-column sheets keep parsing identically); tag names must resolve to an existing `gear_tags` row (new `tag_not_found` skip reason — no silent tag invention); money cells always read as dollars (drops the `_cents` aliases that turned `175` into $1.75); per-row audit event now carries resolved `tagIds`.

## Test plan

- [ ] `pnpm --filter ucmc-web test` (workers + dom pools) passes — covers parser, bulk-import action, officer/member field-strip on list + detail
- [ ] `pnpm --filter ucmc-web typecheck` clean
- [ ] Apply `0041_gear_extended_attributes.sql` locally and round-trip create → edit → bulk-import → detail with the new fields
- [ ] Verify non-officer detail read returns `serialNumber: null` and `msrpCents: null`; officer sees both
- [ ] Bulk import a CSV with `tags` referencing an unknown name — row skipped with `tag_not_found` and missing names surfaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)